### PR TITLE
(fix): adding guard for delete_word_left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Fixes a bug where keymap bindings targeting the inner text area (e.g., `delete_word_left`, `delete_line`) were never actually attached, since `CodeEditor` only announced itself, not its inner `TextAreaPlus`, as mounted; adds a default `ctrl+backspace` binding for `delete_word_left` to the `vscode` keymap.
+
 ## [2.5.2] - 2026-03-25
 
 ### Bug Fixes

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -72,6 +72,8 @@ class CodeEditor(TextEditor, inherit_bindings=False):
     def on_mount(self) -> None:
         self.post_message(EditorCollection.EditorSwitched(active_editor=self))
         self.post_message(WidgetMounted(widget=self))
+        if self.text_input is not None:
+            self.post_message(WidgetMounted(widget=self.text_input))
         self.has_shown_clipboard_error = False
         self.has_shown_tree_sitter_error = False
         self._semicolon_query = self.prepare_query(self.SEMICOLON_QUERY)

--- a/src/harlequin_vscode/__init__.py
+++ b/src/harlequin_vscode/__init__.py
@@ -64,6 +64,7 @@ VSCODE_EDITOR_BINDINGS = [
     HarlequinKeyBinding("backspace", "code_editor.delete_left"),
     HarlequinKeyBinding("delete", "code_editor.delete_right"),
     HarlequinKeyBinding("shift+delete", "code_editor.delete_line"),
+    HarlequinKeyBinding("ctrl+backspace", "code_editor.delete_word_left"),
 ]
 VSCODE_DATA_CATALOG_BINDINGS = [
     HarlequinKeyBinding("j", "data_catalog.previous_tab"),

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -29,6 +29,21 @@ async def test_query_formatting(
         assert app.editor.text == "select 1 from foo\n"
 
 
+@pytest.mark.asyncio
+async def test_delete_word_left(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        app.editor.text = "select foo"
+        await pilot.press("ctrl+end")
+        await pilot.press("ctrl+backspace")
+        assert app.editor.text == "select "
+
+
 @pytest.mark.flaky
 @pytest.mark.asyncio
 async def test_multiple_buffers(


### PR DESCRIPTION
Closes #710 (an existing open issue)

**What** are the key elements of this solution?
Adding a post for the `WidgetMounted(widget=self.text_input)` so that `bind_key` can match on the inner `TextAreaPlus` rather than just the `CodeEditor` wrapper.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?
I mirrored the existing pattern from the other composite widgets so `bind_keys` can match on the correct subwidget.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
