### PR TITLE
Fixclipboarderror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   Wrong link on text_area_clipboard_error error message (([#509]https://github.com/tconbeer/harlequin/issues/509))
+
 ## [1.16.2] - 2024-03-29
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
--   Wrong link on text_area_clipboard_error error message (([#509]https://github.com/tconbeer/harlequin/issues/509))
+-   Wrong link on text_area_clipboard_error error message ([#509](https://github.com/tconbeer/harlequin/issues/509))
 
 ## [1.16.2] - 2024-03-29
 

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -98,7 +98,7 @@ class CodeEditor(TextEditor):
         if not self.has_shown_clipboard_error:
             self.app.notify(
                 "Could not access system clipboard.\n"
-                "See https://harlequin.sh/docs/troubleshooting#copying-and-pasting",
+                "See https://harlequin.sh/docs/troubleshooting/copying-and-pasting",
                 severity="error",
                 timeout=10,
             )


### PR DESCRIPTION
`on_text_area_clipboard_error`  is linking to `https://harlequin.sh/docs/troubleshooting#copying-and-pasting` but that link is dead, and `https://harlequin.sh/docs/troubleshooting/copying-and-pasting` is correct.

Closes ([#509](https://github.com/tconbeer/harlequin/issues/509)) (an existing open issue)

**What** are the key elements of this solution?
Switched to the correct link.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
Not appliccable.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. 
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.


