### PR TITLE
feat: add support for sqliterc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+-   SQLite adapter: Harlequin now executes an initialization script on start-up of the SQLite adapter. By default, it executes the script found at `~/.sqliterc`. To execute a different script, start Harlequin with the `--init-path` option (aliases `-i`/`-init`):
+
+    ```bash
+    harlequin -a sqlite --init-path ./my-project-script
+    ```
+
+    To start Harlequin without executing an initialization script, use the `--no-init` flag:
+
+    ```bash
+    harlequin -a sqlite --no-init
+    ```
+
+    **Note:** SQLite initialization scripts can contain dot commands or SQL statements. If Harlequin encounters a dot command, it will attempt to rewrite it as a SQL statement, and then execute the rewritten statement. Otherwise, it will ignore the dot command. Currently, Harlequin can only rewrite `.open` and `.load` commands.
+
+    ([#325](https://github.com/tconbeer/harlequin/issues/325))
+
 ## [1.18.0] - 2024-04-19
 
 ### Features

--- a/src/harlequin_duckdb/adapter.py
+++ b/src/harlequin_duckdb/adapter.py
@@ -361,7 +361,7 @@ class DuckDbAdapter(HarlequinAdapter):
                             connection.execute(cmd)
                             count += 1
             except duckdb.Error as e:
-                msg = f"Attempted to execute script at {init_script[0]}\n{e}"
+                msg = f"Attempted to execute script at {self.init_path}\n{e}"
                 raise HarlequinConnectionError(
                     msg, title="DuckDB could not execute your initialization script."
                 ) from e

--- a/src/harlequin_sqlite/cli_options.py
+++ b/src/harlequin_sqlite/cli_options.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from harlequin.options import (
-    FlagOption,
-    SelectOption,
-    TextOption,
-)
+from pathlib import Path
+
+from harlequin.options import FlagOption, PathOption, SelectOption, TextOption
 
 read_only = FlagOption(
     name="read-only",
@@ -102,7 +100,29 @@ cached_statements = TextOption(
     validator=_int_validator,
 )
 
+
+init = PathOption(
+    name="init-path",
+    description=(
+        "The path to an initialization script. On startup, Harlequin will execute "
+        "the commands in the script against the attached database."
+    ),
+    short_decls=["-i", "-init"],
+    exists=False,
+    file_okay=True,
+    dir_okay=False,
+    resolve_path=True,
+    path_type=Path,
+)
+
+no_init = FlagOption(
+    name="no-init",
+    description="Start Harlequin without executing the initialization script.",
+)
+
 SQLITE_OPTIONS = [
+    init,
+    no_init,
     read_only,
     connection_mode,
     timeout,


### PR DESCRIPTION
Closes #325 

**What** are the key elements of this solution?
This essentially copies the implementation from the DuckDB adapter.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
DuckDB's CLI was designed to copy SQLite's, so they share almost everything in common. It's simple enough and slightly different for the two dbs, so not worth factoring out into a shared module.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: sqlite adapter now supports init files.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
