### PR TITLE
feat/#155/run selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+-   Changes the behavior of the "Run Query" button and <kbd>ctrl+enter</kbd>:
+    -   If text is selected, and that text does not contain parsing errors, the "Run Query" button will show "Run Selection", and <kbd>ctrl+enter</kbd> will run the selected text. If multiple queries are selected (separated by semicolons), they will all be run; if multiple `select` statements are selected, only data from the first selected `select` statement will be loaded into the Results Viewer (or exported).
+    -   If no text is selected, Harlequin will run the single query where the cursor is active. Other queries before and after semicolons will not be run.
+    -   To "Run All", first select all text with <kbd>ctrl+a</kbd>, and then run selection with <kbd>ctrl+enter</kbd>
+-   Lowers the maximum number of records loaded into the results viewer to 10,000. (All records can be exported with <kbd>ctrl+e</kbd>)
+
 ### Features
 
 -   Adds path autocomplete and validation to the file save/open and export data inputs.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1190,14 +1190,14 @@ typing-extensions = ">=4.4.0,<5.0.0"
 
 [[package]]
 name = "textual-textarea"
-version = "0.4.1"
+version = "0.4.2"
 description = "A text area (multi-line input) with syntax highlighting for Textual"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "textual_textarea-0.4.1-py3-none-any.whl", hash = "sha256:cedd01bf30e7dcfae97a922600ad9b234f7a124d1ad08fe760c5a72f8560bbbb"},
-    {file = "textual_textarea-0.4.1.tar.gz", hash = "sha256:bb3878fad9aa827211773713fa955676a3ce4e6d83effca8e2a8a6cbff365817"},
+    {file = "textual_textarea-0.4.2-py3-none-any.whl", hash = "sha256:a4aecc01395e36e8107f4e6e281662b56013af49a2c614933cc0c6e59909514c"},
+    {file = "textual_textarea-0.4.2.tar.gz", hash = "sha256:5a6376d7568e65cb893bd0e776bf90a215a3203c0631a2c6235edc1405e0b0b9"},
 ]
 
 [package.dependencies]
@@ -1392,4 +1392,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a0c0ba904824466aff9cb3f7ee7344b662cbed747deb1be32d7e0af7c25462f7"
+content-hash = "808266b6bfd51040f2ddd287041124379e169a23202f8cbbeff429d9a421a049"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.dependencies]
 python = "^3.8"
 textual = "==0.32.0"
-textual-textarea = "==0.4.1"
+textual-textarea = "==0.4.2"
 click = "^8.1.3"
 duckdb = ">=0.8.0"
 shandy-sqlfmt = ">=0.19.0"

--- a/src/harlequin/tui/app.py
+++ b/src/harlequin/tui/app.py
@@ -41,7 +41,7 @@ class Harlequin(App, inherit_bindings=False):
     """
 
     CSS_PATH = "app.css"
-    MAX_RESULTS = 50_000
+    MAX_RESULTS = 10_000
 
     BINDINGS = [
         Binding("ctrl+q", "quit", "Quit"),
@@ -94,7 +94,7 @@ class Harlequin(App, inherit_bindings=False):
             yield SchemaViewer("Data Catalog", connection=self.connection)
             with Vertical(id="main_panel"):
                 yield CodeEditor(language="sql", theme=self.theme)
-                yield RunQueryBar()
+                yield RunQueryBar(max_results=self.MAX_RESULTS)
                 yield ResultsViewer()
         yield Footer()
 

--- a/src/harlequin/tui/components/code_editor.py
+++ b/src/harlequin/tui/components/code_editor.py
@@ -1,8 +1,13 @@
+import re
+from typing import List, Union
+
 from sqlfmt.api import Mode, format_string
 from sqlfmt.exception import SqlfmtError
 from textual.binding import Binding
 from textual.message import Message
 from textual_textarea import TextArea
+from textual_textarea.key_handlers import Cursor
+from textual_textarea.serde import serialize_lines
 from textual_textarea.textarea import TextInput
 
 from harlequin.tui.components.error_modal import ErrorModal
@@ -56,3 +61,34 @@ class CodeEditor(TextArea):
         else:
             text_input.move_cursor(old_cursor.pos, old_cursor.lno)
             text_input.update(text_input._content)
+
+    @property
+    def _semicolons(self) -> List[Cursor]:
+        semicolons: List[Cursor] = []
+        for i, line in enumerate(self.text_input.lines):
+            for pos in [m.span()[1] for m in re.finditer(";", line)]:
+                semicolons.append(Cursor(i, pos))
+        return semicolons
+
+    @property
+    def current_query(self) -> str:
+        semicolons = self._semicolons
+        if semicolons:
+            before = Cursor(0, 0)
+            after: Union[None, Cursor] = None
+            for c in semicolons:
+                if c <= self.cursor:
+                    before = c
+                elif after is None and c > self.cursor:
+                    after = c
+                    break
+            else:
+                after = Cursor(
+                    len(self.text_input.lines) - 1, len(self.text_input.lines[-1]) - 1
+                )
+            lines, first, last = self.text_input._get_selected_lines(before, after)
+            lines[-1] = lines[-1][: last.pos]
+            lines[0] = lines[0][first.pos :]
+            return serialize_lines(lines)
+        else:
+            return self.text

--- a/src/harlequin/tui/components/run_query_bar.py
+++ b/src/harlequin/tui/components/run_query_bar.py
@@ -1,10 +1,27 @@
+from typing import Union
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.validation import Integer
+from textual.widget import Widget
 from textual.widgets import Button, Checkbox, Input
 
 
 class RunQueryBar(Horizontal):
+    def __init__(
+        self,
+        *children: Widget,
+        name: Union[str, None] = None,
+        id: Union[str, None] = None,  # noqa
+        classes: Union[str, None] = None,
+        disabled: bool = False,
+        max_results: int = 10_000,
+    ) -> None:
+        self.max_results = max_results
+        super().__init__(
+            *children, name=name, id=id, classes=classes, disabled=disabled
+        )
+
     def compose(self) -> ComposeResult:
         yield Checkbox("Limit ", id="limit_checkbox")
         yield Input(
@@ -12,8 +29,10 @@ class RunQueryBar(Horizontal):
             id="limit_input",
             validators=Integer(
                 minimum=0,
-                maximum=50000,
-                failure_description="Please enter a number between 0 and 50,000.",
+                maximum=self.max_results,
+                failure_description=(
+                    f"Please enter a number between 0 and {self.max_results}."
+                ),
             ),
         )
         yield Button("Run Query", id="run_query")

--- a/tests/functional_tests/test_app.py
+++ b/tests/functional_tests/test_app.py
@@ -23,7 +23,7 @@ async def test_select_1(app: Harlequin) -> None:
         await app.workers.wait_for_complete()
         assert app.query_text == q
         await app.workers.wait_for_complete()
-        assert app.relation is not None
+        assert app.relations
         await app.workers.wait_for_complete()
         assert app.data == [(1,)]
 
@@ -223,7 +223,7 @@ async def test_export(app: Harlequin, tmp_path: Path, filename: str) -> None:
     async with app.run_test() as pilot:
         app.editor.text = "select 1 as a"
         await pilot.press("ctrl+j")  # run query
-        assert app.relation is not None
+        assert app.relations
         assert len(app.screen_stack) == 1
 
         await pilot.press("ctrl+e")


### PR DESCRIPTION
- feat: validate and run selection, closes #155 
- fix: reduce max results to 10k
- feat: run selection and run only current query

punts on loading data from multiple queries (#34 ), but builds some of the stuff we'll need (now compile and store multiple `relations`)