### PR TITLE
fix #71: add docs and key label for Run Query action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,39 @@ When Harlequin is open, you can view the schema of your DuckDB database in the l
 
 ### Editing a Query
 
-The main query editor is a full-featured text editor, with features including syntax highlighting, auto-formatting with ``ctrl + ` ``, text selection, copy/paste, and more.
+The main query editor is a full-featured text editor, with features including syntax highlighting, auto-formatting with ``ctrl + ` `` (`ctrl + 2` on some terminals), text selection, copy/paste, and more.
 
 You can save the query currently in the editor with `ctrl + s`. You can open a query in any text or .sql file with `ctrl + o`.
 
 ### Running a Query and Viewing Results
 
-To run a query, press `ctrl + enter`. Up to 50k records will be loaded into the results pane below the query editor. When the focus is on the data pane, you can use your arrow keys or mouse to select different cells.
+To run a query press `ctrl + enter`. Not all terminals support this key combination, so you can also use `ctrl + j`, or click the `RUN QUERY` button in the (blue) footer.
+
+Up to 50k records will be loaded into the results pane below the query editor. When the focus is on the data pane, you can use your arrow keys or mouse to select different cells.
 
 ### Exiting Harlequin
 
 Press `ctrl + q` to quit and return to your shell.
+
+## Contributing
+
+Thanks for your interest in Harlequin! Harlequin is primarily maintained by [Ted Conbeer](https://github.com/tconbeer), but he welcomes all contributions and is looking for additional maintainers!
+
+### Providing Feedback
+
+We'd love to hear from you! [Open an Issue](https://github.com/tconbeer/harlequin/issues/new) to request new features, report bugs, or say hello.
+
+### Setting up Your Dev Environment and Running Tests
+
+1. Install Poetry v1.2 or higher if you don't have it already. You may also need or want pyenv, make, and gcc.
+1. Fork this repo, and then clone the fork into a directory (let's call it `harlequin`), then `cd harlequin`.
+1. Use `poetry install --sync` to install the project (editable) and its dependencies (including all test and dev dependencies) into a new virtual env.
+1. Use `poetry shell` to spawn a subshell.
+1. Type `make` to run all tests and linters, or run `pytest`, `black .`, `ruff . --fix`, and `mypy` individually.
+
+### Opening PRs
+
+1. PRs should be motivated by an open issue. If there isn't already an issue describing the feature or bug, [open one](https://github.com/tconbeer/harlequin/issues/new). Do this before you write code, so you don't waste time on something that won't get merged.
+2. Ideally new features and bug fixes would be tested, to prevent future regressions. Textual provides a test harness that we use to test features of Harlequin. You can find some examples in the `tests` directory of this project. Please include a test in your PR, but if you can't figure it out, open a PR to ask for help.
+2. Open a PR from your fork to the `main` branch of `tconbeer/harlequin`. In the PR description, link to the open issue, and then write a few sentences about **why** you wrote the code you did: explain your design, etc.
+3. Ted may ask you to make changes, or he may make them for you. Don't take this the wrong way -- he values your contributions, but he knows this isn't your job, either, so if it's faster for him, he may push a commit to your branch or create a new branch from your commits.

--- a/src/harlequin/tui/components/code_editor.py
+++ b/src/harlequin/tui/components/code_editor.py
@@ -8,7 +8,13 @@ from harlequin.tui.components.textarea import TextArea, TextInput
 
 class CodeEditor(TextArea):
     BINDINGS = [
-        ("ctrl+enter", "submit", "Run Query"),
+        Binding(
+            "ctrl+enter",
+            "submit",
+            "Run Query",
+            key_display="CTRL+ENTER / CTRL+J",
+            show=True,
+        ),
         Binding("ctrl+j", "submit", "Run Query", show=False),
     ]
 


### PR DESCRIPTION
fixes #71 by making `ctrl+j` a more obvious interface for Run Query