### PR TITLE
fix(deps): upgrade click to 8.3.3 [security]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "textual-textarea==0.17.2",
 
     # click
-    "click==8.1.8",
+    "click==8.3.3",
     "rich-click==1.8.5",
 
     # other deps

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -212,7 +212,7 @@ def test_bad_adapter_opt(
     res = runner.invoke(build_cli(), args=harlequin_args)
     assert res.exit_code == 2
     key_words = ["Error", "Invalid", "-a", "-adapter", "duckdb"]
-    assert all([w in res.stdout for w in key_words])
+    assert all([w in res.stderr for w in key_words])
 
 
 @pytest.mark.parametrize(
@@ -368,4 +368,4 @@ def test_sqlite_extension_not_supported(
         build_cli(), args=f"-a sqlite --extension {extension_path.as_posix()}"
     )
     assert res.exit_code == 2
-    assert "No such option" in res.stdout
+    assert "No such option" in res.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -613,14 +613,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -787,7 +787,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1283,7 +1283,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 's3'", specifier = "==1.34.22" },
-    { name = "click", specifier = "==8.1.8" },
+    { name = "click", specifier = "==8.3.3" },
     { name = "duckdb", marker = "python_full_version < '3.14'", specifier = ">=0.8.0" },
     { name = "duckdb", marker = "python_full_version >= '3.14'", specifier = ">=1.4.2" },
     { name = "harlequin-adbc", marker = "extra == 'adbc'" },


### PR DESCRIPTION
Supersedes #998. Same click bump, plus the test changes it needs — Renovate can't modify the tests itself, so its PR was red on all 15 `Test` jobs.

`click` is a **direct, shipped dependency** (`project.dependencies`), so unlike the transitive dev-only advisories in #996, this one reaches PyPI users. Renovate surfaced it via the OSV feed; GitHub's advisory database has no click alert for this repo.

### Why the tests broke

click 8.2 stopped mixing stderr into stdout in `CliRunner` (the `mix_stderr` parameter was removed). Two tests assert on click's own `UsageError` output, which now goes to stderr, so `res.stdout` was empty:

- `test_bad_adapter_opt` — `assert all([w in res.stdout for w in key_words])`
- `test_sqlite_extension_not_supported` — `assert "No such option" in res.stdout`

### Do those messages belong on stderr?

Yes — verified against the real CLI, not just `CliRunner`:

```
$ harlequin -a bar                 # exit 2
  stdout: (empty)
  stderr: Invalid value for '-a' ...
```

They're diagnostics on an exit-code-2 path, so stderr is correct, and click 8.2's change fixed a long-standing wart. The tests now assert `res.stderr`, which pins that behavior. I deliberately did **not** use `res.output` — it's the combined stream, so it would pass whichever way the message was routed and assert nothing about correctness.

### One thing left alone

The other two assertions (`test_bad_profile_opt`, `test_bad_config_exits`) never broke and stay on `res.stdout`. Those messages come from harlequin's own `pretty_print_error`, which calls `rich.print` and writes to **stdout**:

```
$ harlequin --profile foo          # exit 2
  stdout: ╭─ Harlequin couldn't load your profile. ─╮
  stderr: (empty)
```

Arguably those should go to stderr too — they're errors on a failing exit path, and printing them to stdout means anyone piping harlequin's output gets error panels mixed into their data. But that's a user-visible CLI behavior change, not something to smuggle into a security bump, so I left it and the tests now document the current split honestly. Happy to do it as a follow-up.

Locally: `ruff format`, `ruff check`, `mypy` (88 files) clean; 185 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)