### PR TITLE
fix/pin tree sitter sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Pins the tree-sitter and tree-sitter-sql versions to avoid a crash caused by a mismatch between those versions.
+
 ## [2.0.4] - 2025-02-11
 
 ### Bug Fixes

--- a/poetry.lock
+++ b/poetry.lock
@@ -4136,4 +4136,4 @@ trino = ["harlequin-trino"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14.0"
-content-hash = "0e89ca7fc735145fd244d645650aa1c5bb0d68d7544d6a68e33dcb95184f86ff"
+content-hash = "c19cb007e3ace8a4a89809e5ec09a7ee9f7642074249893976d5e7537f99f85d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ questionary = "^2.0.1"
 # optional deps
 boto3 = { version = "^1.34.22", optional = true }
 
+# temp pins
+# tree-sitter-sql 0.3.8 seems incompatible with tree-sitter 0.24.0
+tree-sitter = ">=0.23.0,<0.25.0"
+tree-sitter-sql = "==0.3.7"
+
 # wheel pins: these packages don't build wheels for all Pythons
 numpy = [
     { version = ">=2.0.0,<2.1.0", python = "<3.10.0" },


### PR DESCRIPTION
Fixes an issue with a fresh install of Harlequin, as of tree-sitter-sql 0.3.8 (released a few hours ago): https://github.com/DerekStride/tree-sitter-sql/releases/tag/v0.3.8