### PR TITLE
fix: resolve initialization script paths starting ~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- DuckDB & SQLite adapters: fix bug to properly resolve initialization script paths starting with `~` (i.e. user's home dir) supplied to `--init-path` ([#646](https://github.com/tconbeer/harlequin/pull/646)).
+
 ## [1.24.0] - 2024-08-19
 
 ### Features

--- a/src/harlequin_duckdb/adapter.py
+++ b/src/harlequin_duckdb/adapter.py
@@ -295,7 +295,7 @@ class DuckDbAdapter(HarlequinAdapter):
                 conn_str if conn_str and conn_str != ("",) else IN_MEMORY_CONN_STR
             )
             self.init_path = (
-                Path(init_path).resolve()
+                Path(init_path).expanduser().resolve()
                 if init_path is not None
                 else Path.home() / ".duckdbrc"
             )

--- a/src/harlequin_sqlite/adapter.py
+++ b/src/harlequin_sqlite/adapter.py
@@ -290,7 +290,7 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
                 else IN_MEMORY_CONN_STR
             )
             self.init_path = (
-                Path(init_path).resolve()
+                Path(init_path).expanduser().resolve()
                 if init_path is not None
                 else Path.home() / ".sqliterc"
             )


### PR DESCRIPTION
Fix bug to properly resolve initialization script paths starting with `~` (i.e. user's home dir) supplied to `--init-path` for DuckDB & SQLite adapters.

Using only `.resolve()` means a path like `~/.my_startup.sql` resolves to `/Users/me/~/.my_startup.sql` which does not exist.

Using `.expanduser.resolve()` means the path properly resolves to `/Users/me/.my_startup.sql`.

cf. https://github.com/alexmalins/harlequin-databricks/pull/16

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
