### PR TITLE
feat: close the adapter's connection on quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+-   A new `HarlequinConnection.close()` method can be implemented by adapters to gracefully close database connections when the application exits.
+
 ### Bug Fixes
 
 -   Wrong link on text_area_clipboard_error error message ([#509](https://github.com/tconbeer/harlequin/issues/509))

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -149,6 +149,15 @@ class HarlequinConnection(ABC):
         """
         raise NotImplementedError
 
+    def close(self) -> None:
+        """
+        Closes the connection, if necessary. This function is called when the app
+        quits.
+
+        Returns: None
+        """
+        return None
+
 
 class HarlequinAdapter(ABC):
     """

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -648,6 +648,8 @@ class Harlequin(App, inherit_bindings=False):
             s3_tree=self.data_catalog.s3_tree,
             history=self.history,
         )
+        if self.connection:
+            self.connection.close()
         await super().action_quit()
 
     def action_show_help_screen(self) -> None:


### PR DESCRIPTION
This change introduces a new optional method of HarlequinConnection implementations in adapters, giving them an opportunity to cleanly close the connection to the underlying database when the app exists.

The `close()` method is called in the `action_quit()` handler.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [x] Yes, and I have opened a PR at https://github.com/tconbeer/harlequin-web/pull/67
- [ ] Yes; I haven't opened a PR, but the gist of the change is that the new `HarlequinConnection.close()` can be documented in the "Creating an Adapter" guide.

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary – this is an optional functionality of adapters.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
