### PR TITLE
fix: add NO_COLOR support to the config wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixes a bug where string data was rendered as Rich Markup ([#647](https://github.com/tconbeer/harlequin/issues/647) - thank you [@burncitiesburn](https://github.com/burncitiesburn)!).
 - Fixes a bug where `None` could be inconsistently displayed as `"None"` or the correct `∅ null` ([#658](https://github.com/tconbeer/harlequin/issues/658), [#655](https://github.com/tconbeer/harlequin/issues/655) - thank you, [@sgpeter1](https://github.com/sgpeter1)!).
+- `harlequin --config` now supports the `NO_COLOR` environment variable (the rest of the app already supported it) ([#552](https://github.com/tconbeer/harlequin/issues/552) - thank you [@glujan](https://github.com/glujan)!).
 
 ## [1.25.1] - 2024-10-31
 

--- a/src/harlequin/colors.py
+++ b/src/harlequin/colors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Dict, Type
 
 from pygments.style import Style as PygmentsStyle
@@ -58,19 +59,36 @@ class HarlequinPygmentsStyle(PygmentsStyle):
     highlight_color = DARK_GRAY
 
 
-HARLEQUIN_QUESTIONARY_STYLE = QuestionaryStyle(
-    [
-        ("qmark", f"fg:{GREEN} bold"),
-        ("question", "bold"),
-        ("answer", f"fg:{YELLOW} bold"),
-        ("pointer", f"fg:{YELLOW} bold"),
-        ("highlighted", f"fg:{YELLOW} bold"),
-        ("selected", f"fg:{YELLOW} noreverse bold"),
-        ("separator", f"fg:{PURPLE}"),
-        ("instruction", "fg:#858585 italic"),
-        ("text", ""),
-        ("disabled", "fg:#858585 italic"),
-    ]
+HARLEQUIN_QUESTIONARY_STYLE = (
+    QuestionaryStyle(
+        [
+            ("qmark", "fg:ansidefault bold"),
+            ("question", "fg:ansidefault nobold"),
+            ("answer", "fg:ansidefault bold"),
+            ("pointer", "fg:ansidefault bold"),
+            ("highlighted", "fg:ansidefault bold"),
+            ("selected", "fg:ansidefault noreverse bold"),
+            ("separator", "fg:ansidefault"),
+            ("instruction", "fg:ansidefault italic"),
+            ("text", ""),
+            ("disabled", "fg:ansidefault italic"),
+        ]
+    )
+    if os.getenv("NO_COLOR")
+    else QuestionaryStyle(
+        [
+            ("qmark", f"fg:{GREEN} bold"),
+            ("question", "bold"),
+            ("answer", f"fg:{YELLOW} bold"),
+            ("pointer", f"fg:{YELLOW} bold"),
+            ("highlighted", f"fg:{YELLOW} bold"),
+            ("selected", f"fg:{YELLOW} noreverse bold"),
+            ("separator", f"fg:{PURPLE}"),
+            ("instruction", "fg:#858585 italic"),
+            ("text", ""),
+            ("disabled", "fg:#858585 italic"),
+        ]
+    )
 )
 
 


### PR DESCRIPTION
Closes #552 

**What** are the key elements of this solution?
We check the `NO_COLOR` env var before setting the colors/style for the config app.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
Considered deeper support, including a `HARLEQUIN_NO_COLOR` variable, but it didn't seem necessary. Textual and rich-click already have robust `NO_COLOR` support.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: we should note that we support `NO_COLOR` somewhere.

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary. (the config app doesn't have any tests -- I tested this manually.)
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
