### PR TITLE
Add `pipx run` tip to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Use `pip` or `pipx`:
 pipx install harlequin
 ```
 
-> **Tip**
+> **Tip:**
+>
 > You can run invoke directly with [`pipx run`](https://pypa.github.io/pipx/examples/#pipx-run-examples) anywhere that `pipx` is installed. For example:
 > - `pipx run harlequin --help`
 > - `pipx run harlequin ./my.duckdb`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Use `pip` or `pipx`:
 pipx install harlequin
 ```
 
+> **Tip**
+> You can run invoke directly with [`pipx run`](https://pypa.github.io/pipx/examples/#pipx-run-examples) anywhere that `pipx` is installed. For example:
+> - `pipx run harlequin --help`
+> - `pipx run harlequin ./my.duckdb`
+
 ## Using Harlequin
 
 To open a DuckDB database file:


### PR DESCRIPTION
First of all, the tool looks awesome. Nice work!

This PR proposes guidance for users to create an ephemeral environment using `pipx run`, avoiding the need to pre-install and letting `harlequin` be run as a one-liner anywhere that `pipx` exists.