### PR TITLE
fix #485: avoid crash due to duplicate screen id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   Pressing `F8` on the history screen no longer causes a crash ([#485](https://github.com/tconbeer/harlequin/issues/485))
+
 ## [1.16.0] - 2024-02-22
 
 ### Changes

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -611,7 +611,7 @@ class Harlequin(App, inherit_bindings=False):
                     "Please wait a moment and try again."
                 ),
             )
-        else:
+        elif self.screen.id != "history_screen":
             self.push_screen(
                 HistoryScreen(
                     history=self.history,

--- a/tests/functional_tests/test_history_screen.py
+++ b/tests/functional_tests/test_history_screen.py
@@ -57,3 +57,23 @@ async def test_history_screen(
         snap_results.append(await app_snapshot(app, "New buffer with select 14"))
 
         assert all(snap_results)
+
+
+@pytest.mark.asyncio
+async def test_history_screen_crash(
+    app: Harlequin,
+    app_snapshot: Callable[..., Awaitable[bool]],
+    mock_time: None,
+) -> None:
+    async with app.run_test() as pilot:
+        q = "\n".join([f"select {i};" for i in range(15)])
+        while app.editor is None:
+            await pilot.pause()
+        app.post_message(QuerySubmitted(query_text=q, limit=None))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        # https://github.com/tconbeer/harlequin/issues/485
+        await pilot.press("f8")
+        await pilot.press("f8")


### PR DESCRIPTION
Closes #485 

**What** are the key elements of this solution?

This fix takes option (a) from the issue and maps the F8 key to nothing once the history screen is open.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

An alternative is to bind F8 to the cancel action or nothing in the history screen class, but that makes it awkward as the F8 binding would be then defined in two places.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
