### PR TITLE
feat/config wizard use config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changes
+
+-   The default search path and priority for config files has changed, to better align with the standard defined by each operating system. Harlequin now loads config files from the following locations (and merges them, with items listed first taking priority):
+    1. The file located at the path provided by the `--config-path` CLI option.
+    2. Files named `harlequin.toml`, `.harlequin.toml`, or `pyproject.toml` in the current working directory.
+    3. Files named `harlequin.toml`, `.harlequin.toml`, or `config.toml` in the user's default config directory, in the `harlequin` subdirectory. For example:
+        - Linux: `$XDG_CONFIG_HOME/harlequin/config.toml` or `~/.config/harlequin/config.toml`
+        - Mac: `~/Library/Application Support/harlequin/config.toml`
+        - Windows: `~\AppData\Local\harlequin\config.toml`
+    4. Files named `harlequin.toml`, `.harlequin.toml`, or `pyproject.toml` in the user's home directory (`~`).
+    ([#471](https://github.com/tconbeer/harlequin/issues/471))
+
 ### Features
 
 -   `harlequin --config` option now accepts the `--config-path` CLI option ([#466](https://github.com/tconbeer/harlequin/issues/466)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+-   `harlequin --config` option now accepts the `--config-path` CLI option ([#466](https://github.com/tconbeer/harlequin/issues/466)).
+-   `harlequin --config` now defaults to updating the nearest (highest priority) existing config file in the default search path, instead of `./.harlequin.toml`.
+
 ### Bug Fixes
 
-- `harlequin --config` creates a new file (parent folder as well, if non-existent) instead of crashing with FileNotFoundError ([#465](https://github.com/tconbeer/harlequin/issues/465))
+-   `harlequin --config` creates a new file (parent folder as well, if non-existent) instead of crashing with FileNotFoundError ([#465](https://github.com/tconbeer/harlequin/issues/465))
 
 ## [1.15.0] - 2024-02-12
 

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -114,7 +114,7 @@ def _version_option() -> str:
 def _config_wizard_callback(ctx: click.Context, param: Any, value: bool) -> None:
     if not value or ctx.resilient_parsing:
         return
-    wizard()
+    wizard(ctx.params.get("config_path", None))
     ctx.exit(0)
 
 
@@ -218,7 +218,7 @@ def build_cli() -> click.Command:
         is_flag=True,
         callback=_config_wizard_callback,
         expose_value=True,
-        is_eager=True,
+        # is_eager=True,
     )
     @click.option(
         "--locale",


### PR DESCRIPTION
Closes #466 , closes #471 

This changes the `--config` CLI option to accept the `config-path` param. The more consequential change is the overhaul of the config file search.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [x] Yes, and I have opened a PR at https://github.com/tconbeer/harlequin-web/pull/64
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.