### PR TITLE
Add number separators to query history results

### DIFF
--- a/src/harlequin/history.py
+++ b/src/harlequin/history.py
@@ -23,7 +23,7 @@ class QueryExecution:
             result = Text("ERROR", style="bold italic red", justify="right")
         else:
             res = (
-                f"{self.result_row_count:n} "
+                f"{self.result_row_count:,} "
                 f"{'record' if self.result_row_count == 1 else 'records'}"
                 if self.result_row_count
                 else "SUCCESS"


### PR DESCRIPTION
This fixes #437 

The previous code was :

```
f"{self.result_row_count:n} " 
```
which is replaced by :

```
f"{self.result_row_count:,} " 
```

this will make sure there are separators in the numbers, example given below: 

![harlequin](https://github.com/tconbeer/harlequin/assets/21195835/21f104b7-8a28-41ae-8ff0-6d9f0600c86c)


