### PR TITLE
fix: refresh file tree after Harlequin saves or exports a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Refreshes the file tree in the Data Catalog after Harlequin writes a file, either by saving from the editor or exporting data, so newly written files appear without a manual refresh ([#871](https://github.com/tconbeer/harlequin/issues/871)).
+
 ## [2.5.2] - 2026-03-25
 
 ### Bug Fixes

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -889,11 +889,15 @@ class Harlequin(AppBase):
         if table is None:
             show_export_error(error=ValueError("You must execute a query first."))
             return
-        notify = partial(self.notify, "Data exported successfully.")
+
+        def on_export_success() -> None:
+            self.notify("Data exported successfully.")
+            self.data_catalog.update_file_tree()
+
         callback = partial(
             export_callback,
             table=table,
-            success_callback=notify,
+            success_callback=on_export_success,
             error_callback=show_export_error,
         )
         self.app.push_screen(

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -81,6 +81,8 @@ class CodeEditor(TextEditor, inherit_bindings=False):
 
     def on_text_area_saved(self, message: TextAreaSaved) -> None:
         self.app.notify(f"Editor contents saved to {message.path}")
+        if hasattr(self.app, "data_catalog"):
+            self.app.data_catalog.update_file_tree()
 
     def on_text_area_clipboard_error(self) -> None:
         if not self.has_shown_clipboard_error:

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -1,13 +1,15 @@
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, List, NamedTuple, Type
+from typing import Awaitable, Callable, List, NamedTuple, Set, Type
 from unittest.mock import MagicMock
 
 import pytest
 from textual.geometry import Offset
+from textual.widgets import Input
 
 from harlequin import Harlequin
 from harlequin.catalog import InteractiveCatalogItem
+from harlequin.components import ExportScreen
 from harlequin_duckdb.adapter import DuckDbAdapter
 
 
@@ -287,3 +289,91 @@ async def test_context_menu(
         snap_results.append(await app_snapshot(app, "table context menu expanded"))
 
         assert all(snap_results)
+
+
+def _file_tree_paths(app: Harlequin) -> Set[Path]:
+    """Return the paths of the top-level nodes in the file tree."""
+    assert app.data_catalog.file_tree is not None
+    return {
+        node.data.path
+        for node in app.data_catalog.file_tree.root.children
+        if node.data is not None
+    }
+
+
+@pytest.mark.asyncio
+async def test_file_tree_refreshes_after_editor_save(
+    duckdb_adapter: Type[DuckDbAdapter],
+    tmp_path: Path,
+) -> None:
+    """
+    Regression test for https://github.com/tconbeer/harlequin/issues/871:
+    the file tree should refresh after Harlequin saves a file from the editor,
+    without the user having to manually refresh the catalog.
+    """
+    app = Harlequin(duckdb_adapter((":memory:",)), show_files=tmp_path)
+    async with app.run_test() as pilot:
+        while app.editor is None:
+            await pilot.pause()
+        assert app.data_catalog.file_tree is not None
+
+        new_file = tmp_path / "saved_by_harlequin.sql"
+        assert new_file not in _file_tree_paths(app)
+
+        app.editor.focus()
+        app.editor.text = "select 1"
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        save_input = app.editor.query_one("#textarea__save_input", Input)
+        save_input.value = str(new_file)
+        await pilot.press("enter")
+
+        for _ in range(100):
+            await pilot.pause()
+            if new_file in _file_tree_paths(app):
+                break
+
+        assert new_file.is_file()
+        assert new_file in _file_tree_paths(app)
+
+
+@pytest.mark.asyncio
+async def test_file_tree_refreshes_after_export(
+    duckdb_adapter: Type[DuckDbAdapter],
+    tmp_path: Path,
+) -> None:
+    """
+    Regression test for https://github.com/tconbeer/harlequin/issues/871:
+    the file tree should refresh after Harlequin exports data to a file,
+    without the user having to manually refresh the catalog.
+    """
+    app = Harlequin(duckdb_adapter((":memory:",)), show_files=tmp_path)
+    async with app.run_test(size=(120, 36)) as pilot:
+        while app.editor is None:
+            await pilot.pause()
+
+        app.editor.text = "select 1 as a, 2 as b"
+        await pilot.press("ctrl+j")  # run query
+        for _ in range(100):
+            await pilot.pause()
+            if app.results_viewer.get_visible_table() is not None:
+                break
+        assert app.results_viewer.get_visible_table() is not None
+
+        export_path = tmp_path / "exported.csv"
+        assert export_path not in _file_tree_paths(app)
+
+        await pilot.press("ctrl+e")
+        while not isinstance(app.screen, ExportScreen):
+            await pilot.pause()
+        app.screen.file_input.value = str(export_path)
+        await pilot.pause()
+        await pilot.press("enter")
+
+        for _ in range(100):
+            await pilot.pause()
+            if export_path in _file_tree_paths(app):
+                break
+
+        assert export_path.is_file()
+        assert export_path in _file_tree_paths(app)


### PR DESCRIPTION
fix: refresh file tree after Harlequin saves or exports a file

Fixes #871

## Problem

When Harlequin writes a file to disk itself — either by saving the query
editor's contents (`ctrl+s`) or by exporting a result set (Data > Export) —
the Data Catalog's file tree does not update. A file the user just created
through Harlequin appears missing/stale in Harlequin's own file browser until
they manually press `ctrl+r` to refresh the catalog.

As the maintainer (and reporter) noted on the issue:

> works fine to manually refresh with ctrl+r, but we should add a hook to
> refresh the file tree after Harlequin saves a file (via the editor or data
> export). not a regression.

## Root cause

The catalog already knows how to reload the file tree
(`DataCatalog.update_file_tree()` in
`src/harlequin/components/data_catalog/__init__.py`), but that method was only
wired into the manual refresh action (`ctrl+r` ->
`Harlequin.action_refresh_catalog`, `src/harlequin/app.py`). Neither
file-writing code path called it:

- `CodeEditor.on_text_area_saved` (`src/harlequin/components/code_editor.py`)
  handled the `TextAreaSaved` message from the editor by only calling
  `self.app.notify(...)`.
- `Harlequin.action_export` (`src/harlequin/app.py`) passed a success callback
  that only called `self.notify(...)`.

## Fix

Call the existing `update_file_tree()` from both write-completion paths:

- `code_editor.py`: after notifying, `on_text_area_saved` now calls
  `self.app.data_catalog.update_file_tree()`, guarded by
  `hasattr(self.app, "data_catalog")` — matching the existing defensive idiom
  in this widget (e.g. `action_focus_data_catalog`), so the reusable
  `CodeEditor` is unaffected when hosted outside Harlequin.
- `app.py`: `action_export`'s success callback now both notifies and calls
  `self.data_catalog.update_file_tree()`.

`update_file_tree()` is a no-op when no file tree is shown (`show_files` is
unset), so both call sites are safe in every configuration.

## Tests

Added two regression tests to `tests/functional_tests/test_data_catalog.py`
using the existing Textual-pilot harness (no new test infrastructure):

- `test_file_tree_refreshes_after_editor_save` — starts Harlequin with
  `show_files` pointing at a temp dir, saves a new `.sql` file through the
  editor's real `ctrl+s` flow, and asserts the new file appears as a node in
  the file tree.
- `test_file_tree_refreshes_after_export` — runs a query, exports the result
  to a `.csv` in the shown directory, and asserts the exported file appears in
  the file tree.

Both tests fail on `main` and pass with the fix.

## Verification

```
# Before the fix (src reverted, tests present):
$ uv run pytest \
    tests/functional_tests/test_data_catalog.py::test_file_tree_refreshes_after_editor_save \
    tests/functional_tests/test_data_catalog.py::test_file_tree_refreshes_after_export -q
FAILED ...::test_file_tree_refreshes_after_editor_save - AssertionError
FAILED ...::test_file_tree_refreshes_after_export - AssertionError
2 failed

# After the fix:
$ uv run pytest \
    tests/functional_tests/test_data_catalog.py::test_file_tree_refreshes_after_editor_save \
    tests/functional_tests/test_data_catalog.py::test_file_tree_refreshes_after_export -q
2 passed

# Full affected suites + linters/type-checker:
$ uv run pytest tests/functional_tests/test_data_catalog.py \
    tests/functional_tests/test_query_editor.py \
    tests/functional_tests/test_export.py -q
22 passed, 2 skipped   (67 snapshots passed)

$ uv run ruff check <changed files>            # All checks passed!
$ uv run ruff format --check <changed files>   # already formatted
$ uv run mypy <changed files>                  # Success: no issues found
```

## Compatibility

No API changes and no behavior change on the manual `ctrl+r` refresh. The new
calls only reload the file tree that Harlequin already renders; when no file
tree is shown they are no-ops. Fully backward compatible.
