### PR TITLE
feat: open a table's data on double-click / submit in the Data Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Double-clicking (or pressing <kbd>enter</kbd> on) a table or view in the Data Catalog now opens its data directly, running `select * from <relation> limit 100` in a new buffer, instead of only inserting its name into the editor.
+
 ### Performance
 
 - Importing Harlequin's adapter API no longer imports the TUI ([#524](https://github.com/tconbeer/harlequin/issues/524)). `import harlequin_duckdb` drops from ~770ms to ~120ms, and `import harlequin_sqlite` from ~700ms to ~65ms, since neither pulls in Textual, questionary, prompt_toolkit or sqlfmt any more. Adapter authors feel this on every test run; the TUI's own start-up is unchanged.

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -397,12 +397,26 @@ class Harlequin(AppBase):
         self.update_schema_data()
 
     @on(HarlequinTree.NodeSubmitted)
-    def insert_node_into_editor(self, message: HarlequinTree.NodeSubmitted) -> None:
+    async def insert_node_into_editor(
+        self, message: HarlequinTree.NodeSubmitted
+    ) -> None:
         message.stop()
         if self.editor is None:
             # recycle message while editor loads
             callback = partial(self.post_message, message)
             self.set_timer(delay=0.1, callback=callback)
+            return
+        node_data = getattr(message.node, "data", None)
+        # A table/view double-click opens the data directly: put
+        # "select * from <relation> limit 100" in a new buffer and run it.
+        # Relations (tables, views, mat. views, ...) all subclass
+        # RelationCatalogItem; check by name to avoid an adapter import.
+        if node_data is not None and any(
+            cls.__name__ == "RelationCatalogItem" for cls in type(node_data).__mro__
+        ):
+            query = f"select *\nfrom {node_data.query_name}\nlimit 100"
+            await self.editor_collection.insert_buffer_with_text(query_text=query)
+            self.post_message(QuerySubmitted(queries=[query], limit=None))
             return
         self.editor.insert_text_at_selection(text=message.insert_name)
         self.editor.focus()

--- a/tests/functional_tests/test_open_table_on_submit.py
+++ b/tests/functional_tests/test_open_table_on_submit.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+import pytest
+
+from harlequin import Harlequin
+from harlequin.app import QuerySubmitted
+from harlequin.components.data_catalog.tree import HarlequinTree
+
+
+class _RelationCatalogItem:
+    """Stand-in whose class name matches the adapters' relation item, which is
+    how the app recognizes a table/view node (checked by name to avoid importing
+    an adapter). A column/schema node would NOT have this name."""
+
+    def __init__(self, query_name: str) -> None:
+        self.query_name = query_name
+
+
+# match the real class name the app looks for
+_RelationCatalogItem.__name__ = "RelationCatalogItem"
+
+
+class _FakeNode:
+    def __init__(self, data: object) -> None:
+        self.data = data
+
+
+@pytest.mark.asyncio
+async def test_submitting_a_table_runs_select_star(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """Double-clicking / submitting a relation node opens and runs
+    'select * from <relation> limit 100' instead of inserting the name."""
+    messages: list = []
+    async with app.run_test(message_hook=messages.append) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        node = _FakeNode(_RelationCatalogItem('"main"."foo"'))
+        app.post_message(HarlequinTree.NodeSubmitted(node=node))  # type: ignore[arg-type]
+        await pilot.pause()
+        await pilot.pause()
+
+        submitted = [m for m in messages if isinstance(m, QuerySubmitted)]
+        assert submitted, "submitting a table should run a query"
+        assert any(
+            "select *" in q.lower() and "limit 100" in q.lower()
+            for m in submitted
+            for q in m.queries
+        )
+
+
+@pytest.mark.asyncio
+async def test_submitting_a_non_relation_inserts_name(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """A non-relation node (e.g. a column) keeps the old behavior: its name is
+    inserted into the editor and no query is run."""
+    messages: list = []
+    async with app.run_test(message_hook=messages.append) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        app.editor.text = ""
+
+        class _Column:  # not named RelationCatalogItem
+            query_name = "some_col"
+
+        node = _FakeNode(_Column())
+        app.post_message(HarlequinTree.NodeSubmitted(node=node))  # type: ignore[arg-type]
+        await pilot.pause()
+        await pilot.pause()
+
+        # a non-relation node must NOT run a query (it inserts text instead)
+        assert not [m for m in messages if isinstance(m, QuerySubmitted)]
+        assert app.editor.text != ""  # something was inserted into the editor


### PR DESCRIPTION
Double-clicking (or pressing <kbd>enter</kbd> on) a relation node in the Data Catalog currently just inserts the relation name into the editor. This changes it to open the table's data directly: it puts `select * from <relation> limit 100` in a new buffer and runs it. Non-relation nodes (columns, schemas) keep the existing insert-name behavior.

Relations are recognized by checking the catalog item's class name against `RelationCatalogItem` (by name, to avoid importing any adapter), so it works for every adapter's tables/views/materialized views.

### Note on the behavior change
This changes the default meaning of a double-click, so it's the most opinionated of the set — I'm very happy to gate it behind a config option (e.g. `catalog_double_click = "insert" | "open"`) if you'd prefer to keep the current default. Flagging that explicitly for discussion.

### Tests
Adds functional tests covering both paths (relation submit runs `select *`; non-relation still inserts the name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZYuqGN3VBZYL84jz4rWYz
