### PR TITLE
fix #745: suppress exceptions raised after App.exit() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Harlequin now supports `infinity` and `-infinity` timestamps (from Postgres and DuckDB), as well as other timestamps that may have previously overflowed Python's native types and been shown as `null` ([#690](https://github.com/tconbeer/harlequin/issues/690) - thank you [@yrashk](https://github.com/yrashk)!).
+- Harlequin will no longer show a traceback for exceptions that occur after App shutdown has started ([#745](https://github.com/tconbeer/harlequin/issues/745)).
 
 ## [2.0.1] - 2025-01-29
 

--- a/src/harlequin/app_base.py
+++ b/src/harlequin/app_base.py
@@ -64,3 +64,13 @@ class AppBase(App, inherit_bindings=False):
         Changes the default screen to re-order bindings, with global bindings first.
         """
         return ScreenBase(id="_default")
+
+    def _handle_exception(self, error: Exception) -> None:
+        """
+        Prevents tracebacks from being printed due to exceptions that
+        occur after App.exit() is called.
+        See https://github.com/Textualize/textual/issues/5325
+        """
+        if self._exit:
+            return
+        return super()._handle_exception(error)


### PR DESCRIPTION
Fixes #745