### PR TITLE
fix/#652/windows tz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Harlequin's Data Catalog is now interactive! Adapters can define interactions on catalog nodes, which can be selected via a context menu by right-clicking on nodes in the context menu or pressing `.` (this binding is configurable via the `data_catalog.show_context_menu` action).
-- For adapters that support it, Harlequin's Data Catalog now loads lazily. This should dramatically improve Data Catalog load time for catalogs with thousands of nodes. The Data Catalog is no longer cached.
+- Harlequin's Data Catalog is now interactive! Adapters can define interactions on catalog nodes, which can be selected via a context menu by right-clicking on nodes in the context menu or pressing `.` (this binding is configurable via the `data_catalog.show_context_menu` action) ([#213](https://github.com/tconbeer/harlequin/issues/213)).
+- For adapters that support it, Harlequin's Data Catalog now loads lazily. This should dramatically improve Data Catalog load time for catalogs with thousands of nodes. The Data Catalog is no longer cached ([#491](https://github.com/tconbeer/harlequin/issues/491) - thank you [@rymurr](https://github.com/rymurr)!).
 - The DuckDB and SQLite adapters now support lazy-loading and a wide range of interactions, including `use`ing database and schemas, previewing data, dropping objects, and showing DDL for objects.
 
+### Bug Fixes
+
+- Fixes a crash on Windows caused by automatically downloading the 2024b tzdata file from IANA, which includes a single poorly-formatted date that breaks PyArrow's upstream tzdata parser ([#652](https://github.com/tconbeer/harlequin/issues/652) - thank you [@paulrobello](https://github.com/paulrobello) and [@alexmalins](https://github.com/alexmalins)!).
 
 ## [1.24.1] - 2024-09-25
 

--- a/src/harlequin/windows_timezone.py
+++ b/src/harlequin/windows_timezone.py
@@ -40,7 +40,10 @@ def check_and_install_tzdata() -> None:
             try:
                 # tz database is missing. We need to install it.
                 response = urlopen(
-                    "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+                    # "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+                    # see #652
+                    # TODO: unpin this.
+                    "https://data.iana.org/time-zones/releases/tzdata2024a.tar.gz"
                 )
                 with TemporaryDirectory() as tmpdir:
                     tar_path = Path(tmpdir) / "tzdata.tar.gz"


### PR DESCRIPTION
Closes #652

**What** are the key elements of this solution?
This just pins us to the newest working tzdata file. Will need to revert this pin in the future

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
It was easy; updated tzdata doesn't matter much right now.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
