### PR TITLE
feat/adapter conn unique id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Adapters may now implement a `connection_id` property to improve Harlequin's ability to persist the data catalog and query history across Harlequin invocations.
+- Adapters may now implement a `connection_id` property to improve Harlequin's ability to persist the data catalog and query history across Harlequin invocations ([#410](https://github.com/tconbeer/harlequin/issues/410)).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Adapters may now implement a `connection_id` property to improve Harlequin's ability to persist the data catalog and query history across Harlequin invocations.
+
 ### Bug Fixes
 
 - Harlequin no longer constrains the version of the adapter when the adapter is installed as an extra; Harlequin will install the latest available version that does not conflict with other dependencies.
+- The DuckDB and SQLite adapters now use only the resolved file path to the database file to load the data catalog and query history from disk (ignoring other connection options). This should improve cache hits. They will no longer attempt to load a cached catalog or history for in-memory connections.
 
 ## [1.23.2] - 2024-08-15
 

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -234,6 +234,23 @@ class HarlequinAdapter(ABC):
         pass
 
     @property
+    def connection_id(self) -> str | None:
+        """
+        Returns a unique ID for this connection, typically a fully-hydrated connection
+        string or similar. This Unique ID is used by Harlequin to cache the data
+        catalog and query history and persist them across invocations of Harlequin.
+
+        If None is returned, Harlequin will attempt to compute a unique ID from the
+        arguments used to initialize the adapter.
+
+        If the empty string is returned, Harlequin will not attempt to load the
+        catalog or buffers from the cache.
+
+        Returns: str | None
+        """
+        return None
+
+    @property
     def implements_copy(self) -> bool:
         """
         True if the adapter's connection implements the copy() method. Adapter must

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -317,13 +317,13 @@ class Harlequin(AppBase):
 
     @on(CatalogCacheLoaded)
     def build_trees(self, message: CatalogCacheLoaded) -> None:
-        if self.connection_hash is not None and (
+        if self.connection_hash and (
             cached_db := message.cache.get_db(self.connection_hash)
         ):
             self.post_message(NewCatalog(catalog=cached_db))
         if self.show_s3 is not None:
             self.data_catalog.load_s3_tree_from_cache(message.cache)
-        if self.connection_hash is not None:
+        if self.connection_hash:
             history = message.cache.get_history(self.connection_hash)
             self.history = history if history is not None else History.blank()
 

--- a/src/harlequin/catalog_cache.py
+++ b/src/harlequin/catalog_cache.py
@@ -41,10 +41,14 @@ class CatalogCache:
     history: dict[str, History]
 
     def get_db(self, connection_hash: str) -> Catalog | None:
-        return self.databases.get(connection_hash, None)
+        if connection_hash:
+            return self.databases.get(connection_hash, None)
+        return None
 
     def get_history(self, connection_hash: str) -> History | None:
-        return self.history.get(connection_hash, None)
+        if connection_hash:
+            return self.history.get(connection_hash, None)
+        return None
 
     def get_s3(
         self, cache_key: tuple[str | None, str | None, str | None]
@@ -75,14 +79,16 @@ def update_catalog_cache(
     s3_tree: S3Tree | None,
     history: History | None,
 ) -> None:
+    if connection_hash is None and s3_tree is None:
+        return
     cache = _load_cache()
     if cache is None:
         cache = CatalogCache(databases={}, s3={}, history={})
-    if catalog is not None and connection_hash is not None:
+    if catalog is not None and connection_hash:
         cache.databases[connection_hash] = catalog
     if s3_tree is not None and s3_tree.catalog_data is not None:
         cache.s3[s3_tree.cache_key] = s3_tree.catalog_data
-    if history is not None and connection_hash is not None:
+    if history is not None and connection_hash:
         cache.history[connection_hash] = history
     _write_cache(cache)
 

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -362,11 +362,17 @@ def build_cli() -> click.Command:
             pretty_print_error(e)
             ctx.exit(2)
 
+        connection_id = (
+            adapter_instance.connection_id
+            if adapter_instance.connection_id is not None
+            else get_connection_hash(conn_str, config)
+        )
+
         tui = Harlequin(
             adapter=adapter_instance,
             keymap_names=keymap_names,
             user_defined_keymaps=user_defined_keymaps,
-            connection_hash=get_connection_hash(conn_str, config),
+            connection_hash=connection_id,
             max_results=max_results,
             theme=theme,
             show_files=show_files,

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -75,11 +73,7 @@ def test_default(
     mock_adapter.assert_called_once_with(conn_str=expected_conn_str)
     mock_harlequin.assert_called_once_with(
         adapter=mock_adapter.return_value,
-        connection_hash=hashlib.md5(
-            json.dumps({"conn_str": expected_conn_str}).encode("utf-8")
-        )
-        .digest()
-        .hex(),
+        connection_hash=mock_adapter.return_value.connection_id,
         max_results=DEFAULT_LIMIT,
         keymap_names=DEFAULT_KEYMAP_NAMES,
         user_defined_keymaps=[],


### PR DESCRIPTION
Closes #410 

**What** are the key elements of this solution?
This adds a new property to the Adapter ABC, with a default implementation that returns `None`. If the adapter returns `None`, we default to the old behavior of guessing a connection ID.

This also implements the `connection_id` for the DuckDB and SQLite adapters, which just uses the resolved filepath as the connection ID.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [x] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
