### PR TITLE
fix #493: strip whitespace from current_query and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   If the cursor is after the final semicolon in the query editor, and there is only whitespace after the semicolon, Harlequin will now execute the last query before the semicolon, instead of doing nothing when clicking Run Query or pressing <kbd>ctrl+j</kbd>.
+
 ## [1.16.1] - 2024-03-27
 
 ### Bug Fixes

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -819,7 +819,7 @@ class Harlequin(App, inherit_bindings=False):
         """
         if self.editor is None:
             return ""
-        selection = self.editor.selected_text
+        selection = self.editor.selected_text.strip()
         if self.connection is None:
             return selection
         if selection:

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -62,7 +62,7 @@ class CodeEditor(TextEditor):
             after = (lno, len(self.text_input.document.get_line(lno)))
         return self.text_input.get_text_range(
             start=(before[0], before[1]), end=(after[0], after[1])
-        )
+        ).strip()
 
     @property
     def previous_query(self) -> str:
@@ -82,7 +82,7 @@ class CodeEditor(TextEditor):
 
         return self.text_input.get_text_range(
             start=(first[0], first[1]), end=(second[0], second[1])
-        )
+        ).strip()
 
     def on_mount(self) -> None:
         self.post_message(EditorCollection.EditorSwitched(active_editor=self))


### PR DESCRIPTION
Closes #493

**What** are the key elements of this solution?
This PR strips whitespace from `editor.current_query`, `editor.previous_query`, and `app._validate_selection`, so that the previous query is executed when the current query is only whitespace. The previous behavior was confusing (see issue).

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
The database doesn't care about whitespace, so it's better to strip it than add new logic with `isspace`, etc.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
