### PR TITLE
feat: foreign-key navigation in the Results Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Cells in foreign-key columns of the Results Viewer carry a `↗`; clicking it opens the referenced row (`select * from <table> where <column> = <value>`) in a new buffer. An adapter reports its foreign keys through `HarlequinCursor.foreign_key_columns()`; harlequin-postgres does, and it works across joins.
+
 ## [2.12.1] - 2026-08-30
 
 ### Bug Fixes

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -63,6 +63,19 @@ class HarlequinCursor(ABC):
         """
         pass
 
+    def foreign_key_columns(self) -> dict[int, tuple[str, str]]:
+        """
+        Reports which result columns are single-column foreign keys, so that
+        Harlequin can open the row a cell references.
+
+        Returns: dict[int, tuple[str, str]], mapping the index of a result column
+            (in the order columns() returns them) to the qualified name of the
+            referenced table and the name of the referenced column, both quoted
+            as they would be written in a query. Adapters that cannot report
+            foreign keys return an empty dict.
+        """
+        return {}
+
 
 class HarlequinConnection(ABC):
     """

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -8,6 +8,7 @@ from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     Optional,
@@ -68,6 +69,7 @@ from harlequin.components.confirm_modal import ConfirmModal
 from harlequin.components.data_catalog import ContextMenu
 from harlequin.components.data_catalog.tree import HarlequinTree
 from harlequin.components.debug_info import AdapterDebugInfo, HarlequinDebugInfo
