### PR TITLE
fix: print error panels to stderr instead of stdout

### DIFF
--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -49,9 +49,11 @@ class HarlequinLocaleError(HarlequinError):
 
 
 def pretty_print_error(error: HarlequinError) -> None:
-    from rich import print as rich_print
+    from rich.console import Console
 
-    rich_print(pretty_error_message(error))
+    # errors are diagnostics on a failing exit path, so they belong on stderr;
+    # rich.print would put them on stdout and contaminate piped output.
+    Console(stderr=True).print(pretty_error_message(error))
 
 
 def pretty_error_message(error: HarlequinError) -> Panel:

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -274,7 +274,7 @@ def test_bad_profile_opt(
     res = runner.invoke(build_cli(), args=harlequin_args)
     assert res.exit_code == 2
     key_words = ["profile", "config"]
-    assert all([w in res.stdout for w in key_words])
+    assert all([w in res.stderr for w in key_words])
 
 
 @pytest.mark.parametrize("filename", ["good_config.toml", "pyproject.toml"])
@@ -331,7 +331,7 @@ def test_bad_config_exits(
     res = runner.invoke(build_cli(), args=f"--config-path {config_path.as_posix()}")
     assert res.exit_code == 2
     key_words = ["default_profile", "foo"]
-    assert all([w in res.stdout for w in key_words])
+    assert all([w in res.stderr for w in key_words])
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Follow-up to #1000, which surfaced this. Now that click's own usage errors go to stderr, harlequin's error panels going to stdout is an inconsistency worth closing.

### The problem

`pretty_print_error` used `rich.print`, which writes to **stdout**. These panels are printed on failing exit paths (`exit_code == 2`), so anyone piping harlequin's output got error panels mixed into their data:

```
$ harlequin --profile foo          # before, exit 2
  stdout: ╭─ Harlequin couldn't load your profile. ─╮
  stderr: (empty)
```

### After

```
$ harlequin --profile foo          # after, exit 2
  stdout: (empty)
  stderr: ╭─ Harlequin couldn't load your profile. ─╮
```

Verified against the real CLI with redirected streams, not just `CliRunner`.

The two CLI tests that assert on these messages move from `res.stdout` to `res.stderr`. Together with #1000, all four error assertions in `test_cli.py` now assert stderr, which is consistent and pins the behavior — nothing is asserted through the combined `res.output` stream.

### Depends on #1000

This can't land without the click 8.3.3 bump. On click 8.1.8 `CliRunner` mixes stderr into stdout, so `res.stderr` isn't separately captured and the updated assertions wouldn't work. Rebased onto main now that #1000 is merged.

### Deliberately not included

`pretty_print_warning` (used by `windows_timezone.py` and `locale_manager.py`) still writes to stdout. Warnings are arguably diagnostics too and could follow, but that's a separate behavior change and I kept this PR to the errors. Say the word and I'll do it.

Locally: `ruff format`, `ruff check`, `mypy` (88 files) clean; 185 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)