### PR TITLE
list items in the data_catalog pane ordered by label

### DIFF
--- a/src/harlequin/components/data_catalog.py
+++ b/src/harlequin/components/data_catalog.py
@@ -93,6 +93,7 @@ class DataCatalog(Tree[CatalogItem]):
         parent: TreeNode[CatalogItem],
         expanded_nodes: Set[str],
     ) -> None:
+        items.sort(key=lambda x: x.label)
         for item in items:
             if item.children:
                 new_node = parent.add(


### PR DESCRIPTION
A quick and easy change to order the items in each subtree alphabetically based on their label.

I realise that this isn't the optimal or well fleshed solution, and perhaps something more configurable would be better. However, just as a default starting point I think it's a decent change.