### PR TITLE
fix: sort query separators so multi-query runs are correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Running a buffer that contains several queries no longer merges, skips, or repeats queries, and runs them in the order they appear in the buffer ([#929](https://github.com/tconbeer/harlequin/issues/929)). Selecting queries backwards now runs the same queries as selecting them forwards, and placing the cursor immediately after a semicolon runs only the query it terminates.
 - Fixes an intermittent crash (`ValueError: task_done() called too many times`) when the Data Catalog was refreshed — for example by the automatic refresh after running a query — while its background loader was still fetching a node ([#991](https://github.com/tconbeer/harlequin/issues/991)).
 - A Data Catalog node that turns out to have no children no longer keeps a phantom expand arrow.
 - Expanding a node that was already queued for background loading no longer loads it twice, which could collapse a subtree you had opened.

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -9,7 +9,7 @@ from textual.css.query import InvalidQueryFormat, NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import ContentSwitcher, TabbedContent, TabPane, Tabs
-from textual.widgets.text_area import Selection
+from textual.widgets.text_area import Location, Selection
 from textual_textarea import TextAreaSaved, TextEditor
 
 from harlequin.autocomplete import MemberCompleter, WordCompleter
@@ -51,23 +51,42 @@ class CodeEditor(TextEditor, inherit_bindings=False):
             # there are literal semicolons in the text.
             return [self.text]
 
-        queries: list[str] = []
-        prev_query: str | None = None
-        query_start = (0, 0)
+        # a selection can be made in either direction, so its end
+        # can come before its start.
+        selection_start = min(self.selection.start, self.selection.end)
+        selection_end = max(self.selection.start, self.selection.end)
+
+        # each query spans from the end of the previous separator
+        # (or the start of the buffer) through its own separator.
+        queries: list[tuple[Location, Location, str]] = []
+        query_start: Location = (0, 0)
         for query_end in [*separators, self.text_input.document.end]:
-            if query_start > self.selection.end:
-                break
             q = self.text_input.get_text_range(start=query_start, end=query_end).strip()
-            if q and query_end >= self.selection.start:
-                queries.append(q)
-            elif q:
-                prev_query = q
+            if q:
+                queries.append((query_start, query_end, q))
             query_start = query_end
 
-        if not queries and prev_query:
-            return [prev_query]
+        if not queries:
+            return []
 
-        return queries
+        # an empty selection (a bare cursor) spans no range, so it only
+        # overlaps a query if it sits strictly inside that query.
+        overlapping = [
+            q
+            for start, end, q in queries
+            if start < selection_end and end > selection_start
+        ]
+        if overlapping:
+            return overlapping
+
+        # the cursor sits on a boundary between queries (or in the whitespace
+        # between them); run the first query that ends at or after the cursor.
+        for _, end, q in queries:
+            if end >= selection_start:
+                return [q]
+
+        # the cursor is in trailing whitespace after the last query.
+        return [queries[-1][2]]
 
     def on_mount(self) -> None:
         self.post_message(EditorCollection.EditorSwitched(active_editor=self))
@@ -123,9 +142,9 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         if hasattr(self.app, "action_focus_data_catalog"):
             self.app.action_focus_data_catalog()
 
-    def _query_separators(self) -> list[tuple[int, int]]:
+    def _query_separators(self) -> list[Location]:
         """
-        Return a list of tuples that represent the row and col
+        Return a sorted list of tuples that represent the row and col
         positions of query separators (semicolons) in the buffer text.
         """
         if self.text_input is None:
@@ -134,7 +153,12 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         if self.text_input.is_syntax_aware:
             assert self._semicolon_query is not None
             query_result = self.query_syntax_tree(query=self._semicolon_query)
-            return [n.end_point for n in query_result.get("semicolon", [])]
+            # tree-sitter captures nodes in the order its patterns match them,
+            # which is not the order they appear in the buffer.
+            return sorted(
+                (n.end_point.row, n.end_point.column)
+                for n in query_result.get("semicolon", [])
+            )
 
         else:
             # tree-sitter is not installed. naively split on semicolons and
@@ -151,7 +175,7 @@ class CodeEditor(TextEditor, inherit_bindings=False):
                 )
                 self.has_shown_tree_sitter_error = True
 
-            semicolons: list[tuple[int, int]] = []
+            semicolons: list[Location] = []
             for i, line in enumerate(self.text.splitlines()):
                 for pos in [m.span()[1] for m in re.finditer(";", line)]:
                     semicolons.append((i, pos))

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -334,3 +334,65 @@ async def test_footer_inputs(
         snap_results.append(await app_snapshot(app, "Goto Input visible"))
 
         assert all(snap_results)
+
+
+@pytest.mark.asyncio
+async def test_selected_queries(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """Regression test for #929: the queries at the cursor or selection are
+    returned once each, in the order they appear in the buffer."""
+    create = "create table foo (a int);"
+    insert = "insert into foo values (1);"
+    select = "select * from foo;"
+    drop = "drop table foo;"
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+
+        while app.editor is None:
+            await pilot.pause()
+
+        assert app.editor.text_input is not None
+        assert app.editor.text_input.is_syntax_aware
+        app.editor.text = f"{create}\n{insert}\n{select}\n{drop}\n"
+        await pilot.pause()
+
+        # tree-sitter does not capture the semicolons in buffer order
+        assert app.editor._query_separators() == [(0, 25), (1, 27), (2, 18), (3, 15)]
+
+        # the whole buffer
+        app.editor.selection = Selection((0, 0), (4, 0))
+        assert app.editor.selected_queries() == [create, insert, select, drop]
+
+        # a reverse selection is the same as a forward one
+        app.editor.selection = Selection((4, 0), (0, 0))
+        assert app.editor.selected_queries() == [create, insert, select, drop]
+
+        # a selection that partially covers two queries runs both of them
+        app.editor.selection = Selection((1, 5), (2, 5))
+        assert app.editor.selected_queries() == [insert, select]
+
+        # a cursor inside a query runs only that query
+        for row, query in enumerate([create, insert, select, drop]):
+            app.editor.selection = Selection((row, 3), (row, 3))
+            assert app.editor.selected_queries() == [query]
+
+        # a cursor just after a semicolon runs the query it terminates,
+        # not the one that follows it
+        app.editor.selection = Selection((1, 27), (1, 27))
+        assert app.editor.selected_queries() == [insert]
+
+        # a cursor at the start of a query runs that query
+        app.editor.selection = Selection((2, 0), (2, 0))
+        assert app.editor.selected_queries() == [select]
+
+        # a cursor in the trailing whitespace runs the last query
+        app.editor.selection = Selection((4, 0), (4, 0))
+        assert app.editor.selected_queries() == [drop]
+
+        # a semicolon in a string literal does not separate queries
+        app.editor.text = "select 'a;b'"
+        await pilot.pause()
+        app.editor.selection = Selection((0, 0), (0, 0))
+        assert app.editor.selected_queries() == ["select 'a;b'"]


### PR DESCRIPTION
Closes #929.

tree-sitter returns captures in pattern-match order, not buffer order — for a four-statement buffer the semicolon capture comes back as `[(0,25), (2,18), (3,15), (1,27)]`. `selected_queries()` walked that as if it were sorted, so statement ranges went backwards: some queries merged, some were skipped, and some ran twice. Sorting the separators fixes the reported bug; while in there, reverse selections are now normalized (`Selection.start`/`.end` are anchor/cursor, so a backwards drag had `start > end`) and statements are selected by range overlap, so a cursor immediately after a `;` runs only the statement it terminates instead of that one plus the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)