### PR TITLE
fix: don't call task_done() on a swapped catalog load queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Fixes an intermittent crash (`ValueError: task_done() called too many times`) when the Data Catalog was refreshed — for example by the automatic refresh after running a query — while its background loader was still fetching a node ([#991](https://github.com/tconbeer/harlequin/issues/991)).
 - A Data Catalog node that turns out to have no children no longer keeps a phantom expand arrow.
 - Expanding a node that was already queued for background loading no longer loads it twice, which could collapse a subtree you had opened.
 

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -421,14 +421,23 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
             key=lambda catalog_item: catalog_item.label,
         )
 
-    @work(name="_database_tree_background_loader")
+    @work(
+        name="_database_tree_background_loader",
+        exclusive=True,
+        group="database_tree_loaders",
+    )
     async def _loader(self) -> None:
         """Background loading queue processor."""
         worker = get_current_worker()
+        # Bind the queue once: reload() replaces self._load_queue, and calling
+        # task_done() on the replacement -- which has no outstanding get() -- is
+        # what raised "task_done() called too many times". exclusive=True also
+        # retires this worker when reload() starts its successor.
+        queue = self._load_queue
         while not worker.is_cancelled:
             # Get the next node that needs loading off the queue. Note that
             # this blocks if the queue is empty.
-            priority, _, node = await self._load_queue.get()
+            priority, _, node = await queue.get()
             key = id(node)
             try:
                 if self._queued_priority.get(key) != priority:
@@ -472,8 +481,8 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                     await self._populate_node(node, content)
                     self._schedule_prefetch_scan()
             finally:
-                # Mark this iteration as done.
-                self._load_queue.task_done()
+                # Mark this iteration as done, on the queue this item came from.
+                queue.task_done()
 
     async def _on_tree_node_expanded(
         self, event: Tree.NodeExpanded[CatalogItem]

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -1,6 +1,15 @@
 import sys
+import threading
 from pathlib import Path
-from typing import Awaitable, Callable, List, NamedTuple, Set, Type
+from typing import (
+    Awaitable,
+    Callable,
+    ClassVar,
+    List,
+    NamedTuple,
+    Set,
+    Type,
+)
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +17,7 @@ from textual.geometry import Offset
 from textual.widgets import Input
 
 from harlequin import Harlequin
-from harlequin.catalog import InteractiveCatalogItem
+from harlequin.catalog import CatalogItem, InteractiveCatalogItem
 from harlequin.components import ExportScreen
 from harlequin_duckdb.adapter import DuckDbAdapter
 
@@ -412,3 +421,63 @@ async def test_file_tree_refreshes_after_export(
 
         assert export_path.is_file()
         assert export_path in _file_tree_paths(app)
+
+
+class BlockingCatalogItem(InteractiveCatalogItem):
+    """A catalog item whose fetch_children() blocks until it is released."""
+
+    started: ClassVar[threading.Event] = threading.Event()
+    release: ClassVar[threading.Event] = threading.Event()
+
+    def fetch_children(self) -> List[CatalogItem]:
+        type(self).started.set()
+        type(self).release.wait(timeout=10)
+        return []
+
+
+@pytest.mark.asyncio
+async def test_reload_while_loader_is_fetching(
+    duckdb_adapter: Type[DuckDbAdapter],
+) -> None:
+    """Reloading the catalog mid-fetch must not crash the background loader.
+
+    reload() replaces the tree's load queue. The loader used to call task_done()
+    on whatever `self._load_queue` pointed at when its fetch returned, so a reload
+    that landed mid-fetch made it call task_done() on the fresh queue -- which has
+    no outstanding get() -- and the worker died with "task_done() called too many
+    times" ([#991](https://github.com/tconbeer/harlequin/issues/991)).
+    """
+    BlockingCatalogItem.started.clear()
+    BlockingCatalogItem.release.clear()
+
+    app = Harlequin(duckdb_adapter((":memory:",)))
+    async with app.run_test(size=(120, 36)) as pilot:
+        tree = app.data_catalog.database_tree
+        while tree.loading:
+            await pilot.pause()
+
+        node = tree.root.add(
+            "blocking",
+            data=BlockingCatalogItem(
+                qualified_identifier="blocking",
+                query_name="blocking",
+                label="blocking",
+                type_label="t",
+            ),
+        )
+        tree._add_to_load_queue(node, priority=0)  # type: ignore[arg-type]
+
+        # wait until the adapter call is actually in flight
+        while not BlockingCatalogItem.started.is_set():
+            await pilot.pause()
+
+        # ... and swap the queue out from under the in-flight loader
+        await tree.reload()
+        BlockingCatalogItem.release.set()
+        for _ in range(50):
+            await pilot.pause()
+
+        loaders = [
+            w for w in app.workers if w.name == "_database_tree_background_loader"
+        ]
+        assert not [w.error for w in loaders if w.error is not None]


### PR DESCRIPTION
Closes #991.

`reload()` replaces `self._load_queue` with a fresh `PriorityQueue` and starts a new `_loader()`. The old loader was not cancelled, and its `finally` block resolved `self._load_queue` at *finally-time* — so a loader that was mid-fetch when the reload landed called `task_done()` on the **new** queue, which has no outstanding `get()`, and died with `ValueError: task_done() called too many times`.

Harlequin refreshes the catalog automatically after every query, so any query could trigger it.

Both fixes suggested in the issue, since they cover different halves of the race:

- `_loader` binds `queue = self._load_queue` once per run and calls `task_done()` on *that* object, so a swap can't misdirect it.
- `_loader` is now `exclusive=True` in its own `group="database_tree_loaders"`, so `reload()` retires the previous loader instead of leaving two running. (An explicit group matters here — the default group would also cancel the `_load_children` thread workers.)

### Verification

`test_reload_while_loader_is_fetching` pins the exact race: it blocks an adapter's `fetch_children()` on an event, waits until the call is genuinely in flight, calls `reload()`, then releases the fetch and asserts the loader worker has no error.

Confirmed it fails without the fix and passes with it:

```
=== WITH FIX ===     1 passed
=== WITHOUT FIX ===  ValueError: task_done() called too many times
                     1 failed
```

Also stress-tested end to end against a synthetic high-latency adapter (~95 reload/fetch collisions per run, at 100/250/400ms latency): reproduces reliably on `main`, clean on this branch across 6 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)