### PR TITLE
Custom themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Adds support for user-defined custom themes loaded from TOML files. Place theme files in the directory printed by `harlequin --locate-themes` ([#966](https://github.com/tconbeer/harlequin/pull/966), [#855](https://github.com/tconbeer/harlequin/discussions/855)).
+
 ## [2.5.2] - 2026-03-25
 
 ### Bug Fixes

--- a/src/harlequin/app_base.py
+++ b/src/harlequin/app_base.py
@@ -12,7 +12,9 @@ from harlequin.colors import HARLEQUIN_TEXTUAL_THEME
 from harlequin.exception import (
     HarlequinThemeError,
     pretty_error_message,
+    pretty_print_warning,
 )
+from harlequin.themes import load_user_themes
 
 
 class ScreenBase(Screen):
@@ -42,18 +44,30 @@ class AppBase(App, inherit_bindings=False):
     ):
         super().__init__(driver_class, css_path, watch_css)
         self.register_theme(HARLEQUIN_TEXTUAL_THEME)
+
+        user_themes = load_user_themes()
+        for user_theme in user_themes.loaded_themes.values():
+            self.register_theme(user_theme)
+        for path, exc in user_themes.failed_themes:
+            pretty_print_warning(
+                title="Harlequin couldn't load a theme.",
+                message=f"Failed to load theme from {path}:\n{exc}",
+            )
+
         try:
             self.theme = theme or "harlequin"
         except InvalidThemeError:
             from harlequin.colors import VALID_THEMES
 
-            valid_themes = ", ".join(VALID_THEMES.keys())
+            all_themes = sorted(
+                {*VALID_THEMES.keys(), *user_themes.loaded_themes.keys()}
+            )
             e = HarlequinThemeError(
                 (
-                    f"No theme found with the name {theme}.\n"
-                    "Supported themes changed in Harlequin v2.0.0. "
-                    "Theme must be `harlequin` or the name of a Textual Theme:\n"
-                    f"{valid_themes}"
+                    f"No theme found with the name {theme!r}.\n"
+                    "Theme must be `harlequin`, the name of a Textual built-in theme, "
+                    "or a custom theme loaded from your theme directory.\n"
+                    f"Available themes: {', '.join(all_themes)}"
                 ),
                 title="Harlequin couldn't load your theme.",
             )

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -87,6 +87,7 @@ click.rich_click.OPTION_GROUPS = {
             "options": [
                 "--config",
                 "--keys",
+                "--locate-themes",
                 "--version",
                 "--help",
             ],
@@ -118,6 +119,13 @@ def _version_option() -> str:
     )
 
     return output
+
+
+def _locate_themes_callback(ctx: click.Context, param: Any, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    print(get_theme_directory())
+    ctx.exit(0)
 
 
 def _config_wizard_callback(ctx: click.Context, param: Any, value: bool) -> None:
@@ -262,6 +270,17 @@ def build_cli() -> click.Command:
         is_flag=True,
         callback=_keys_app_callback,
         expose_value=True,
+    )
+    @click.option(
+        "--locate-themes",
+        help=(
+            "Print the path to the user theme directory and exit. "
+            "Place custom .toml theme files in this directory."
+        ),
+        is_flag=True,
+        callback=_locate_themes_callback,
+        expose_value=False,
+        is_eager=True,
     )
     @click.option(
         "--locale",

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -23,6 +23,7 @@ from harlequin.keys_app import HarlequinKeys
 from harlequin.locale_manager import set_locale
 from harlequin.options import AbstractOption
 from harlequin.plugins import load_adapter_plugins
+from harlequin.themes import get_theme_directory
 from harlequin.windows_timezone import check_and_install_tzdata
 
 # configure defaults
@@ -193,8 +194,9 @@ def build_cli() -> click.Command:
         show_default=True,
         help=(
             "Set the theme (colors) of the Harlequin IDE. "
-            "Must be `harlequin` or the name of a Textual theme: "
-            f"{ALL_THEMES}"
+            f"Built-in themes: {ALL_THEMES}. "
+            "Custom themes can be added as TOML files in "
+            f"{get_theme_directory()}."
         ),
     )
     @click.option(

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -9,10 +9,9 @@ import tomlkit
 from rich import print as rich_print
 from rich.markup import escape
 from rich.panel import Panel
-from textual.theme import BUILTIN_THEMES
 
 from harlequin.adapter import HarlequinAdapter
-from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE, YELLOW
+from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE, VALID_THEMES, YELLOW
 from harlequin.config import (
     Config,
     ConfigFile,
@@ -24,6 +23,7 @@ from harlequin.config import (
 from harlequin.exception import HarlequinWizardError, pretty_print_error
 from harlequin.options import ListOption
 from harlequin.plugins import load_adapter_plugins, load_keymap_plugins
+from harlequin.themes import load_user_themes
 
 
 def wizard(config_path: Path | None) -> None:
@@ -65,9 +65,11 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
+    user_themes = load_user_themes()
+    all_theme_names = sorted({*VALID_THEMES.keys(), *user_themes.loaded_themes.keys()})
     theme = questionary.select(
         message="What theme should this profile use?",
-        choices=sorted(BUILTIN_THEMES.keys()),
+        choices=all_theme_names,
         default=selected_profile.get("theme", "harlequin"),
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()

--- a/src/harlequin/themes.py
+++ b/src/harlequin/themes.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple
+
+from platformdirs import user_config_path
+from textual.color import Color
+from textual.theme import Theme as TextualTheme
+from tomlkit.exceptions import TOMLKitError
+from tomlkit.toml_file import TOMLFile
+
+from harlequin.exception import HarlequinThemeError
+
+# Fields recognized in a theme TOML file; unknown keys are silently ignored
+# so theme files can include author/description metadata without erroring.
+_THEME_FIELDS = frozenset(
+    {
+        "primary",
+        "secondary",
+        "background",
+        "surface",
+        "panel",
+        "warning",
+        "error",
+        "success",
+        "accent",
+        "foreground",
+        "dark",
+    }
+)
+
+
+@dataclass
+class HarlequinTheme:
+    """Represents a user-defined Harlequin color theme loaded from a TOML file."""
+
+    name: str
+    primary: str
+    secondary: str | None = None
+    background: str | None = None
+    surface: str | None = None
+    panel: str | None = None
+    warning: str | None = None
+    error: str | None = None
+    success: str | None = None
+    accent: str | None = None
+    foreground: str | None = None
+    dark: bool = True
+
+    def to_textual_theme(self) -> TextualTheme:
+        color_fields: dict[str, str | None] = {
+            "primary": self.primary,
+            "secondary": self.secondary,
+            "background": self.background,
+            "surface": self.surface,
+            "panel": self.panel,
+            "warning": self.warning,
+            "error": self.error,
+            "success": self.success,
+            "accent": self.accent,
+            "foreground": self.foreground,
+        }
+        for color in color_fields.values():
+            if color is not None:
+                Color.parse(color)
+
+        return TextualTheme(
+            name=self.name,
+            dark=self.dark,
+            **{k: v for k, v in color_fields.items() if v is not None},  # type: ignore[arg-type]
+        )
+
+
+class UserThemeLoadResult(NamedTuple):
+    loaded_themes: dict[str, TextualTheme]
+    failed_themes: list[tuple[Path, Exception]]
+
+
+def get_theme_directory() -> Path:
+    """Return the platform-appropriate directory for user theme files.
+
+    On Linux:   ~/.config/harlequin/themes/
+    On macOS:   ~/Library/Application Support/harlequin/themes/
+    On Windows: C:\\Users\\<user>\\AppData\\Local\\harlequin\\themes\\
+    """
+    return user_config_path(appname="harlequin", appauthor=False) / "themes"
+
+
+def load_user_theme(path: Path) -> TextualTheme:
+    """Parse a single TOML theme file and return a TextualTheme.
+
+    Raises HarlequinThemeError if the file cannot be parsed or contains
+    invalid color values.
+    """
+    toml_file = TOMLFile(path)
+    try:
+        raw: dict = toml_file.read().unwrap()
+    except TOMLKitError as e:
+        raise HarlequinThemeError(
+            f"Could not parse theme file at {path}: {e}",
+            title="Harlequin couldn't load your theme.",
+        ) from e
+
+    name = str(raw.get("name", path.stem))
+    known = {k: v for k, v in raw.items() if k in _THEME_FIELDS}
+    try:
+        theme = HarlequinTheme(name=name, **known)
+        return theme.to_textual_theme()
+    except Exception as e:
+        raise HarlequinThemeError(
+            f"Invalid theme file at {path}: {e}",
+            title="Harlequin couldn't load your theme.",
+        ) from e
+
+
+def load_user_themes(theme_dir: Path | None = None) -> UserThemeLoadResult:
+    """Load all TOML theme files from the theme directory.
+
+    Returns a UserThemeLoadResult with successfully loaded themes and a list
+    of (path, exception) pairs for any files that failed to load. A missing
+    theme directory is not an error — it returns empty results.
+    """
+    directory = theme_dir if theme_dir is not None else get_theme_directory()
+    loaded: dict[str, TextualTheme] = {}
+    failed: list[tuple[Path, Exception]] = []
+
+    if not directory.exists():
+        return UserThemeLoadResult(loaded_themes=loaded, failed_themes=failed)
+
+    for path in directory.iterdir():
+        if path.suffix == ".toml":
+            try:
+                theme = load_user_theme(path)
+                loaded[theme.name] = theme
+            except Exception as e:
+                failed.append((path, e))
+
+    return UserThemeLoadResult(loaded_themes=loaded, failed_themes=failed)

--- a/tests/unit_tests/test_themes.py
+++ b/tests/unit_tests/test_themes.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.theme import Theme as TextualTheme
+
+from harlequin.exception import HarlequinThemeError
+from harlequin.themes import (
+    HarlequinTheme,
+    UserThemeLoadResult,
+    load_user_theme,
+    load_user_themes,
+)
+
+
+def write_theme(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestHarlequinTheme:
+    def test_to_textual_theme_minimal(self) -> None:
+        theme = HarlequinTheme(name="minimal", primary="#ff0000")
+        result = theme.to_textual_theme()
+        assert isinstance(result, TextualTheme)
+        assert result.name == "minimal"
+
+    def test_to_textual_theme_all_fields(self) -> None:
+        theme = HarlequinTheme(
+            name="full",
+            primary="#4e78c4",
+            secondary="#f39c12",
+            accent="#e74c3c",
+            background="#0e1726",
+            surface="#17202a",
+            panel="#1e2a35",
+            error="#e74c3c",
+            success="#2ecc71",
+            warning="#f1c40f",
+            foreground="#dddddd",
+            dark=True,
+        )
+        result = theme.to_textual_theme()
+        assert isinstance(result, TextualTheme)
+        assert result.name == "full"
+
+    def test_to_textual_theme_light(self) -> None:
+        theme = HarlequinTheme(name="light", primary="#2c4251", dark=False)
+        result = theme.to_textual_theme()
+        assert result.dark is False
+
+    def test_to_textual_theme_invalid_color_raises(self) -> None:
+        from textual.color import ColorParseError
+
+        theme = HarlequinTheme(name="bad", primary="not-a-color")
+        with pytest.raises(ColorParseError):
+            theme.to_textual_theme()
+
+
+class TestLoadUserTheme:
+    def test_valid_minimal_theme(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "my-theme.toml",
+            'name = "my-theme"\nprimary = "#4e78c4"\n',
+        )
+        result = load_user_theme(path)
+        assert isinstance(result, TextualTheme)
+        assert result.name == "my-theme"
+
+    def test_valid_full_theme(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "full.toml",
+            "\n".join(
+                [
+                    'name = "full"',
+                    'primary = "#4e78c4"',
+                    'secondary = "#f39c12"',
+                    'accent = "#e74c3c"',
+                    'background = "#0e1726"',
+                    'surface = "#17202a"',
+                    'panel = "#1e2a35"',
+                    'error = "#e74c3c"',
+                    'success = "#2ecc71"',
+                    'warning = "#f1c40f"',
+                    "dark = true",
+                ]
+            ),
+        )
+        result = load_user_theme(path)
+        assert result.name == "full"
+
+    def test_name_defaults_to_file_stem(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "fallback-name.toml",
+            'primary = "#4e78c4"\n',
+        )
+        result = load_user_theme(path)
+        assert result.name == "fallback-name"
+
+    def test_unknown_fields_are_ignored(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "meta.toml",
+            "\n".join(
+                [
+                    'name = "meta"',
+                    'primary = "#4e78c4"',
+                    'author = "Someone"',
+                    'description = "A theme"',
+                    'homepage = "https://example.com"',
+                ]
+            ),
+        )
+        result = load_user_theme(path)
+        assert result.name == "meta"
+
+    def test_invalid_color_raises(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "bad.toml",
+            'name = "bad"\nprimary = "not-a-color"\n',
+        )
+        with pytest.raises(HarlequinThemeError, match="Invalid theme"):
+            load_user_theme(path)
+
+    def test_invalid_toml_raises(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "bad.toml",
+            "name = [unclosed\n",
+        )
+        with pytest.raises(HarlequinThemeError, match="Could not parse"):
+            load_user_theme(path)
+
+    def test_missing_primary_raises(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "no-primary.toml",
+            'name = "no-primary"\nsecondary = "#f39c12"\n',
+        )
+        with pytest.raises(HarlequinThemeError):
+            load_user_theme(path)
+
+    def test_light_theme(self, tmp_path: Path) -> None:
+        path = write_theme(
+            tmp_path / "light.toml",
+            'name = "light"\nprimary = "#2c4251"\ndark = false\n',
+        )
+        result = load_user_theme(path)
+        assert result.dark is False
+
+
+class TestLoadUserThemes:
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        result = load_user_themes(theme_dir=tmp_path)
+        assert isinstance(result, UserThemeLoadResult)
+        assert result.loaded_themes == {}
+        assert result.failed_themes == []
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        result = load_user_themes(theme_dir=tmp_path / "nonexistent")
+        assert result.loaded_themes == {}
+        assert result.failed_themes == []
+
+    def test_ignores_non_toml_files(self, tmp_path: Path) -> None:
+        (tmp_path / "theme.yaml").write_text(
+            'name = "yaml"\nprimary = "#4e78c4"\n', encoding="utf-8"
+        )
+        (tmp_path / "theme.json").write_text(
+            '{"name": "json"}', encoding="utf-8"
+        )
+        (tmp_path / "readme.txt").write_text("hello", encoding="utf-8")
+        result = load_user_themes(theme_dir=tmp_path)
+        assert result.loaded_themes == {}
+        assert result.failed_themes == []
+
+    def test_loads_multiple_themes(self, tmp_path: Path) -> None:
+        for i, color in enumerate(["#ff0000", "#00ff00", "#0000ff"]):
+            write_theme(
+                tmp_path / f"theme-{i}.toml",
+                f'name = "theme-{i}"\nprimary = "{color}"\n',
+            )
+        result = load_user_themes(theme_dir=tmp_path)
+        assert len(result.loaded_themes) == 3
+        assert result.failed_themes == []
+
+    def test_failed_themes_tracked_separately(self, tmp_path: Path) -> None:
+        write_theme(
+            tmp_path / "good.toml",
+            'name = "good"\nprimary = "#4e78c4"\n',
+        )
+        write_theme(
+            tmp_path / "bad.toml",
+            'name = "bad"\nprimary = "not-a-color"\n',
+        )
+        result = load_user_themes(theme_dir=tmp_path)
+        assert len(result.loaded_themes) == 1
+        assert "good" in result.loaded_themes
+        assert len(result.failed_themes) == 1
+        assert result.failed_themes[0][0] == tmp_path / "bad.toml"
+
+    def test_returns_themes_keyed_by_name(self, tmp_path: Path) -> None:
+        write_theme(
+            tmp_path / "filename.toml",
+            'name = "custom-name"\nprimary = "#4e78c4"\n',
+        )
+        result = load_user_themes(theme_dir=tmp_path)
+        assert "custom-name" in result.loaded_themes
+        assert "filename" not in result.loaded_themes


### PR DESCRIPTION
Related to [https://github.com/tconbeer/harlequin/discussions/855]

**What** are the key elements of this solution?
- Adds `src/harlequin/themes.py` with a `HarlequinTheme` dataclass, `load_user_themes()`, `load_user_theme()`, `get_theme_directory()`, and a `UserThemeLoadResult` NamedTuple for tracking load failures gracefully.
- User themes are defined as `.toml` files placed in a platform-appropriate directory (`~/.config/harlequin/themes/` on Linux, equivalent on macOS and Windows via exisiting `platformdirs`).
- Themes are loaded and registered at app startup in `AppBase.__init__()`. Any files that fail to parse emit a warning rather than crashing.
- The config wizard now lists user themes alongside built-in themes.
- A `--locate-themes` flag prints the theme directory path and exits, making the feature discoverable.

  Example theme file:
  ```toml
  name = "my-theme"
  primary = "#4e78c4"
  secondary = "#f39c12"
  accent = "#e74c3c"
  background = "#0e1726"
  surface = "#17202a"
  panel = "#1e2a35"
  error = "#e74c3c"
  success = "#2ecc71"
  warning = "#f1c40f"
  dark = true

  # Optional metadata (ignored by Harlequin)
  author = "Your Name"
  description = "A dark blue theme."
  homepage = "https://github.com/you/your-theme"

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
- TOML over YAML: Harlequin already uses tomlkit for config files, so TOML avoids adding a new dependency. Posting (which you linked as inspiration) uses YAML, but the formats are equivalent for this use case.
- No custom syntax color system: textual_textarea already auto-derives SQL syntax highlighting from a registered TextualTheme's semantic colors (primary → keywords, accent → strings/numbers, etc.) via text_area_theme_from_app_theme(). This means a well-designed theme file automatically produces coherent SQL syntax highlighting with no extra configuration required. Granular per-token control could be added later as an optional [syntax] sub-section if there is demand (I doubt it tbh).
- platformdirs: Already a dependency; handles Windows/macOS/Linux paths correctly without any platform-specific code.
- Unknown fields are silently ignored: Theme files can include author, description, and homepage metadata without errors, making them self-documenting.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: document the theme file format (fields, valid color strings), the theme directory location per platform, and the --locate-themes flag.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
