### PR TITLE
chore: add retries to flaky tests, especially on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run --no-sync pytest -m "not online" ${{ matrix.os == 'Windows-latest' && '-m "not flaky_windows"' || '' }} --snapshot-warn-unused
+          uv run --no-sync pytest -m "not online" ${{ matrix.os == 'Windows-latest' && '--force-flaky --max-runs=3' || '' }} --snapshot-warn-unused
 
       - name: Store snapshot report on failure
         uses: actions/upload-artifact@v4  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test = [
     "pytest-textual-snapshot @ https://github.com/tconbeer/pytest-textual-snapshot.git#main",
     # extension tests require consistent version of duckdb.
     "duckdb==1.1.1",
+    "flaky>=3.8.1",
 ]
 
 
@@ -169,5 +170,4 @@ strict_equality = true
 markers = [
     "online: requeries internet connection (deselect with '-m \"not online\"')",
     "use_cache: override the autouse fixture the disables the buffer cache",
-    "flaky_windows: likely to fail for no reason on windows."
 ]

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -36,6 +36,7 @@ async def test_query_formatting(
         assert app.editor.text == "select 1 from foo\n"
 
 
+@pytest.mark.flaky
 @pytest.mark.asyncio
 async def test_multiple_buffers(
     app: Harlequin,
@@ -119,6 +120,7 @@ async def test_multiple_buffers(
         assert all(snap_results)
 
 
+@pytest.mark.flaky
 @pytest.mark.asyncio
 async def test_word_autocomplete(
     app_all_adapters: Harlequin,
@@ -188,6 +190,7 @@ async def test_word_autocomplete(
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Initial snapshot very flaky on windows."
 )
+@pytest.mark.flaky
 @pytest.mark.asyncio
 async def test_member_autocomplete(
     app_small_duck: Harlequin,

--- a/uv.lock
+++ b/uv.lock
@@ -561,6 +561,15 @@ wheels = [
 ]
 
 [[package]]
+name = "flaky"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/c5/ef69119a01427204ff2db5fc8f98001087bcce719bbb94749dcd7b191365/flaky-3.8.1.tar.gz", hash = "sha256:47204a81ec905f3d5acfbd61daeabcada8f9d4031616d9bcb0618461729699f5", size = 25248, upload-time = "2024-03-12T22:17:59.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/b8/b830fc43663246c3f3dd1ae7dca4847b96ed992537e85311e27fa41ac40e/flaky-3.8.1-py2.py3-none-any.whl", hash = "sha256:194ccf4f0d3a22b2de7130f4b62e45e977ac1b5ccad74d4d48f3005dcc38815e", size = 19139, upload-time = "2024-03-12T22:17:51.59Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,6 +1015,7 @@ static = [
 ]
 test = [
     { name = "duckdb" },
+    { name = "flaky" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-textual-snapshot" },
@@ -1058,6 +1068,7 @@ static = [
 ]
 test = [
     { name = "duckdb", specifier = "==1.1.1" },
+    { name = "flaky", specifier = ">=3.8.1" },
     { name = "pytest", specifier = ">=7.3.1,<9.0.0" },
     { name = "pytest-asyncio", specifier = "==0.21.0" },
     { name = "pytest-textual-snapshot", git = "https://github.com/tconbeer/pytest-textual-snapshot.git" },


### PR DESCRIPTION
Closes #857 

**What** are the key elements of this solution?
Adds the flaky plugin for pytest; marks 3 tests as flaky on all platforms; runs Windows tests in --force-flaky mode to retry all failing tests.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
slower tests but hopefully fewer failures; a lot of windows tests in particular have different (flaky) behavior in tests that I can't reproduce in person.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [ ] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