+from harlequin.components.results_viewer import ResultsTable
 from harlequin.config import (
     get_highest_priority_existing_config_file,
     load_config,
@@ -488,6 +490,34 @@ class Harlequin(AppBase):
             self.set_timer(delay=0.1, callback=callback)
             return
         await self.editor_collection.insert_buffer_with_text(query_text=message.text)
+
+    @on(ResultsTable.ForeignKeyFollowed)
+    async def follow_foreign_key(
+        self, message: ResultsTable.ForeignKeyFollowed
+    ) -> None:
+        message.stop()
+        if self.editor is None:
+            self._recycle_message(message)
+            return
+        query = (
+            f"select *\nfrom {message.ref_table}\n"
+            f"where {message.ref_col} = {self._sql_literal(message.value)}"
+        )
+        await self.editor_collection.insert_buffer_with_text(query_text=query)
+        self.post_message(
+            QuerySubmitted(queries=[query], limit=self.run_query_bar.limit_value)
+        )
+
+    @staticmethod
+    def _sql_literal(value: Any) -> str:
+        """Spells a cell's value as a SQL literal: numbers bare, the rest quoted."""
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        return "'" + str(value).replace("'", "''") + "'"
 
     @on(HarlequinDriver.ConfirmAndExecute)
     def driver_confirm_and_execute(
@@ -1185,6 +1215,8 @@ class Harlequin(AppBase):
                 results[id_] = fetch(
                     executed, limit=limit, display_limit=self.viewer_max_rows
                 )
+                if executed.cursor is not None:
+                    results[id_].foreign_keys = executed.cursor.foreign_key_columns()
             except BaseException as e:
                 errors.append((e, executed.statement.sql))
         # each ResultSet times its own fetch; the app reports the batch,

--- a/src/harlequin/app.tcss
+++ b/src/harlequin/app.tcss
@@ -375,6 +375,10 @@ ResultsTable > .datatable--hover {
     background: $boost;
 }
 
+ResultsTable > .results-table--foreign-key {
+    color: $secondary;
+}
+
 /* TEXT MODALS (CELL VIEW, ERROR) */
 TextModal {
     align: center middle;

--- a/src/harlequin/components/results_viewer.py
+++ b/src/harlequin/components/results_viewer.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+from rich.align import Align
+from rich.cells import cell_len
+from rich.console import RenderableType
 from rich.style import Style
 from rich.text import Text
+from textual.coordinate import Coordinate
 from textual.css.query import NoMatches
+from textual.message import Message
 from textual.widgets import (
     ContentSwitcher,
     TabbedContent,
@@ -22,6 +27,8 @@ if TYPE_CHECKING:
 
     from harlequin.query import ResultSet
 
+FOREIGN_KEY_GLYPH = "↗"
+
 
 class ResultsTable(DataTable, inherit_bindings=False):
     DEFAULT_CSS = """
@@ -30,8 +37,27 @@ class ResultsTable(DataTable, inherit_bindings=False):
             width: 100%;
         }
     """
+    COMPONENT_CLASSES: ClassVar[set[str]] = {
+        *DataTable.COMPONENT_CLASSES,
+        "results-table--foreign-key",
+    }
+
+    class ForeignKeyFollowed(Message):
+        """The glyph on a foreign-key cell was clicked."""
+
+        def __init__(self, ref_table: str, ref_col: str, value: Any) -> None:
+            super().__init__()
+            self.ref_table = ref_table
+            self.ref_col = ref_col
+            self.value = value
 
     def on_mount(self) -> None:
+        # every value in a foreign-key column is rendered with the glyph beside it
+        for column_index in self.foreign_keys:
+            if self.is_valid_column_index(column_index):
+                self.ordered_columns[column_index].content_width += cell_len(
+                    f"{FOREIGN_KEY_GLYPH} "
+                )
         self.post_message(WidgetMounted(widget=self))
 
     def __init__(
@@ -62,7 +88,9 @@ class ResultsTable(DataTable, inherit_bindings=False):
         render_markup: bool = True,
         fetched_row_count: int | None = None,
         fetch_truncated: bool = False,
+        foreign_keys: dict[int, tuple[str, str]] | None = None,
     ):
+        self.foreign_keys = foreign_keys or {}
         self.plain_column_labels: list[str] = (
             [str(label) for label in plain_column_labels]
             if plain_column_labels is not None
@@ -96,6 +124,62 @@ class ResultsTable(DataTable, inherit_bindings=False):
             disabled=disabled,
             null_rep=null_rep,
             render_markup=render_markup,
+        )
+        # the glyph is styled by its component class, not as a link
+        self.auto_links = False
+
+    def _get_cell_renderable(
+        self, row_index: int, column_index: int, max_width: int | None = None
+    ) -> RenderableType | Text:
+        if row_index < 0 or column_index not in self.foreign_keys:
+            return super()._get_cell_renderable(row_index, column_index, max_width)
+        marker_width = cell_len(f"{FOREIGN_KEY_GLYPH} ")
+        cell = super()._get_cell_renderable(
+            row_index,
+            column_index,
+            None if max_width is None else max_width - marker_width,
+        )
+        if self.get_cell_at(Coordinate(row_index, column_index)) is None:
+            return cell
+        # clicking the glyph runs the action; the value itself stays a plain cell
+        glyph_style = self.get_component_rich_style(
+            "results-table--foreign-key"
+        ) + Style.from_meta(
+            {"@click": f"follow_foreign_key({row_index}, {column_index})"}
+        )
+        if isinstance(cell, Align):
+            value = self._as_text(cell.renderable)
+            if value is None:
+                return cell
+            # a right-aligned value keeps the glyph on the column's edge
+            marked = (
+                Text.assemble(value, " ", (FOREIGN_KEY_GLYPH, glyph_style))
+                if cell.align == "right"
+                else Text.assemble((FOREIGN_KEY_GLYPH, glyph_style), " ", value)
+            )
+            return Align(marked, align=cell.align, style=cell.style)
+        value = self._as_text(cell)
+        if value is None:
+            return cell
+        return Text.assemble((FOREIGN_KEY_GLYPH, glyph_style), " ", value)
+
+    @staticmethod
+    def _as_text(renderable: RenderableType) -> Text | None:
+        """The formatter's str cells are console markup; anything else is left alone."""
+        if isinstance(renderable, Text):
+            return renderable
+        if isinstance(renderable, str):
+            return Text.from_markup(renderable)
+        return None
+
+    def action_follow_foreign_key(self, row_index: int, column_index: int) -> None:
+        ref_table, ref_col = self.foreign_keys[column_index]
+        self.post_message(
+            self.ForeignKeyFollowed(
+                ref_table=ref_table,
+                ref_col=ref_col,
+                value=self.get_cell_at(Coordinate(row_index, column_index)),
+            )
         )
 
     def action_view_cell(self) -> None:
@@ -162,6 +246,7 @@ class ResultsViewer(TabbedContent, can_focus=True):
             backend=result.backend,
             fetched_row_count=result.fetched_row_count,
             fetch_truncated=result.truncated,
+            foreign_keys=result.foreign_keys,
             cursor_type="range",
             max_column_content_width=self.max_col_width,
             null_rep="[dim]∅ null[/]",

--- a/src/harlequin/query.py
+++ b/src/harlequin/query.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterator, Literal, Sequence
 
 import pyarrow as pa
@@ -111,6 +111,11 @@ class ResultSet:
 
     elapsed: float
     """Seconds spent fetching, not including execution."""
+
+    foreign_keys: dict[int, tuple[str, str]] = field(default_factory=dict)
+    """Result-column index -> (referenced table, referenced column), for the
+    columns the cursor reports as foreign keys; see
+    `HarlequinCursor.foreign_key_columns()`."""
 
     @property
     def row_count(self) -> int:

--- a/tests/functional_tests/test_foreign_key_navigation.py
+++ b/tests/functional_tests/test_foreign_key_navigation.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+import pytest
+from rich.align import Align
+from rich.cells import cell_len
+from rich.text import Text
+from textual.coordinate import Coordinate
+from textual.pilot import Pilot
+
+from harlequin import Harlequin
+from harlequin.components.results_viewer import FOREIGN_KEY_GLYPH
+
+FOREIGN_KEYS = {1: ('"main"."other"', '"id"'), 2: ('"main"."other"', '"name"')}
+
+
+@pytest.fixture
+def duckdb_reports_foreign_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DuckDB has no foreign-key metadata; pretend two result columns are keys."""
+    monkeypatch.setattr(
+        "harlequin_duckdb.adapter.DuckDbCursor.foreign_key_columns",
+        lambda self: FOREIGN_KEYS,
+    )
+
+
+async def run_query(
+    app: Harlequin,
+    pilot: Pilot[None],
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    query: str,
+) -> None:
+    assert app.editor is not None
+    app.editor.text = query
+    await pilot.press("ctrl+j")
+    await wait_for_workers(app)
+    await pilot.pause()
+    await wait_for_workers(app)
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_foreign_key_navigation(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    duckdb_reports_foreign_keys: None,
+) -> None:
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        await run_query(
+            app,
+            pilot,
+            wait_for_workers,
+            "create table other as select 2 as id, 'x' as name",
+        )
+        await run_query(
+            app,
+            pilot,
+            wait_for_workers,
+            "select 1 as id, 2 as other_id, 'x' as other_name "
+            "union all select 3, null, null",
+        )
+        table = app.results_viewer.get_visible_table()
+        assert table is not None
+        assert table.foreign_keys == FOREIGN_KEYS
+
+        # a right-aligned number carries the glyph after it, text in front of it
+        number = table._get_cell_renderable(0, 1)
+        assert isinstance(number, Align)
+        assert isinstance(number.renderable, Text)
+        assert number.renderable.plain == f"2 {FOREIGN_KEY_GLYPH}"
+        text = table._get_cell_renderable(0, 2)
+        assert isinstance(text, Text)
+        assert text.plain == f"{FOREIGN_KEY_GLYPH} x"
+        # nulls and non-key columns are left alone, and the raw value is untouched
+        null_cell = table._get_cell_renderable(1, 1)
+        assert isinstance(null_cell, Align)
+        assert FOREIGN_KEY_GLYPH not in str(null_cell.renderable)
+        plain_cell = table._get_cell_renderable(0, 0)
+        assert isinstance(plain_cell, Align)
+        assert FOREIGN_KEY_GLYPH not in str(plain_cell.renderable)
+        assert table.get_cell_at(Coordinate(0, 1)) == 2
+        # the key column grew to fit the glyph
+        label_width = cell_len(table.ordered_columns[1].label.plain)
+        marker_width = cell_len(f"{FOREIGN_KEY_GLYPH} ")
+        assert table.ordered_columns[1].content_width == label_width + marker_width
+
+        # clicking the glyph opens the referenced row in a new buffer and runs it
+        cell = table._get_cell_region(Coordinate(0, 1))
+        await pilot.click(table, offset=(cell.x + cell.width - 2, cell.y))
+        await pilot.pause()
+        assert app.editor_collection.tab_count == 2
+        assert app.editor.text == 'select *\nfrom "main"."other"\nwhere "id" = 2'
+        await wait_for_workers(app)
+        await pilot.pause()
+        await wait_for_workers(app)
+        await pilot.pause()
+        followed = app.results_viewer.get_visible_table()
+        assert followed is not None
+        assert followed.row_count == 1
+        assert followed.get_cell_at(Coordinate(0, 0)) == 2

--- a/tests/unit_tests/test_sql_literal.py
+++ b/tests/unit_tests/test_sql_literal.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from harlequin.app import Harlequin
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, "null"),
+        (True, "true"),
+        (False, "false"),
+        (42, "42"),
+        (0, "0"),
+        (-7, "-7"),
+        (3.14, "3.14"),
+        (Decimal("10"), "'10'"),  # not int/float -> quoted
+        ("abc", "'abc'"),
+        ("it's", "'it''s'"),  # single quotes are doubled/escaped
+        ("a-uuid-like-string", "'a-uuid-like-string'"),
+    ],
+)
+def test_sql_literal_renders_where_clause_values(value: object, expected: str) -> None:
+    """The foreign-key navigation query builds a WHERE clause from a cell value;
+    numbers are bare, everything else is single-quoted with quotes escaped."""
+    assert Harlequin._sql_literal(value) == expected


### PR DESCRIPTION
No linked issue — built for my own use against Postgres, then generalised. Happy to move the "do you want this" conversation to a Discussion if you'd rather.

**What** are the key elements of this solution?

Cells in a foreign-key column carry a `↗`; clicking the glyph opens the referenced row — `select * from <table> where <column> = <value>` — in a new buffer and runs it under the Run Query Bar's limit. Clicking the value itself just moves the cursor, as before.

- `HarlequinCursor.foreign_key_columns()` is a new optional adapter method, default `{}`, in the same shape as `cancel()` / `search_catalog()`: result-column index → `(referenced table, referenced column)`, both quoted. tconbeer/harlequin-postgres#56 implements it from libpq's per-column source metadata, so it works across joins. DuckDB and SQLite report nothing and show nothing.
- The map is read in the fetch worker and travels on `ResultSet.foreign_keys` to `ResultsTable`, alongside the row-count fields.
- The glyph is a Textual `@click` action link (`follow_foreign_key(row, col)`) inside the cell, so Textual's action broker routes the click to `ResultsTable` — no click handler, no timer. A right-aligned value keeps the glyph on the column's right edge, a left-aligned one on its left, so the click target lines up down a column. `auto_links` is off on the table and the glyph is styled by a `results-table--foreign-key` component class.
- The foreign-key column grows by the glyph's width once at mount, so the widest value still fits; a NULL cell gets no glyph (nothing to follow).

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

- *Glyph click, not cell click.* An earlier version navigated on any single click of the cell, debounced 0.35 s so a double-click could win. That hijacked ordinary cell selection and needed a timer; a link inside the cell needs neither.
- *An ABC method rather than `getattr` duck-typing* keeps the adapter contract explicit and costs adapters nothing.
- *`_get_cell_renderable` override.* The glyph is added around fastdatatable's own formatted renderable (`Align` for numbers, `Text`/markup for strings) rather than by reformatting the value, so numbers, nulls and multi-line markers render exactly as they do today. If you'd rather have a decoration hook in textual-fastdatatable, I'm glad to do that first.
- Overlaps #987 in two spots (`_sql_literal` and its unit test); whichever merges second rebases trivially.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the Results Viewer docs mention the `↗` on foreign-key cells and that clicking it opens the referenced row, and the adapter-author docs gain `HarlequinCursor.foreign_key_columns()`. Glad to open it if you want the feature.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`test_foreign_key_navigation.py` drives the whole flow through DuckDB with `foreign_key_columns` monkeypatched: glyph placement for a number and a string, no glyph on a NULL or a non-key column, the raw value untouched, the widened column, and a click on the glyph opening and running the referenced row. `test_sql_literal.py` covers the literal quoting.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. (No issue to reference; see above.)
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
