### PR TITLE
fix: add hatchling build config to ship all 4 packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,3 @@
-[build-system]
-
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-
 [project]
 
 name = "harlequin"
@@ -109,6 +103,22 @@ sqlite = "harlequin_sqlite:HarlequinSqliteAdapter"
 [project.entry-points."harlequin.keymap"]
 
 vscode = "harlequin_vscode:VSCODE"
+
+
+[build-system]
+
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+
+[tool.hatch.build]
+
+packages = [
+    "src/harlequin",
+    "src/harlequin_duckdb",
+    "src/harlequin_sqlite",
+    "src/harlequin_vscode",
+]
 
 
 [tool.ruff]


### PR DESCRIPTION
Fixes another regression from #856 -- the default hatchling settings were only shipping the harlequin package, but not the duckdb, sqlite, and vscode packages that are also required.