### PR TITLE
feat(cli): support setting config path from the `HARLEQUIN_CONFIG_PATH` environment variable (fix #897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Allows setting the config path using the `HARLEQUIN_CONFIG_PATH` environment variable ([#897](https://github.com/tconbeer/harlequin/issues/897))
+
 ## [2.4.1] - 2025-10-30
 
 ### Bug Fixes

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -183,6 +183,8 @@ def build_cli() -> click.Command:
             resolve_path=True,
             path_type=Path,
         ),
+        envvar="HARLEQUIN_CONFIG_PATH",
+        show_envvar=True,
     )
     @click.option(
         "-t",

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -298,6 +298,29 @@ def test_config_path(
     assert mock_adapter.call_args.kwargs["extension"] == ["httpfs", "spatial"]
 
 
+@pytest.mark.parametrize("filename", ["good_config.toml", "pyproject.toml"])
+def test_config_path_fron_env(
+    mock_harlequin: MagicMock,
+    mock_adapter: MagicMock,
+    data_dir: Path,
+    filename: str,
+) -> None:
+    runner = CliRunner()
+    config_path = data_dir / "unit_tests" / "config" / filename
+    res = runner.invoke(
+        build_cli(), env={"HARLEQUIN_CONFIG_PATH": config_path.as_posix()}
+    )
+    assert res.exit_code == 0
+    mock_harlequin.assert_called_once()
+    assert mock_harlequin.call_args
+    # should use default profile of my-duckdb-profile
+    assert mock_harlequin.call_args.kwargs["max_results"] == 200_000
+    mock_adapter.assert_called_once()
+    assert mock_adapter.call_args.kwargs["conn_str"] == ["my-database.db"]
+    assert mock_adapter.call_args.kwargs["read_only"] is False
+    assert mock_adapter.call_args.kwargs["extension"] == ["httpfs", "spatial"]
+
+
 def test_bad_config_exits(
     mock_harlequin: MagicMock,
     mock_adapter: MagicMock,


### PR DESCRIPTION
Closes #897 (an existing open issue)

**What** are the key elements of this solution?

Allows setting the config path using the `HARLEQUIN_CONFIG_PATH` environment variable.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

It was the cleanest and easiest path. 
Using `auto_envvar_prefix` would have automatically exposed all parameters way out of the scope.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [x] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web): https://github.com/tconbeer/harlequin-web/pull/136
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.


> [!NOTE]
> I have some test failures locally, but the exact same failures that I have running the test suite on `main`, and unrelated to the change. I'll adjust if the CI fails on something else