### PR TITLE
perf: load the Data Catalog by viewport instead of eagerly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.7.0] - 2026-08-05
+### Features
+
+- The Data Catalog no longer appears to hang while loading large databases ([#838](https://github.com/tconbeer/harlequin/issues/838)). It now builds tree nodes only for objects you can actually see, bounds its background loading to the visible part of the tree instead of eagerly walking every schema, and shows a `loading…` placeholder under a node while its children are fetched.
+
+### Bug Fixes
+
+- A Data Catalog node that turns out to have no children no longer keeps a phantom expand arrow.
+- Expanding a node that was already queued for background loading no longer loads it twice, which could collapse a subtree you had opened.
 
 ### Dependencies
 

--- a/scripts/catalog_lag.py
+++ b/scripts/catalog_lag.py
@@ -1,0 +1,77 @@
+"""Run Harlequin against a real database and report event-loop lag on exit.
+
+Event-loop lag is what "the catalog is hanging" actually means: every millisecond
+the loop is blocked is a millisecond of unrendered keystrokes and scrolling.
+
+Usage:
+    uv run python scripts/catalog_lag.py --adapter postgres "postgresql://..."
+    uv run python scripts/catalog_lag.py --profile my-big-mysql
+
+Browse the catalog as you normally would -- expand big schemas, scroll fast --
+then quit with ctrl+q. Anything over ~100ms at p95 is visible jank.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+from harlequin.app import Harlequin
+
+SAMPLE_INTERVAL = 0.05
+
+
+class Heartbeat:
+    """Sample how late a fixed-interval timer actually fires."""
+
+    def __init__(self) -> None:
+        self.lags: list[float] = []
+
+    async def run(self) -> None:
+        while True:
+            start = time.monotonic()
+            await asyncio.sleep(SAMPLE_INTERVAL)
+            self.lags.append(time.monotonic() - start - SAMPLE_INTERVAL)
+
+    def report(self) -> str:
+        if not self.lags:
+            return "no samples collected"
+        lags = sorted(self.lags)
+
+        def pct(p: float) -> float:
+            return lags[min(int(len(lags) * p), len(lags) - 1)] * 1000
+
+        over_100ms = sum(1 for lag in lags if lag > 0.1)
+        return (
+            f"\nevent-loop lag over {len(lags)} samples "
+            f"({len(lags) * SAMPLE_INTERVAL:.0f}s of use):\n"
+            f"  p50 {pct(0.50):6.1f} ms\n"
+            f"  p95 {pct(0.95):6.1f} ms\n"
+            f"  p99 {pct(0.99):6.1f} ms\n"
+            f"  max {lags[-1] * 1000:6.1f} ms\n"
+            f"  {over_100ms} samples ({over_100ms / len(lags):.1%}) over 100ms\n"
+        )
+
+
+def main() -> None:
+    heartbeat = Heartbeat()
+    original_on_mount = Harlequin.on_mount
+
+    async def on_mount(self: Harlequin) -> None:
+        asyncio.create_task(heartbeat.run())
+        await original_on_mount(self)
+
+    Harlequin.on_mount = on_mount  # type: ignore[method-assign]
+
+    from harlequin.cli import harlequin
+
+    try:
+        # `harlequin` is a click command; the decorator hides `.main` from mypy
+        harlequin.main(sys.argv[1:], standalone_mode=False)  # type: ignore[attr-defined]
+    finally:
+        print(heartbeat.report(), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -231,6 +231,7 @@ class Harlequin(AppBase):
         self.connection: HarlequinConnection | None = None
         self.harlequin_driver = HarlequinDriver(app=self)
         self._completer_merge_timer: Timer | None = None
+        self._pending_completer_items: list[tuple[CatalogItem, list[CatalogItem]]] = []
 
         if keymap_names is None:
             keymap_names = ("vscode",)
@@ -1161,31 +1162,45 @@ class Harlequin(AppBase):
         )
 
     def extend_completers(self, parent: CatalogItem, items: list[CatalogItem]) -> None:
-        if (
-            self.editor_collection.word_completer is not None
-            and self.editor_collection.member_completer is not None
-        ):
-            # appending to the catalog is cheap, but merging the full
-            # completion list is O(n log n), so when the Data Catalog's lazy
-            # loader delivers a stream of items (one message per node), we
-            # defer the merge and run it at most once per second.
-            self.editor_collection.word_completer.extend_catalog(
-                parent=parent, items=items, defer_merge=True
-            )
-            self.editor_collection.member_completer.extend_catalog(
-                parent=parent, items=items, defer_merge=True
-            )
-            if self._completer_merge_timer is None:
-                self._completer_merge_timer = self.set_timer(
-                    1.0, self._merge_completers
-                )
+        # Building completions for a node, and then merging the full completion
+        # list (O(n log n) over the whole catalog), are both too expensive for the
+        # event loop: a schema can hold thousands of relations, and the Data
+        # Catalog's lazy loader delivers one message per node. Batch the arrivals
+        # and do the work in a thread, at most once per second.
+        self._pending_completer_items.append((parent, items))
+        if self._completer_merge_timer is None:
+            self._completer_merge_timer = self.set_timer(1.0, self._merge_completers)
 
     def _merge_completers(self) -> None:
         self._completer_merge_timer = None
-        if self.editor_collection.word_completer is not None:
-            self.editor_collection.word_completer.merge()
-        if self.editor_collection.member_completer is not None:
-            self.editor_collection.member_completer.merge()
+        if self._pending_completer_items:
+            batch = self._pending_completer_items
+            self._pending_completer_items = []
+            self._extend_and_merge_completers(batch)
+
+    @work(
+        thread=True,
+        exclusive=True,
+        exit_on_error=False,
+        group="completer_mergers",
+        description="merging catalog completions",
+    )
+    def _extend_and_merge_completers(
+        self, batch: list[tuple[CatalogItem, list[CatalogItem]]]
+    ) -> None:
+        word_completer = self.editor_collection.word_completer
+        member_completer = self.editor_collection.member_completer
+        if word_completer is None or member_completer is None:
+            return
+        for parent, items in batch:
+            word_completer.extend_catalog(parent=parent, items=items, defer_merge=True)
+            member_completer.extend_catalog(
+                parent=parent, items=items, defer_merge=True
+            )
+        # merge() swaps in a freshly built list, so a completer call on the main
+        # thread reads either the old list or the new one, never a partial one.
+        word_completer.merge()
+        member_completer.merge()
 
     def update_completers(self, catalog: Catalog) -> None:
         if self.connection is None:

--- a/src/harlequin/autocomplete/completers.py
+++ b/src/harlequin/autocomplete/completers.py
@@ -109,7 +109,13 @@ class WordCompleter:
     def _merge_completions(
         *completion_lists: list[HarlequinCompletion],
     ) -> list[HarlequinCompletion]:
-        return [c for c in sorted(itertools.chain(*completion_lists))]
+        # sorting on an explicit key is ~5x faster than on HarlequinCompletion's
+        # rich comparisons (which build two tuples per comparison), and this runs
+        # over the whole catalog every time the lazy loader delivers more of it.
+        return sorted(
+            itertools.chain(*completion_lists),
+            key=lambda c: (c.priority, c.label),
+        )
 
     @staticmethod
     def _dedupe_labels(

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from asyncio import PriorityQueue
-from contextlib import suppress
 from typing import TYPE_CHECKING, Generator, Iterable, TypeVar
 
 from rich.style import Style
 from rich.text import Text, TextType
-from textual import work
+from textual import events, work
 from textual.await_complete import AwaitComplete
 from textual.reactive import var
+from textual.timer import Timer
 from textual.widgets._tree import Tree, TreeNode
 from textual.worker import WorkerCancelled, WorkerFailed, get_current_worker
 
@@ -24,6 +25,29 @@ from harlequin.messages import WidgetMounted
 if TYPE_CHECKING:
     from typing_extensions import Self
 
+DEMAND_PRIORITY = 0
+"""Priority for a node the user expanded; jumps ahead of all speculative work."""
+
+PREFETCH_PRIORITY = 100
+"""Priority for a node we load speculatively, because it's on (or near) screen."""
+
+PREFETCH_MARGIN = 20
+"""Lines above and below the viewport to warm, so a short scroll finds data ready."""
+
+POPULATE_CHUNK_SIZE = 250
+"""TreeNodes to add per event-loop slice, so a wide node can't stall rendering."""
+
+PREFETCH_DEBOUNCE = 0.1
+"""Seconds to coalesce viewport scans; scrolling fires them in bursts."""
+
+LOADING_ITEM = CatalogItem(
+    qualified_identifier="__loading__",
+    query_name="",
+    label="",
+    type_label="",
+)
+"""Sentinel data for the placeholder shown under a node while its children load."""
+
 
 class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
     catalog: var[Catalog | None] = var["Catalog | None"](
@@ -38,14 +62,20 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         disabled: bool = False,
     ) -> None:
         self._load_queue: PriorityQueue[
-            tuple[int, str, int, TreeNode[InteractiveCatalogItem]]
+            tuple[int, int, TreeNode[InteractiveCatalogItem]]
         ] = PriorityQueue()
         """
-        _load_queue is a priority queue, ordered by a priority int,
-        then the string label of the node, then the id of the node,
-        which should prevent any comparisons between TreeNodes, which
-        do not implement cmp operators.
+        _load_queue is a priority queue, ordered by a priority int, then by an
+        ever-increasing sequence number, which makes the queue FIFO within a
+        priority and ensures the TreeNodes are never compared (they do not
+        implement cmp operators).
         """
+        self._queue_seq = 0
+        self._queued_priority: dict[int, int] = {}
+        """The priority each pending node was queued at, keyed by id(node)."""
+        self._loading: set[int] = set()
+        """ids of nodes whose fetch_children() call is in flight."""
+        self._prefetch_timer: Timer | None = None
         super().__init__(
             label="Root",
             data=CatalogItem(
@@ -66,6 +96,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         self.show_root = False
         self.guide_depth = 3
         self.root.expand()
+        self._schedule_prefetch_scan()
         self.post_message(WidgetMounted(widget=self))
 
     def _build_item_label(self, label: str, type_label: str) -> Text:
@@ -82,27 +113,79 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         assert isinstance(self.root.data, CatalogItem)
         self.root.data.children = catalog.items if catalog is not None else []
         await self.reload()
-        # add the root's children to the prefetch queue
-        for child in self.root.children:
-            if isinstance(child.data, InteractiveCatalogItem) and not child.data.loaded:
-                self._add_to_load_queue(child)  # type: ignore[arg-type]
+        self._schedule_prefetch_scan()
         self.loading = False
 
     def _add_to_load_queue(
-        self, node: TreeNode[InteractiveCatalogItem], priority: int = 100
+        self, node: TreeNode[InteractiveCatalogItem], priority: int = PREFETCH_PRIORITY
     ) -> None:
         """Add the given node to the load priority queue.
+
+        A node already queued at an equal or better priority is left alone; one
+        queued at a worse priority is re-queued, and the stale entry is dropped
+        when it surfaces. This keeps a node the user expands from being fetched
+        (and re-rendered) twice.
 
         Args:
             node: The node to add to the load queue.
             priority: An order for this node to be loaded; lowest first.
         """
-        assert node.data is not None
-        if not node.data.loaded:
-            with suppress(TypeError):
-                # typeError will be raised if this node already exists in the queue,
-                # since TreeNodes do not implement cmp operators.
-                self._load_queue.put_nowait((priority, str(node.label), id(node), node))
+        if node.data is None or node.data.loaded:
+            return
+        key = id(node)
+        if key in self._loading:
+            return
+        queued_at = self._queued_priority.get(key)
+        if queued_at is not None and queued_at <= priority:
+            return
+        self._queued_priority[key] = priority
+        self._queue_seq += 1
+        self._load_queue.put_nowait((priority, self._queue_seq, node))
+
+    def _prefetch_window(self) -> tuple[int, int]:
+        """The inclusive range of tree lines worth loading speculatively."""
+        top = int(self.scroll_offset.y)
+        return max(0, top - PREFETCH_MARGIN), top + self.size.height + PREFETCH_MARGIN
+
+    def _in_prefetch_window(self, node: TreeNode[CatalogItem]) -> bool:
+        line = node.line
+        if line < 0:  # node is not displayed (an ancestor is collapsed)
+            return False
+        first, last = self._prefetch_window()
+        return first <= line <= last
+
+    def _schedule_prefetch_scan(self) -> None:
+        """Queue a viewport scan, coalescing the bursts that scrolling produces."""
+        if self._prefetch_timer is not None:
+            self._prefetch_timer.stop()
+        self._prefetch_timer = self.set_timer(
+            PREFETCH_DEBOUNCE, self._queue_nodes_in_view
+        )
+
+    def _queue_nodes_in_view(self) -> None:
+        """Speculatively load the unloaded nodes on (or just off) screen.
+
+        Bounding prefetch by the viewport rather than by the tree's shape is what
+        keeps this affordable on a large remote database: a catalog that fits on
+        screen is loaded in full, exactly as before, while a catalog with
+        thousands of objects costs a screenful of fetches no matter how big it
+        gets.
+        """
+        self._prefetch_timer = None
+        first, last = self._prefetch_window()
+        lines = self._tree_lines
+        for line_no in range(first, min(last + 1, len(lines))):
+            node = lines[line_no].node
+            if isinstance(node.data, InteractiveCatalogItem) and not node.data.loaded:
+                self._add_to_load_queue(node)  # type: ignore[arg-type]
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        super().watch_scroll_y(old_value, new_value)
+        self._schedule_prefetch_scan()
+
+    def _on_resize(self, event: events.Resize) -> None:
+        super()._on_resize(event)
+        self._schedule_prefetch_scan()
 
     def reload(self) -> AwaitComplete:
         """Reload the `DirectoryTree` contents.
@@ -112,6 +195,8 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         """
         # Orphan the old queue...
         self._load_queue = PriorityQueue()
+        self._queued_priority.clear()
+        self._loading.clear()
         # ... reset the root node ...
         processed = self.reload_node(self.root)
         # ... and replace the old loader with a new one.
@@ -201,7 +286,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                         content = await self._load_children(reopening).wait()
                     except (WorkerCancelled, WorkerFailed):
                         continue
-                    self._populate_node(reopening, content)
+                    await self._populate_node(reopening, content)
                     to_reopen.extend(reopening.children)
                     reopening.expand()
 
@@ -255,22 +340,53 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
 
     TCatalogItem_co = TypeVar("TCatalogItem_co", bound=CatalogItem, covariant=True)
 
-    def _populate_node(
+    async def _populate_node(
         self, node: TreeNode[TCatalogItem_co], content: Iterable[TCatalogItem_co]
     ) -> None:
-        """Populate the given tree node with the given directory content.
+        """Populate the given tree node with the given catalog items.
+
+        Adding TreeNodes is main-thread work, and a schema can hold thousands of
+        relations, so the children are added a chunk at a time and the event loop
+        is released in between. The lock is taken per chunk rather than for the
+        whole run so the tree can rebuild and render the rows added so far.
 
         Args:
             node: The Tree node to populate.
-            content: The collection of `Path` objects to populate the node with.
+            content: The CatalogItems to populate the node with.
         """
+        items = list(content)
+        async with self.lock:
+            node.remove_children()
+        for offset in range(0, len(items), POPULATE_CHUNK_SIZE):
+            async with self.lock:
+                for item in items[offset : offset + POPULATE_CHUNK_SIZE]:
+                    node.add(
+                        self._build_item_label(item.label, item.type_label),
+                        data=item,
+                        allow_expand=bool(item.children)
+                        or not getattr(item, "loaded", True),
+                    )
+            await asyncio.sleep(0)
+
+    def _show_loading_placeholder(self, node: TreeNode[CatalogItem]) -> None:
+        """Give an expanded node something to show while its children are fetched.
+
+        Without this the node expands to nothing at all, which is what makes a
+        slow catalog look like a hung one.
+        """
+        if self._has_placeholder(node):
+            return
+        type_label_style = self.get_component_rich_style("harlequin-tree--type-label")
         node.remove_children()
-        for item in content:
-            node.add(
-                self._build_item_label(item.label, item.type_label),
-                data=item,
-                allow_expand=bool(item.children) or not getattr(item, "loaded", True),
-            )
+        node.add(
+            Text("loading…", style=Style(color=type_label_style.color, italic=True)),
+            data=LOADING_ITEM,
+            allow_expand=False,
+        )
+
+    @staticmethod
+    def _has_placeholder(node: TreeNode[CatalogItem]) -> bool:
+        return len(node.children) == 1 and node.children[0].data is LOADING_ITEM
 
     @work(thread=True, exit_on_error=False, description="_load_children")
     def _load_children(self, node: TreeNode[CatalogItem]) -> list[CatalogItem]:
@@ -312,12 +428,27 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         while not worker.is_cancelled:
             # Get the next node that needs loading off the queue. Note that
             # this blocks if the queue is empty.
-            *_, node = await self._load_queue.get()
-            content: list[CatalogItem] = []
-            async with self.lock:
+            priority, _, node = await self._load_queue.get()
+            key = id(node)
+            try:
+                if self._queued_priority.get(key) != priority:
+                    # a stale entry: this node was re-queued at a better priority
+                    # (or has since been loaded), so it is handled elsewhere.
+                    continue
+                del self._queued_priority[key]
+                if priority > DEMAND_PRIORITY and not self._in_prefetch_window(
+                    node  # type: ignore[arg-type]
+                ):
+                    # scrolled or collapsed out of view before we got to it, so
+                    # the speculation no longer pays for itself.
+                    continue
+                self._loading.add(key)
                 try:
-                    # Spin up a short-lived thread that will load the content of
-                    # the directory associated with that node.
+                    # Spin up a short-lived thread that will load the children of
+                    # the catalog item associated with that node. The tree lock is
+                    # deliberately not held here: an adapter's fetch_children() can
+                    # take seconds against a remote database, and holding the lock
+                    # across it would block the tree's own rendering and input.
                     content = await self._load_children(node).wait()
                 except WorkerCancelled:
                     # The worker was cancelled, that would suggest we're all
@@ -326,15 +457,23 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                 except WorkerFailed:
                     # This particular worker failed to start. We don't know the
                     # reason so let's no-op that (for now anyway).
-                    pass
-                else:
-                    # We're still here and we have directory content, get it into
-                    # the tree.
-                    if content:
-                        self._populate_node(node, content)
+                    continue
                 finally:
-                    # Mark this iteration as done.
-                    self._load_queue.task_done()
+                    self._loading.discard(key)
+                # _load_children may have cleared allow_expand, and setting that
+                # only bumps the node's update counter -- nothing repaints. Without
+                # this, a node we found to be empty keeps a phantom expand arrow.
+                self._invalidate()
+                # Only build TreeNodes the user can actually reach. A collapsed
+                # node keeps its children on `node.data`, and they are rendered
+                # if and when it is expanded. Empty content still has to be
+                # populated, to clear the placeholder off a node with no children.
+                if node.is_expanded or self._has_placeholder(node):  # type: ignore[arg-type]
+                    await self._populate_node(node, content)
+                    self._schedule_prefetch_scan()
+            finally:
+                # Mark this iteration as done.
+                self._load_queue.task_done()
 
     async def _on_tree_node_expanded(
         self, event: Tree.NodeExpanded[CatalogItem]
@@ -345,14 +484,12 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
             return
         if isinstance(node.data, InteractiveCatalogItem) and not node.data.loaded:
             # if this node isn't loaded yet, add it to the front of the queue
-            self._add_to_load_queue(node, priority=0)  # type: ignore[arg-type]
-        if (
-            isinstance(node.data, CatalogItem)
-            and node.data.children
-            and not node.children
-        ):
-            self._populate_node(node, content=node.data.children)
-        # pre-fetch the node's grandchildren
-        for child in node.children:
-            if isinstance(child.data, InteractiveCatalogItem):
-                self._add_to_load_queue(child)  # type: ignore[arg-type]
+            self._show_loading_placeholder(node)
+            self._add_to_load_queue(node, priority=DEMAND_PRIORITY)  # type: ignore[arg-type]
+        elif node.data.children and (not node.children or self._has_placeholder(node)):
+            await self._populate_node(node, content=node.data.children)
+        self._schedule_prefetch_scan()
+
+    def _on_tree_node_collapsed(self, event: Tree.NodeCollapsed[CatalogItem]) -> None:
+        # the lines below shifted up; re-scan so we prefetch what's on screen now
+        self._schedule_prefetch_scan()

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -4,11 +4,14 @@ from typing import Awaitable, Callable
 from unittest.mock import MagicMock
 
 import pytest
+from textual.pilot import Pilot
 from textual.widgets import Input
+from textual.widgets._tree import TreeNode
 from textual.worker import WorkerCancelled
 
 from harlequin.app import Harlequin
 from harlequin.autocomplete import HarlequinCompletion
+from harlequin.catalog import CatalogItem
 
 
 @pytest.fixture(autouse=True)
@@ -186,6 +189,29 @@ def wait_for_workers() -> Callable[[Harlequin], Awaitable[None]]:
                 await app.workers.wait_for_complete(filtered_workers)
 
     return wait_for_filtered_workers
+
+
+@pytest.fixture
+def expand_catalog_node() -> Callable[[Pilot, TreeNode[CatalogItem]], Awaitable[None]]:
+    """Expand a catalog node and wait until its real children are rendered.
+
+    The catalog shows a "loading…" placeholder child as soon as an unloaded node
+    is expanded, so waiting on `node.children` alone returns before the adapter
+    has answered.
+    """
+
+    async def expand(pilot: Pilot, node: TreeNode[CatalogItem]) -> None:
+        node.expand()
+        while True:
+            data = node.data
+            if data is None or (
+                getattr(data, "loaded", True)
+                and len(node.children) == len(data.children)
+            ):
+                return
+            await pilot.pause()
+
+    return expand
 
 
 @pytest.fixture

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -65,13 +65,15 @@ async def test_data_catalog(
         assert dbs[0].data.query_name == '"small"'
         assert dbs[0].is_expanded is False
 
-        # the small db has two schemas, but you can't see them yet
-        # pause while the children are loaded
+        # the small db has two schemas, but you can't see them yet: a collapsed
+        # node holds its children on `data` and only builds TreeNodes when it is
+        # expanded, so that a huge catalog costs a screenful of nodes, not one
+        # per object in the database.
         assert isinstance(dbs[0].data, InteractiveCatalogItem)
         while not dbs[0].data.loaded:
             await pilot.pause(0.1)
-        assert len(dbs[0].children) == 2
-        assert all(not node.is_expanded for node in dbs[0].children)
+        assert len(dbs[0].data.children) == 2
+        assert not dbs[0].children
         snap_results.append(await app_snapshot(app, "Initialization"))
 
         assert str(dbs[1].label) == "tiny db"
@@ -79,9 +81,16 @@ async def test_data_catalog(
 
         # click on "small" and see it expand.
         await pilot.click(catalog.__class__, offset=Offset(x=6, y=1))
+        await pilot.pause()
         assert dbs[0].is_expanded is True
         assert dbs[1].is_expanded is False
+        assert len(dbs[0].children) == 2
         assert all(not node.is_expanded for node in dbs[0].children)
+        # the schemas are on screen now, so the catalog probes them; wait, or the
+        # snapshot catches "empty" still showing an expand arrow it will lose.
+        for schema in dbs[0].children:
+            while not getattr(schema.data, "loaded", True):
+                await pilot.pause()
         snap_results.append(await app_snapshot(app, "small expanded"))
 
         # small's second schema is "main". click "main"
@@ -260,6 +269,7 @@ async def test_context_menu(
     app_small_duck: Harlequin,
     app_snapshot: Callable[..., Awaitable[bool]],
     wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    expand_catalog_node: Callable[..., Awaitable[None]],
 ) -> None:
     app = app_small_duck
     snap_results: List[bool] = []
@@ -275,11 +285,7 @@ async def test_context_menu(
         ):
             await pilot.pause()
         for db_node in app.data_catalog.database_tree.root.children:
-            db_node.expand()
-            while not db_node.children:
-                if getattr(db_node.data, "loaded", True):
-                    break
-                await pilot.pause()
+            await expand_catalog_node(pilot, db_node)
             for schema_node in db_node.children:
                 schema_node.expand()
 

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -7,11 +7,9 @@ import pytest
 from textual.message import Message
 from textual.notifications import Notify
 from textual.widgets.text_area import Selection
-from textual.widgets.tree import TreeNode
 
 from harlequin import Harlequin
 from harlequin.app import QuerySubmitted
-from harlequin.catalog import CatalogItem
 
 
 @pytest.mark.asyncio
@@ -190,18 +188,12 @@ async def test_member_autocomplete(
     app_small_duck: Harlequin,
     app_snapshot: Callable[..., Awaitable[bool]],
     wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    expand_catalog_node: Callable[..., Awaitable[None]],
 ) -> None:
     app = app_small_duck
     snap_results: List[bool] = []
     async with app.run_test() as pilot:
         await wait_for_workers(app)
-
-        async def _expand_and_wait(node: TreeNode[CatalogItem]) -> None:
-            node.expand()
-            while not node.children:
-                if getattr(node.data, "loaded", True):
-                    break
-                await pilot.pause()
 
         # we need to expand the data catalog to load items into the completer
         while (
@@ -210,11 +202,13 @@ async def test_member_autocomplete(
         ):
             await pilot.pause()
         for db_node in app.data_catalog.database_tree.root.children:
-            await _expand_and_wait(db_node)
+            await expand_catalog_node(pilot, db_node)
             await wait_for_workers(app)
             for schema_node in db_node.children:
-                await _expand_and_wait(schema_node)
+                await expand_catalog_node(pilot, schema_node)
                 await wait_for_workers(app)
+        # the relations are on screen now, so the catalog prefetches their
+        # columns; wait for those to reach the member completer.
         await pilot.pause(1)
 
         # now the completer should be populated


### PR DESCRIPTION
Closes #838.

The catalog looked like it hung because `_loader` built TreeNodes for every *prefetched* node, not just expanded ones — 76,562 nodes from expanding one database, ~350ms of main-thread work per schema. Three smaller costs sat behind it: prefetch was unbounded, the completer merge sorted the whole catalog on the event loop, and the tree lock was held across the adapter's blocking `fetch_children()`.

**`database_tree.py`**
- TreeNodes are built only for nodes you can reach; a collapsed node keeps its children on `node.data`.
- Prefetch is bounded by the viewport (visible lines ± 20, debounced 100ms) rather than the tree's shape — a catalog that fits on screen still loads in full; a huge one costs a screenful of fetches regardless of size.
- Population is chunked (250 nodes/slice), the fetch no longer holds the tree lock, and an expanded node shows a `loading…` placeholder instead of nothing.
- Queue dedupe rewritten around a priority map; the old `suppress(TypeError)` never actually deduped.

**`app.py` / `completers.py`** — completer extend+merge moved into a threaded worker, and `_merge_completions` sorts on an explicit key instead of `HarlequinCompletion.__lt__` (4.8x faster, identical ordering).

Two bugs fixed on the way: a node queued for prefetch and then expanded was loaded twice, and the second populate called `remove_children()`, collapsing a subtree you had opened; and `allow_expand` never schedules a repaint, so a node found to be empty kept a phantom expand arrow.

### Measured

80 schemas x 3,000 relations, 200ms latency, via a synthetic high-latency adapter:

| | before | after |
|---|---|---|
| event-loop lag p50 / p95 / max | 318 / 678 / 1470 ms | **0 / 13 / 132 ms** |
| TreeNodes for one expanded db | 76,562 | **83** |
| expand a table -> columns visible | 0.71 s | **0.19 s** (0.20 s network floor) |

Small/local databases are unchanged in feel: everything on screen still prefetches eagerly, 0ms lag.

`scripts/catalog_lag.py` reports the same percentiles against a real database, for checking this against large remote Postgres/MySQL.

### Testing

Full suite passes with no snapshot changes. Three tests asserted the old contract and were updated; the new `expand_catalog_node` fixture replaces an inline idiom that returned early now that the placeholder makes `node.children` truthy immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)