### PR TITLE
fix: don't crash when an adapter raises a non-Harlequin error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Running a buffer that contains several queries no longer merges, skips, or repeats queries, and runs them in the order they appear in the buffer ([#929](https://github.com/tconbeer/harlequin/issues/929)). Selecting queries backwards now runs the same queries as selecting them forwards, and placing the cursor immediately after a semicolon runs only the query it terminates.
+- Harlequin no longer crashes if an adapter raises an exception other than a `HarlequinQueryError` while executing a query, fetching results, canceling queries, or loading completions; it shows an error modal and keeps running ([#982](https://github.com/tconbeer/harlequin/issues/982)).
 - Fixes an intermittent crash (`ValueError: task_done() called too many times`) when the Data Catalog was refreshed — for example by the automatic refresh after running a query — while its background loader was still fetching a node ([#991](https://github.com/tconbeer/harlequin/issues/991)).
 - A Data Catalog node that turns out to have no children no longer keeps a phantom expand arrow.
 - Expanding a node that was already queued for background loading no longer loads it twice, which could collapse a subtree you had opened.

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -86,7 +86,6 @@ from harlequin.exception import (
     HarlequinConfigError,
     HarlequinConnectionError,
     HarlequinError,
-    HarlequinQueryError,
     pretty_error_message,
     pretty_print_error,
 )
@@ -1071,7 +1070,7 @@ class Harlequin(AppBase):
     @work(
         thread=True,
         exclusive=True,
-        exit_on_error=True,
+        exit_on_error=False,
         group="query_runners",
         description="Executing queries.",
     )
@@ -1084,7 +1083,9 @@ class Harlequin(AppBase):
         for q in queries:
             try:
                 cur = self.connection.execute(q)
-            except HarlequinQueryError as e:
+            # adapters are supposed to raise HarlequinQueryError, but a raw
+            # driver exception must not take down the app.
+            except Exception as e:
                 self.post_message(QueryError(query_text=q, error=e))
                 break
             else:
@@ -1107,14 +1108,22 @@ class Harlequin(AppBase):
     @work(
         thread=True,
         exclusive=True,
-        exit_on_error=True,
+        exit_on_error=False,
         group="query_cancellers",
         description="Cancelling queries.",
     )
     def _cancel_query(self) -> None:
         if self.connection is None or not self.adapter.IMPLEMENTS_CANCEL:
             return
-        self.connection.cancel()
+        try:
+            self.connection.cancel()
+        except Exception as e:
+            self.call_from_thread(
+                self._push_error_modal,
+                title="Cancel Error",
+                header="Harlequin could not cancel your queries.",
+                error=e,
+            )
         self.post_message(QueriesCanceled())
 
     def _get_selected_queries(self) -> list[str]:
@@ -1138,7 +1147,7 @@ class Harlequin(AppBase):
     @work(
         thread=True,
         exclusive=True,
-        exit_on_error=True,
+        exit_on_error=False,
         group="query_runners",
         description="fetching data from adapter.",
     )
@@ -1152,10 +1161,11 @@ class Harlequin(AppBase):
         for id_, (cur, q) in cursors.items():
             try:
                 cur_data = cur.fetchall()
+                cols = cur.columns()
             except BaseException as e:
                 errors.append((e, q))
             else:
-                data[id_] = (cur.columns(), cur_data, q)
+                data[id_] = (cols, cur_data, q)
         elapsed = time.monotonic() - submitted_at
         self.post_message(
             ResultsFetched(cursors=cursors, data=data, errors=errors, elapsed=elapsed)
@@ -1217,13 +1227,21 @@ class Harlequin(AppBase):
     @work(
         thread=True,
         exclusive=True,
-        exit_on_error=True,
+        exit_on_error=False,
         group="completer_builders",
         description="building completers",
     )
     def _build_completers(self, catalog: Catalog) -> None:
         assert self.connection is not None
-        extra_completions = self.connection.get_completions()
+        try:
+            extra_completions = self.connection.get_completions()
+        except Exception:
+            # completions are a nice-to-have; build the rest without them.
+            extra_completions = []
+            self.notify(
+                "Harlequin could not load completions from your adapter.",
+                severity="warning",
+            )
         word_completer, member_completer = completer_factory(
             catalog=catalog,
             extra_completions=extra_completions,

--- a/tests/functional_tests/test_app.py
+++ b/tests/functional_tests/test_app.py
@@ -339,3 +339,40 @@ async def test_rich_markup(
         await wait_for_workers(app)
         await pilot.pause()
         assert await app_snapshot(app, "select markup")
+
+
+@pytest.mark.asyncio
+async def test_adapter_raises_unexpected_error(
+    app: Harlequin,
+    monkeypatch: pytest.MonkeyPatch,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """
+    An adapter that raises a raw driver exception instead of a
+    HarlequinQueryError should not crash the app.
+    """
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        assert app.connection is not None
+
+        def raise_driver_error(query: str) -> None:
+            raise RuntimeError("1049 (42000): Unknown database 'ht;'")
+
+        monkeypatch.setattr(app.connection, "execute", raise_driver_error)
+
+        app.editor.text = "use ht;"
+        await pilot.press("ctrl+a")
+        await pilot.press("ctrl+j")
+        await wait_for_workers(app)
+        await pilot.pause()
+
+        assert app.is_running
+        assert isinstance(app.screen, ErrorModal)
+        assert "Unknown database" in str(app.screen.error)
+
+        await pilot.press("space")
+        assert len(app.screen_stack) == 1
+        assert "non-responsive" not in app.run_query_bar.classes
+        assert "non-responsive" not in app.results_viewer.classes


### PR DESCRIPTION
Partially addresses #982 ; will follow up with a fix in harlequin-mysql for the other part.

`_execute_query` only caught `HarlequinQueryError`, and its worker ran with `exit_on_error=True`, so a raw driver exception (in #982, a `mysql.connector` `ProgrammingError` raised while the pool reconnected after `USE`) tore down the app with a traceback. It now catches any exception from `execute()` and posts a `QueryError`, which shows the usual error modal.

Same treatment for the other query-path workers that could crash the app: `_cancel_query`, `_fetch_data` (`cur.columns()` was outside the `try`), and `_build_completers` (falls back to no extra completions and warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
