### PR TITLE
ci: give Test Build jobs distinct check names

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,7 +16,7 @@ concurrency:
   
 jobs:
   test-build:
-    name: ${{ matrix.os }} - ${{ matrix.py }}
+    name: build - ${{ matrix.os }} - ${{ matrix.py }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
`test.yml` and `test-build.yml` both named their matrix jobs `${{ matrix.os }} - ${{ matrix.py }}`, so two different workflows published checks under identical names.

### Why it matters

Branch protection's required contexts are plain strings — `ubuntu-latest - 3.12`, `MacOs-latest - 3.11`, `Windows-latest - 3.10`, `ubuntu-latest - 3.13`, `ubuntu-latest - 3.10`. Every one of those is emitted by *both* workflows, so a required context can be satisfied by whichever run happens to report, and tooling can't attribute a result to a workflow.

This isn't theoretical. On #998, the `Test` workflow failed all 15 jobs while `Test Build` passed all 15 — and because the names collide, `gh pr checks` showed a mix of pass and fail under the same names. I misread that PR's state twice today before grouping by workflow run instead.

### The change

One line: prefix the build matrix with `build - `.

```diff
   test-build:
-    name: ${{ matrix.os }} - ${{ matrix.py }}
+    name: build - ${{ matrix.os }} - ${{ matrix.py }}
```

### No branch protection change needed

The required contexts keep their existing names and now resolve unambiguously to `test.yml`, which is the workflow that actually runs the test suite. `Static Analysis` was already unique. Nothing to update on the settings side — and after this lands, a red `Test` run can no longer be masked by a green build check of the same name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)