### PR TITLE
fix #800: use shlex to split connection strings in config wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Fixes a bug in `harlequin --config` where connection strings containing spaces were improperly split into multiple strings ([#800](https://github.com/tconbeer/harlequin/issues/800) - thank you [@Bento-HS](https://github.com/Bento-HS)!).
+
 ## [2.1.1] - 2025-03-17
 
 ### Bug Fixes

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -59,7 +60,7 @@ def _wizard(config_path: Path | None) -> None:
 
     conn_str = questionary.text(
         message="What connection string(s) should this profile use?",
-        instruction="Separate items by a space.",
+        instruction="Separate items by a space. Quote a single item containing spaces.",
         default=" ".join(selected_profile.get("conn_str", [])),
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
@@ -143,7 +144,7 @@ def _wizard(config_path: Path | None) -> None:
 
     adapter_options = {}
     if conn_str:
-        adapter_options["conn_str"] = conn_str.split(" ")
+        adapter_options["conn_str"] = shlex.split(conn_str)
     _prompt_to_set_adapter_options(
         adapter_options=adapter_options,
         adapter_cls=adapter_cls,


### PR DESCRIPTION
Closes #800 

**What** are the key elements of this solution?
Use `shlex.split()` instead of `str.split()` to split the input of the conn str prompt in the config wizard, so we respect quotes.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
Super easy.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
