### PR TITLE
fix #465

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- `harlequin --config` creates a new file (parent folder as well, if non-existent) instead of crashing with FileNotFoundError ([#465](https://github.com/tconbeer/harlequin/issues/465))
+
 ## [1.15.0] - 2024-02-12
 
 ### Features

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -152,7 +152,9 @@ def _wizard() -> None:
 
     new_profile.update(adapter_options)
 
-    _confirm_profile_generation(default_profile, profile_name, new_profile)
+    profile_confirm = _confirm_profile_generation(
+        default_profile, profile_name, new_profile
+    )
 
     config["profiles"][profile_name] = new_profile  # type: ignore
 
@@ -162,7 +164,9 @@ def _wizard() -> None:
         full_config["tool"]["harlequin"] = config  # type: ignore
         config = full_config
 
-    file.write(config)
+    if profile_confirm:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file.write(config)
 
 
 def _prompt_for_path() -> tuple[Path, bool]:
@@ -175,8 +179,7 @@ def _prompt_for_path() -> tuple[Path, bool]:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
     path = Path(raw_path)
-    path = Path.expanduser(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = path.expanduser()
     is_pyproject = path.stem == "pyproject"
     if path.suffix != ".toml":
         raise HarlequinWizardError(
@@ -265,7 +268,7 @@ def _prompt_to_set_default_profile(
 
 def _confirm_profile_generation(
     default_profile: str | None, profile_name: str, new_profile: dict[str, Any]
-) -> None:
+) -> bool:
     new_config: dict[str, Any] = (
         {} if default_profile is None else {"default_profile": default_profile}
     )
@@ -287,6 +290,8 @@ def _confirm_profile_generation(
 
     if not all_good:
         raise KeyboardInterrupt()
+
+    return True
 
 
 def _validate_int(raw: str) -> bool:

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -175,6 +175,8 @@ def _prompt_for_path() -> tuple[Path, bool]:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
     path = Path(raw_path)
+    path = Path.expanduser(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     is_pyproject = path.stem == "pyproject"
     if path.suffix != ".toml":
         raise HarlequinWizardError(


### PR DESCRIPTION
When a non existent parent directory is given in the path, the error mentioned in #465 arises. Fixed this issue. Haven't checked this in Windows