### PR TITLE
feat: Click flag for allowing unsigned extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+-   Add `-u`/`-unsigned`/`--allow-unsigned-extensions` CLI flag for allowing loading of unsigned extensions.
+
 ### Bug Fixes
 
 - Error modal no longer crashes

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ You can also open a database in read-only mode:
 harlequin -r "path/to/duck.db"
 ```
 
+### Loading Unsigned Extensions
+If you need to load a custom or otherwise unsigned extension, you can use the
+`-unsigned` flag just as you would with the DuckDB CLI, or `-u` for convenience:
+
+```bash
+harlequin -u
+```
+
+The long flag `--allow-unsigned-extensions` is another synonym.
+
 ### Using Harlequin with MotherDuck
 
 You can use Harlequin with MotherDuck, just as you would use the DuckDB CLI:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # harlequin
+
 A Terminal-based SQL IDE for DuckDB.
 
 ![harlequin TUI](harlequinv0018.gif)
@@ -18,9 +19,9 @@ pipx install harlequin
 > **Tip:**
 >
 > You can run invoke directly with [`pipx run`](https://pypa.github.io/pipx/examples/#pipx-run-examples) anywhere that `pipx` is installed. For example:
+>
 > - `pipx run harlequin --help`
 > - `pipx run harlequin ./my.duckdb`
-
 
 ## Using Harlequin
 
@@ -43,6 +44,7 @@ harlequin -r "path/to/duck.db"
 ```
 
 ### Loading Unsigned Extensions
+
 If you need to load a custom or otherwise unsigned extension, you can use the
 `-unsigned` flag just as you would with the DuckDB CLI, or `-u` for convenience:
 
@@ -82,7 +84,7 @@ When Harlequin is open, you can view the schema of your DuckDB database in the l
 
 ### Editing a Query
 
-The main query editor is a full-featured text editor, with features including syntax highlighting, auto-formatting with <kbd>f4</kbd>, text selection, copy/paste, and more. 
+The main query editor is a full-featured text editor, with features including syntax highlighting, auto-formatting with <kbd>f4</kbd>, text selection, copy/paste, and more.
 
 > **Tip:**
 >

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -15,6 +15,13 @@ from harlequin import Harlequin
     help="Open the database file in read-only mode.",
 )
 @click.option(
+    "-u",
+    "-unsigned",
+    "--allow-unsigned-extensions",
+    is_flag=True,
+    help="Allow loading unsigned extensions",
+)
+@click.option(
     "-t",
     "--theme",
     default="monokai",
@@ -48,6 +55,7 @@ def harlequin(
     theme: str,
     md_token: Union[str, None],
     md_saas: bool,
+    allow_unsigned_extensions: bool,
 ) -> None:
     if not db_path:
         db_path = [":memory:"]
@@ -57,5 +65,6 @@ def harlequin(
         theme=theme,
         md_token=md_token,
         md_saas=md_saas,
+        allow_unsigned_extensions=allow_unsigned_extensions,
     )
     tui.run()

--- a/src/harlequin/duck_ops.py
+++ b/src/harlequin/duck_ops.py
@@ -16,15 +16,18 @@ def connect(
     read_only: bool = False,
     md_token: Union[str, None] = None,
     md_saas: bool = False,
+    allow_unsigned_extensions: bool = False,
 ) -> duckdb.DuckDBPyConnection:
     if not db_path:
         db_path = [":memory:"]
     primary_db, *other_dbs = db_path
     token = f"?token={md_token}" if md_token else ""
     saas = "?saas_mode=true" if md_saas else ""
+    config = {"allow_unsigned_extensions": str(allow_unsigned_extensions).lower()}
+
     try:
         connection = duckdb.connect(
-            database=f"{primary_db}{token}{saas}", read_only=read_only
+            database=f"{primary_db}{token}{saas}", read_only=read_only, config=config
         )
         for db in other_dbs:
             connection.execute(f"attach '{db}'{' (READ_ONLY)' if read_only else ''}")

--- a/src/harlequin/tui/app.py
+++ b/src/harlequin/tui/app.py
@@ -64,12 +64,17 @@ class Harlequin(App, inherit_bindings=False):
         driver_class: Union[Type[Driver], None] = None,
         css_path: Union[CSSPathType, None] = None,
         watch_css: bool = False,
+        allow_unsigned_extensions: bool = False,
     ):
         super().__init__(driver_class, css_path, watch_css)
         self.theme = theme
         self.limit = 500
         try:
-            self.connection = connect(db_path, read_only=read_only)
+            self.connection = connect(
+                db_path,
+                read_only=read_only,
+                allow_unsigned_extensions=allow_unsigned_extensions,
+            )
         except HarlequinExit:
             self.exit()
 

--- a/tests/functional_tests/test_duck_ops.py
+++ b/tests/functional_tests/test_duck_ops.py
@@ -21,6 +21,9 @@ def test_connect(tiny_db: Path, small_db: Path, tmp_path: Path) -> None:
     assert connect([tiny_db, Path(":memory:"), small_db], read_only=False)
     assert connect([tiny_db, small_db], read_only=True)
     assert connect([tmp_path / "new.db"])
+    assert connect([], allow_unsigned_extensions=True)
+    assert connect([tiny_db], allow_unsigned_extensions=True)
+    assert connect([tiny_db, small_db], read_only=True, allow_unsigned_extensions=True)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
This adds a `-u`/`--allow-unsigned-extensions` flag to the click options
and forwards it to the `duckdb` Python API for allowing users to load
unsigned extensions.

It defaults to False, which is the existing behavior.

There is an `-unsigned` synonym to have parity with the DuckDB CLI flag.