### PR TITLE
refactor: use Click.chain to detect double-clicks in the Data Catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Refactoring
+
+- The Data Catalog now uses Textual's `Click.chain` to detect double-clicks, instead of tracking the previously-clicked line with a timer ([#708](https://github.com/tconbeer/harlequin/issues/708)).
+
 ## [2.6.0] - 2026-08-03
 
 ### Performance

--- a/src/harlequin/components/data_catalog/tree.py
+++ b/src/harlequin/components/data_catalog/tree.py
@@ -19,7 +19,6 @@ class HarlequinTree(Tree[TTreeNode], inherit_bindings=False):
     COMPONENT_CLASSES: ClassVar[set[str]] = {
         "harlequin-tree--type-label",
     }
-    double_click: int | None = None
 
     class CatalogError(Message):
         def __init__(self, catalog_type: str, error: BaseException) -> None:
@@ -76,30 +75,16 @@ class HarlequinTree(Tree[TTreeNode], inherit_bindings=False):
         click_line: Union[int, None] = meta.get("line", None)
         if event.button == 1:  # left button click
             self.post_message(self.HideContextMenu())
-            if (
-                self.double_click is not None
-                and click_line is not None
-                and self.double_click == click_line
-            ):
+            if event.chain == 2 and click_line is not None:  # double click
                 event.prevent_default()
                 node = self.get_node_at_line(click_line)
                 if node is not None:
                     self.post_message(self.NodeSubmitted(node=node))
                     node.expand()
-            else:
-                self.double_click = click_line
-                self.set_timer(
-                    delay=0.5,
-                    callback=self._clear_double_click,
-                    name="double_click_timer",
-                )
         elif event.button == 3 and click_line is not None:  # right click
             node = self.get_node_at_line(click_line)
             if node is not None and isinstance(node.data, CatalogItem):
                 self.post_message(self.ShowContextMenu(node=node))
-
-    def _clear_double_click(self) -> None:
-        self.double_click = None
 
     def action_submit(self) -> None:
         if self.cursor_node is not None:

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -133,6 +133,35 @@ async def test_data_catalog(
 
 
 @pytest.mark.asyncio
+async def test_double_click_inserts_node_into_editor(
+    app_multi_duck: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    app = app_multi_duck
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        catalog = app.data_catalog
+
+        dbs = catalog.database_tree.root.children
+        assert isinstance(dbs[0].data, InteractiveCatalogItem)
+        while not dbs[0].data.loaded:
+            await pilot.pause(0.1)
+
+        # a single click on "small" selects and expands it, but inserts nothing
+        await pilot.click(catalog.__class__, offset=Offset(x=6, y=1))
+        await pilot.pause()
+        assert app.editor.text == ""
+
+        # a double click inserts the node's query name into the editor
+        await pilot.double_click(catalog.__class__, offset=Offset(x=6, y=1))
+        await pilot.pause()
+        assert app.editor.text == '"small"'
+        assert dbs[0].is_expanded is True
+
+
+@pytest.mark.asyncio
 async def test_file_tree(
     duckdb_adapter: Type[DuckDbAdapter],
     data_dir: Path,


### PR DESCRIPTION
Closes #708

**What** are the key elements of this solution?

- `HarlequinTree.on_click` now branches on Textual's `Click.chain` instead of storing the previously-clicked line in `HarlequinTree.double_click` and clearing it with a 0.5s timer. The `double_click` class attribute and `_clear_double_click` are gone.
- Adds `test_double_click_inserts_node_into_editor`, which double-clicks a database node and asserts its query name lands in the editor. `pilot.double_click` makes this easy to drive; the old timer-based implementation was awkward to test.
- This branch also carries a small chore commit that gitignores `CLAUDE.md` and `.claude/`. Happy to split it out if you'd rather keep this PR to one thing.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Textual already tracks click chains on the App (`CLICK_CHAIN_TIME_THRESHOLD`, 0.5s — the same window we were implementing by hand), so the widget just reads `event.chain`.

One intentional behavior change: Textual increments the chain only when clicks land on the *same screen cell*, where the old code accepted any click on the same *row*. That matches how double-clicks work elsewhere, but it is slightly stricter than what shipped before.

Triple-clicks are now a no-op rather than a second submission: `chain == 2` fires once, and the third click falls through to the tree's default click handling.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)