### PR TITLE
fix: allow starting harlequin via `python -m harlequin`

### DIFF
--- a/src/harlequin/__main__.py
+++ b/src/harlequin/__main__.py
@@ -1,0 +1,3 @@
+from harlequin.cli import harlequin
+
+harlequin()


### PR DESCRIPTION
This is especially useful for use with different python versions/installations, such as virtualenvs