### PR TITLE
Plan: M1 technical plan for hsql

### DIFF
--- a/docs/plans/harlequin-for-agents.md
+++ b/docs/plans/harlequin-for-agents.md
@@ -159,8 +159,11 @@ the TUI.
   works without compromise.
 - `hsql --help` omits every TUI-only option (`--theme`, `--keymap-name`, `--show-files`,
   `--show-s3`, `--locale`, `--config`, `--keys`), which is a real token saving for an
-  agent reading it. It still carries the full adapter connection-option matrix; that's
-  unavoidable and shared.
+  agent reading it. It also omits the adapter connection-option matrix: `hsql --help`
+  lists the *names* of installed adapters and points at `hsql --help -a <adapter>` for
+  one adapter's options. That keeps the first thing an agent reads small and stable, and
+  keeps `--help` true for every adapter rather than showing whichever one is the
+  default.
 - The handoff gets a natural verb: `hsql open query.sql` reads much better than
   `harlequin --new-buffer query.sql`.
 
@@ -217,7 +220,7 @@ hsql <SUBCOMMAND> [OPTIONS]         catalog, describe, fmt, spec, info,
       --null-string STR  Render NULL as STR. Default: empty for csv, "NULL" for table.
   -P, --profile NAME     Same profiles as the TUI.
   -l, --limit N          Max rows per result set. Default: 500. 0 = no limit.
-      --result all|last|N  Which result set(s) to emit. Default: all (text), last (data).
+      --result all|last|N  Which result set(s) to emit. Default: all.
       --on-error stop|continue    Default: stop.
       --stats            Write a one-line JSON summary to stderr.
       --color auto|always|never   Default: never.
@@ -248,8 +251,19 @@ point — `hsql -P prod -c ...` means the agent never handles a credential.
 
 **Truncation is always announced.** If `--limit` bites, stderr gets
 `note: results truncated at 500 rows (--limit)`, and text formats append a visible
-`… 500 of N rows` footer. The TUI's default of 100,000 rows is right for a TUI and a
-catastrophe for an agent; `hsql` defaults to 500.
+`… 500 of 500+ rows` footer.
+
+Note that `-l` here is a *hard* limit — it caps what leaves the database, via the
+adapter's `set_limit()`. The TUI's `--limit` is a soft display cap: it fetches everything
+and caps what loads into the viewer, which is why the TUI can report an exact
+`Showing 100,000 of 3,412,887`. `hsql` deliberately doesn't buy that number, so it says
+`500+`; only `-l 0` yields an exact count. The TUI's default of 100,000 is right for a
+TUI and a catastrophe for an agent; `hsql` defaults to 500.
+
+Detecting truncation at all requires fetching `limit + 1` rows and emitting `limit` —
+`set_limit(n)` followed by `fetchall()` returns at most n rows and cannot say whether an
+n+1th existed. Worth stating here rather than leaving to implementation, because it's the
+kind of detail that gets optimized away and quietly breaks this promise.
 
 The stderr notice fires **even under `-t`**. `-t` suppresses stdout chrome, not
 warnings; a flag that silently defeats truncation reporting would undo principle 5.
@@ -285,8 +299,11 @@ identically whether stdout is CSV or Parquet.
 **`hsql -c "select 1"` against DuckDB in under 300ms**, tracked as a benchmark in CI and
 protected by the import-linter rule from §4.
 
-**Large results stream.** `hsql` should not materialize a full Arrow table for a
-CSV/JSONL export. This also chips at [#875](https://github.com/tconbeer/harlequin/issues/875).
+**Large results stream — in M5, not M1.** Streaming has to start at the cursor:
+`HarlequinCursor.fetchall()` materializes the whole result before any writer exists, so
+no amount of care in the format layer helps. Deferred wholesale to M5 along with
+[#875](https://github.com/tconbeer/harlequin/issues/875), rather than half-designed
+now.
 
 ### User stories
 
@@ -766,6 +783,12 @@ Because the CLI is a separate command, **every milestone here is purely additive
 | **M5** | Scale | Streaming output, `--offset`/pagination, memory work for large results (**#875**). |
 | **M6** | MCP | `hsql mcp` over the M1 execution core: `run_query`, `list_catalog`, `describe_object`, `explain_query`, `format_sql`, plus catalog and docs resources. Read-only by default. |
 
+**On M1.** Implementation is planned in detail in
+[the M1 technical plan](./m1-hsql-technical-plan.md): the module architecture, the
+refactors that have to land first, and an eight-PR sequence across two releases. A few
+figures and defaults in this document were corrected against measurements taken while
+writing it; §8 there lists them.
+
 **On M0.** Name availability is the only thing in this plan that someone else can take
 while we deliberate, which is why it's a milestone rather than a task. It's also cheap
 enough to do this week.
@@ -831,11 +854,16 @@ any of fifteen databases on the first try."
   and it's also the single most useful catalog call an agent can make. Child counts, the
   node budget, and `--stats` are what keep that honest until adapters can serve it in
   one query.
-- **Cold start.** The import-linter rule protects against Textual creeping in, but the
-  adapter plugins themselves can be slow to import. May need lazy entry-point resolution
-  so `hsql -c` against DuckDB doesn't pay for an installed BigQuery adapter.
+- **Cold start.** Measured rather than feared, and worse than this section assumed: a
+  bare `harlequin --version` takes 1.3s today. Lazy entry-point resolution is a
+  requirement of M1, not a contingency — `load_adapter_plugins()` imports every installed
+  adapter on every invocation, worth 160ms with four installed and unbounded as the
+  ecosystem grows. An import-linter rule in this repo would also never have caught the
+  largest single cause, which is upstream: `harlequin.adapter` pays 265ms for
+  `textual-fastdatatable`, whose backend needs no Textual but whose package `__init__`
+  imports the DataTable widget. See the M1 technical plan.
 - **Memory.** Materializing an Arrow table for a large export is the same failure as
-  #875. Streaming needs to be designed into M1's format layer, not retrofitted.
+  #875, and it is not fixed in M1. See the streaming note in §5.
 - **Secrets.** `info --json`, `config show`, error messages, and history are all leak
   surfaces, and agents paste output into transcripts. Mitigated structurally by the
   secret option type in §7 (**#667**) rather than by remembering to redact at each site —

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -104,7 +104,11 @@ Driving that grammar directly, with no Textual and no textual-textarea, measures
 **28ms to import, 92 modules**, and 22ms to split a 2000-statement script. It gets
 string literals, line comments, block comments, quoted identifiers and unicode right.
 It gets `$$`-dollar-quoting wrong — and so does the TUI today, because it's the same
-grammar and the same query. See §3.2.
+grammar and the same query.
+
+Two further things fell out of driving it directly. Tree-sitter is used in exactly one
+place in Harlequin — that one query — and nowhere else. And its `Point.column` is a
+**byte** offset, which the editor feeds to a function expecting characters. See §3.2.
 
 ### 1.5 Two places already write results to stdout that shouldn't
 
@@ -280,39 +284,54 @@ against sqlfmt's 85ms, no new SQL scanner to maintain, and — the part that mat
 and the editor cannot disagree about where a statement ends.
 
 ```python
-SEMICOLON_QUERY = '(";" @semicolon)'          # one definition, both consumers
-
-def tree_sitter_available() -> bool: ...
-def find_separators(text: str) -> list[int]: ...   # offset just past each separator
-def split(text: str) -> list[Statement]: ...       # separators -> trimmed statements
+def find_separators(text: str) -> list[Point]: ...  # (row, character column) past each ";"
+def split(text: str) -> list[Statement]: ...        # separators -> trimmed statements
 ```
 
-The editor keeps its own path, and that's correct rather than a compromise:
-`selected_queries()` needs to know which statements *intersect the selection*, so it
-works in `(row, column)` Locations against textual-textarea's already-parsed incremental
-tree. Reparsing the buffer through a second parser would be slower and no more accurate.
-What it stops owning is the query pattern and the fallback policy, which it imports from
-here. So: one grammar, one query constant, one definition of "empty statement", two
-slicers because there are genuinely two coordinate systems — and a shared fixture corpus
-of tricky SQL that both are tested against.
+**`tree-sitter` and `tree-sitter-sql` become explicit, required dependencies of
+`harlequin`** (Ted's call). Both are installed for everyone today, transitively via
+`textual[syntax]`; depending on them directly costs 28ms, makes the guarantee real
+instead of incidental, and collapses this section from "two splitters, carefully kept in
+sync" to one. The accepted cost is that Harlequin stops installing on a platform with no
+tree-sitter wheel — which is why `textual` made it an extra, and which the
+`harlequin.sh/docs/troubleshooting/tree-sitter` page currently exists to explain. That
+page becomes obsolete; PR 7 removes it.
 
-**Two honest caveats.**
+**With that, there is exactly one splitter.** Tree-sitter is used in precisely one place
+in Harlequin today — `code_editor.py`, for the semicolon query, and nowhere else
+(highlighting is textual-textarea's own business and unaffected). So the editor calls
+`find_separators(self.text)` and slices as it does now, and we delete `SEMICOLON_QUERY`,
+`_semicolon_query`, `prepare_query`, `query_syntax_tree`, `has_shown_tree_sitter_error`,
+and the whole `is_syntax_aware` fallback branch.
 
-*tree-sitter is optional.* It arrives via `textual[syntax]`, so in practice every
-Harlequin install has it, but the TUI has an explicit degraded path
-(`is_syntax_aware == False` → naive regex split plus a warning toast) because
-tree-sitter wheels aren't available everywhere — that's what the
-`harlequin.sh/docs/troubleshooting/tree-sitter` page is for. `hsql` mirrors it: naive
-split, plus a stderr warning saying that statement splitting may be wrong without
-tree-sitter. Promoting `tree-sitter`/`tree-sitter-sql` to hard dependencies of
-`harlequin` would delete the degraded path for everyone and is tempting at 28ms, but it
-would break installs on platforms without wheels. See §6.
+The one thing given up is textual-textarea's incremental tree: the shared library
+reparses. Measured, that's 0.6ms for a realistic buffer and 22ms for a pathological
+2000-statement one, and `selected_queries()` runs on submit rather than on keystroke. A
+worthwhile trade for deleting a divergence.
 
-*Dollar-quoting is wrong.* `create function f() … $$ … ; … $$ …` splits inside the
-function body. The TUI has this bug today, identically, because it's the grammar's. It
-should be its own issue rather than M1 scope — and it's a good demonstration that
-sharing the grammar means `hsql` inherits the TUI's behavior including its bugs, which
-is the definition of no drift.
+**This fixes a live unicode bug in the TUI, which is why the shared library returns
+character columns.** Tree-sitter's `Point.column` is a **byte** offset; Textual's own
+docstring says so, and it hands the raw nodes back. But `get_text_range()` takes
+*character* columns, and `code_editor.py:159` passes one straight into the other. Any
+non-ASCII before a semicolon on the same line shifts the cut:
+
+```
+select '日本語';select 2
+  splits today  -> "select '日本語';select"  |  "2"
+  should be     -> "select '日本語';"        |  "select 2"
+```
+
+Both halves are then syntax errors. It's narrow — it needs non-ASCII before the
+semicolon and a non-space after it, so `.strip()` usually absorbs the off-by-one — but
+it's real, reproducible, and in `main` right now. Owning the byte→character conversion
+in one place, once, is what stops `hsql` from inheriting it. Worth its own issue and a
+changelog line, since it's a TUI bug fix that happens to fall out of this work.
+
+*One known bug we don't fix:* `create function f() … $$ … ; … $$ …` splits inside the
+dollar-quoted body. The TUI has it today, identically, because it's the grammar's. Its
+own issue, not M1 scope — and a decent demonstration that sharing the grammar means
+`hsql` inherits the TUI's behavior including its bugs, which is the definition of no
+drift.
 
 ### 3.3 Output — duckdb serializes, `hsql` lays out
 
@@ -550,11 +569,15 @@ stdout leaks from §1.5. Add import-linter contracts and the cold-start benchmar
 Ships value on its own: importing `harlequin_duckdb` goes from 691ms to 56ms, which
 every adapter's test suite and every library consumer feels.
 
-**PR 2 — `harlequin.statements` and `harlequin.query`.** The tree-sitter splitter and its
-fallback; the editor refactored to import the shared query constant; the tricky-SQL
-corpus. Then the execution core, with `_execute_query` and `_fetch_data` refactored onto
-it. Delete the dead `_split_query_text`. Snapshot tests are the safety net for the TUI
-refactor.
+**PR 2 — `harlequin.statements` and `harlequin.query`.** Add `tree-sitter` and
+`tree-sitter-sql` to `dependencies`. Build the splitter; refactor `CodeEditor` onto it and
+delete its fallback branch, fixing the unicode column bug in the same move; land the
+tricky-SQL corpus. Then the execution core, with `_execute_query` and `_fetch_data`
+refactored onto it. Delete the dead `_split_query_text`. Snapshot tests are the safety
+net for the TUI refactor.
+
+This is the only PR in Release A with user-visible behavior in it — the unicode fix — so
+it gets a changelog entry and its own issue while the rest stay silent.
 
 **PR 3 — `export.py` decoupled from `ResultsTable`, plus `harlequin.layout`.** Extend
 `export.py` with `tsv` and `jsonl` (option variants of formats it already writes) and the
@@ -581,7 +604,8 @@ notices, plain errors.
 known theme name.
 
 **PR 7 — Docs.** The "Headless & Agents" topic (a PR against `tconbeer/harlequin-web`),
-README, changelog.
+README, changelog. Retire the `troubleshooting/tree-sitter` page, which describes a
+degraded mode that no longer exists (§3.2).
 
 **PR 8 — The agent eval suite.** Three tasks against fixture databases, scored on
 wrong-flag retries and completion. §13 of the product plan calls this the metric that
@@ -637,11 +661,10 @@ Beyond that:
   named test. It's the idiom the scripting audience will try first.
 - **Truncation:** exactly-at-limit, one-over-limit, and under-limit, on both duckdb and
   sqlite — the two implement `set_limit` differently enough to matter.
-- **The tricky-SQL corpus** against both the editor's slicer and `statements.split()`,
-  including a skip-marked case for dollar-quoting so the known bug is recorded rather
-  than forgotten.
-- **Splitter fallback:** the naive path exercised with tree-sitter monkeypatched out, so
-  the degraded behavior stays tested on machines that have it.
+- **The tricky-SQL corpus** against `statements.split()` and, through `selected_queries()`,
+  the editor — same fixtures, one splitter underneath. Includes non-ASCII before a
+  semicolon with no following space (the §3.2 bug, which fails on `main`) and a
+  skip-marked dollar-quoting case so the known bug is recorded rather than forgotten.
 
 ---
 
@@ -655,19 +678,16 @@ Beyond that:
 - *The TUI keeps its current row-count display.* `detect_overflow=False` there; only
   `hsql` pays the extra row. No snapshot churn in PR 2.
 - *Streaming is out.* Not designed around, not partially built — see §3.3 and §7.
+- *`tree-sitter` and `tree-sitter-sql` become required dependencies.* One splitter, no
+  fallback, the troubleshooting page retired (§3.2). Accepted cost: no install on
+  platforms without a tree-sitter wheel.
 
 **Still open.**
 
-1. **`tree-sitter` and `tree-sitter-sql` as hard dependencies of `harlequin`?** They're
-   installed for everyone today via `textual[syntax]`, and depending on them directly
-   would let us delete the degraded splitter path and its troubleshooting page. The
-   reason not to is the reason Textual made it an extra: platforms without wheels. You'll
-   know better than me how much traffic that troubleshooting page gets. My default is to
-   keep it optional and mirror the TUI's fallback.
-2. **`hsql --help` showing only the selected adapter's options** — confirmed as an
+1. **`hsql --help` showing only the selected adapter's options** — confirmed as an
    improvement rather than a regression? It's what makes startup cost bounded, and I'd
    want to make the same call even if it weren't.
-3. **`--result` default.** The product plan says `all` for text formats and `last` for
+2. **`--result` default.** The product plan says `all` for text formats and `last` for
    data formats. That's context-dependent behavior, which cuts against determinism. I'd
    rather default to `all` everywhere and let `json`/`csv` emit multiple documents when a
    script produces multiple result sets — but "csv with two headers in it" is genuinely

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -246,16 +246,40 @@ struct come out" — in two places, and the disagreement would surface as `hsql`
 TUI showing different data for the same query. That is the worst possible place for
 these two front doors to diverge.
 
-**Truncation falls out of the backend's `max_rows`, and needs `limit + 1` at the cursor.**
-`set_limit(n)` then `fetchall()` returns at most n rows and tells you nothing about
-whether an n+1th existed; exactly n is ambiguous. So `execute()` requests `limit + 1`,
-and `fetch()` calls `create_backend(data, max_rows=limit)`. `DataTableBackend` already
-distinguishes `row_count` (capped) from `source_row_count` (what it was handed), so
-`truncated = source_row_count > row_count` — the mechanism exists, we just have to feed
-it one extra row. This is why the limit is a value object with an explicit
-`detect_overflow` rather than an `int` each caller interprets: principle 5 of the product
-plan ("truncation must always be announced — never silent") is unimplementable without
-it, and it costs exactly one row.
+**Harlequin already has two different limits, and `hsql` wants the other one.** This is
+worth spelling out, because the names collide and I had it wrong in an earlier draft:
+
+| | What it does | Where |
+| --- | --- | --- |
+| **Soft, display** — `harlequin --limit`, `max_results`, default 100,000 | Fetches *everything*, caps what's loaded into the viewer | `results_viewer.py:147`, `create_backend(max_rows=…)` |
+| **Hard, fetch** — the Run Query Bar's limit checkbox | `cur.set_limit(n)`, so fewer rows leave the database | `app.py:1093` |
+
+The soft limit is why the TUI needs no overflow detection and never did: because it
+fetched every row, it knows the exact total and already says so —
+`"(Showing 100,000 of 3,412,887 Records)"` at `results_viewer.py:234`. That's strictly
+better than anything an inference could give it. My earlier suggestion that it show
+"100,000+" was wrong.
+
+**`hsql -l` is the hard limit.** Fetching a million rows to print five hundred would
+defeat the entire point of a limit for an agent — time, memory, and egress. There is also
+no viewport headless, so the soft limit has no meaning: `hsql` has exactly one limit
+concept, and it's the fetch-side one. Same flag name, different semantics between the two
+commands; the docs need one sentence about that rather than a pretense that they match.
+
+**Which is why truncation needs `limit + 1`.** `set_limit(n)` then `fetchall()` returns at
+most n rows and tells you nothing about whether an n+1th existed; exactly n is ambiguous.
+So `execute()` requests `limit + 1` and `fetch()` calls `create_backend(data, max_rows=limit)`.
+`DataTableBackend` already distinguishes `row_count` (capped) from `source_row_count`
+(what it was handed), so `truncated = source_row_count > row_count` — the mechanism
+exists, we just feed it one extra row. This is why the limit is a value object with an
+explicit `detect_overflow` rather than an `int` each caller interprets: principle 5 of the
+product plan ("truncation must always be announced — never silent") is unimplementable
+without it, and it costs exactly one row.
+
+The asymmetry is real and defensible: the TUI can afford to know the exact total because
+it already paid for every row; `hsql` deliberately hasn't, so it reports `500 of 500+`.
+Under `-l 0` there's no `set_limit` at all, so the count is exact and `--stats` reports
+`"truncated": false` against a real number.
 
 **No adapter-interface change for limits in M1.** The clean long-term answer is for the
 cursor to say whether more rows exist — a `has_more()`, or a `set_limit()` that reports
@@ -507,10 +531,29 @@ Two-phase parse, which is what obstacle 3 forces and what makes `hsql --help` ch
 2. Resolve the profile (a profile may name an adapter), pick the one adapter in play,
    `load_adapter(name)`, and build the real command with only that adapter's options.
 
-An invocation only ever uses one adapter, so this is not a compromise — and
-`hsql --help` showing one adapter's connection options instead of all four is *better*
-for an agent, not worse. `hsql --help -a postgres` shows postgres'; `hsql info --json`
-(M2) enumerates everything.
+An invocation only ever uses one adapter, so for *execution* this is not a compromise.
+
+**Help is the exception, and it works differently (Ted's call).** My earlier version had
+plain `hsql --help` render the default adapter's options, which is misleading: a Postgres
+user reading `hsql --help` would see DuckDB's connection options and reasonably conclude
+those were the only ones. `--help` is the one path that has to be true for every adapter.
+So:
+
+- **`hsql --help`** shows the adapter-agnostic surface — every option in §5 of the product
+  plan, the format list, the exit codes — plus the *names* of installed adapters and a
+  line saying `run 'hsql --help -a <adapter>' for its connection options`. No adapter is
+  imported to render this at all, only `adapter_names()`.
+- **`hsql --help -a postgres`** imports postgres alone and adds its connection options.
+- **`hsql --help -P prod`** does the same for whatever adapter the profile names, which is
+  the form a human will actually reach for.
+
+This is better than what I had on every axis: it's honest, the top-level help is small and
+stable (the thing an agent reads first), the adapter options are one explicitly signposted
+call away, and rendering the common case imports nothing. It also degrades well as the
+ecosystem grows — twenty installed adapters make the help *list* longer by twenty lines,
+not the help *body* by twenty option tables.
+
+`hsql info --json` (M2) remains the way to enumerate everything at once.
 
 `harlequin` itself keeps its current all-adapters help. Changing it would alter published
 `--help` output and the docs built from it, for no benefit to a TUI already paying for
@@ -675,23 +718,44 @@ Beyond that:
 - *Limits stay on the existing machinery.* `cursor.set_limit()` and the backend's
   `max_rows`, exactly as they are — no new adapter-interface method for truncation in M1
   (see §3.1).
-- *The TUI keeps its current row-count display.* `detect_overflow=False` there; only
-  `hsql` pays the extra row. No snapshot churn in PR 2.
+- *No overflow detection in the TUI.* It doesn't need any: `--limit` there is a soft
+  display cap over a full fetch, so it already reports the exact total (§3.1).
+  `detect_overflow=False`, no snapshot churn in PR 2.
 - *Streaming is out.* Not designed around, not partially built — see §3.3 and §7.
 - *`tree-sitter` and `tree-sitter-sql` become required dependencies.* One splitter, no
   fallback, the troubleshooting page retired (§3.2). Accepted cost: no install on
   platforms without a tree-sitter wheel.
+- *`--help` is adapter-agnostic*, listing adapter names and pointing at `--help -a X`
+  for connection options (§3.6). Ted's design; better than what I proposed.
+- *`--result` defaults to `all`, in every format* (below).
 
-**Still open.**
+### On `--result`
 
-1. **`hsql --help` showing only the selected adapter's options** — confirmed as an
-   improvement rather than a regression? It's what makes startup cost bounded, and I'd
-   want to make the same call even if it weren't.
-2. **`--result` default.** The product plan says `all` for text formats and `last` for
-   data formats. That's context-dependent behavior, which cuts against determinism. I'd
-   rather default to `all` everywhere and let `json`/`csv` emit multiple documents when a
-   script produces multiple result sets — but "csv with two headers in it" is genuinely
-   awkward, so the plan's version may be the lesser evil. Weak opinion.
+The flag only matters when one invocation produces more than one result set — `hsql -c
+"select 1; select 2"`, or the common `-f script.sql` shape of a few setup statements
+followed by the query you actually care about. `all` emits every result set; `last` emits
+only the final one; `N` picks one. With a single statement, which is most invocations,
+the flag does nothing.
+
+The product plan's proposal was `all` for text formats and `last` for data formats. The
+problem isn't the values, it's that the *same command* would emit different things
+depending on `-F`, which is exactly the context-dependence principle 4 exists to prevent.
+Agreed on consistency, so:
+
+**`--result all` is the default everywhere. Formats that can't hold multiple result sets
+say so rather than lying.** Concretely:
+
+- One result set: works in every format, no change.
+- Multiple, into `table` / `markdown` / `vertical` / `jsonl`: all of them, in order.
+- Multiple, into `csv` / `tsv` / `json`: **error, exit 2** —
+  `hsql: error: 3 result sets, but csv holds one; use --result last or --result 3`.
+
+Writing two headers into one CSV is silent corruption of the same family as silent
+truncation, and an error that names the fix costs an agent one retry with a clear signal.
+The alternative — silently defaulting to `last` — throws away data the user asked for
+without saying so.
+
+**Still open.** Nothing.
 
 ---
 
@@ -715,8 +779,8 @@ release.
 ## 8. Corrections to the product plan
 
 - **§4 says the full adapter option matrix on `hsql --help` is "unavoidable and shared."**
-  It's avoidable, via the two-phase parse in §3.6, and avoiding it is both a token saving
-  and the fix for the only unbounded startup cost.
+  It's avoidable. `hsql --help` lists adapter *names* and points at `--help -a X`, which
+  is both a token saving and the fix for the only unbounded startup cost (§3.6).
 - **§12 lists cold start as a risk with "may need lazy entry-point resolution."** Not a
   maybe: it's worth 160ms of a 380ms invocation with four adapters installed, and it
   grows without bound. A requirement of M1, not a contingency.
@@ -732,3 +796,14 @@ release.
   change to the cursor interface, and M1 doesn't design around it — `rows()` returns an
   iterator because that's the natural shape, not as a hedge. Agreed with Ted; the product
   plan's §5 bullet should move to M5 outright.
+- **§5's truncation footer says `… 500 of N rows`, and N is unknowable.** Under a hard
+  fetch limit we deliberately never learn the true total — that's the point of the limit.
+  The footer is `500 of 500+`, and only `-l 0` yields an exact count. (The TUI *can* say
+  `100,000 of 3,412,887` because its limit is a display cap over a full fetch; see §3.1.)
+- **§5 lists `--limit` as though it means the same thing in both commands.** It doesn't:
+  soft display cap in the TUI, hard fetch limit in `hsql`. Worth one explicit sentence in
+  the docs rather than letting a reader assume they match.
+- **§5's `--result` default is format-dependent** (`all` for text, `last` for data), which
+  makes the same command emit different things depending on `-F`. It's `all` everywhere,
+  with an error rather than silent corruption where a format can't hold more than one
+  result set (§6).

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -1,0 +1,492 @@
+# M1 Technical Plan — `hsql`, the headless CLI
+
+Implementation plan for milestone M1 of [Harlequin for agents](./harlequin-for-agents.md).
+That document is the product spec: what `hsql` is, why it's a separate command, and what
+its contract with an agent looks like. This one is about how we build it, what has to be
+refactored first, and in what order it can ship.
+
+**M1's scope, from the roadmap:** second console script; extract the shared execution
+core; import-linter rule and cold-start benchmark in CI; `-c`, `-f`, stdin, `-o`, `-F` +
+shorthands, default `--limit 500`, truncation notices, `--stats`, exit codes,
+`--on-error`, `--color`/`NO_COLOR`, plain errors; unknown-option hint on `harlequin`;
+the seeded "Headless & Agents" docs topic. Closes
+[#524](https://github.com/tconbeer/harlequin/issues/524).
+
+---
+
+## 1. Where the code actually is today
+
+Everything below was measured on this repo at `2.8.0`, not estimated.
+
+### 1.1 There is no execution core to share
+
+Query execution lives entirely inside the Textual app, as two threaded workers that
+communicate by posting messages:
+
+- `Harlequin._execute_query` (`src/harlequin/app.py:1077`) — loops over statements,
+  calls `connection.execute(q)`, applies `cur.set_limit(...)`, collects cursors, posts
+  `QueriesExecuted`.
+- `Harlequin._fetch_data` (`src/harlequin/app.py:1154`) — drains each cursor with
+  `fetchall()` + `columns()`, times the batch, posts `ResultsFetched`.
+
+There is no importable function. `hsql` cannot call any of this, and a naive copy is
+exactly the "two products" failure §12 of the product plan warns about.
+
+The split into *execute all, then fetch all* is deliberate and good — it's what lets the
+TUI show "query executed" before results materialize. The extracted core should preserve
+that shape rather than flatten it, so the TUI can adopt it without changing its
+concurrency model.
+
+`Harlequin._split_query_text` (`app.py:1135`) is a naive `text.split(";")`. **It is dead
+code** — nothing calls it. The live splitter is `CodeEditor.selected_queries()`
+(`components/code_editor.py:36`), which uses tree-sitter via textual-textarea and is
+therefore both correct and unavailable outside a running app. See §3.2.
+
+### 1.2 Cold start is 1.3 seconds, and the reason is structural
+
+```
+$ time harlequin --version
+harlequin, version 2.8.0
+real    0m1.335s
+```
+
+That is the cheapest possible invocation of the current CLI. The 300ms target in the
+product plan is not a matter of shaving milliseconds; four separate things each pull in
+the whole TUI:
+
+| # | Cause | Cost |
+| --- | --- | --- |
+| 1 | `harlequin/__init__.py` imports `harlequin.app` at module scope, so importing *any* `harlequin.*` submodule imports Textual, sqlfmt, prompt_toolkit and pyarrow | 660ms floor |
+| 2 | `harlequin/adapter.py:7` imports `textual_fastdatatable.backend` for `AutoBackendType`, which is `Any` | 265ms |
+| 3 | `harlequin/options.py` imports `questionary`, `textual.validation`, `textual.widget` and `harlequin.copy_widgets` at module scope, for `to_questionary()` and `to_widgets()` | 187ms |
+| 4 | `build_cli()` calls `load_adapter_plugins()`, which does `ep.load()` on **every installed adapter** to reach its `ADAPTER_OPTIONS` | 160ms for 4 adapters, unbounded |
+
+Cause 2 recurs in the adapters themselves: `harlequin_duckdb/adapter.py:14` and
+`harlequin_sqlite/adapter.py` both import `textual_fastdatatable.backend` at module
+scope, so even a perfectly clean `hsql` would pay for Textual the moment it loaded an
+adapter.
+
+`harlequin/catalog.py:6` imports `textual.message.Message` for `NewCatalog` and
+`NewCatalogItems` — two TUI-only messages sitting in a module every adapter imports.
+
+**I prototyped the fix and measured it.** With the package `__init__` made lazy
+(PEP 562 `__getattr__`), `AutoBackendType` moved under `TYPE_CHECKING` in core and in
+both first-party adapters, and the widget/questionary imports deferred into
+`to_widgets()` / `to_questionary()`:
+
+```
+headless core (adapter + options + config + plugins + rich_click):
+    115ms   textual=False  questionary=False  238 modules
++ harlequin_duckdb:
+     56ms   textual=False
+```
+
+~171ms plus ~16ms of interpreter startup. Against a floor of 161ms for the runtime
+dependencies `hsql` genuinely needs (click, tomlkit, platformdirs, duckdb, pyarrow),
+that leaves real headroom under 300ms. `from harlequin import Harlequin` still works
+after the change, which matters — it's the documented import for every third-party
+adapter.
+
+Cause 4 is not fixed by import hygiene; see §3.4.
+
+### 1.3 Two places already write results to stdout that shouldn't
+
+- `harlequin/plugins.py:54` — a bare `print()` when a plug-in fails to import. Under
+  `hsql -F csv > out.csv` that lands in the CSV.
+- `harlequin/exception.py:68` `pretty_print_warning` — uses `rich.print`, i.e. stdout.
+  Reached from `locale_manager.py` and `windows_timezone.py`, both on the CLI path.
+
+`pretty_print_error` already gets this right, with a comment saying why. The contract
+exists in intent; M1 makes it true.
+
+### 1.4 Export is coupled to a widget
+
+`harlequin/export.py:20` `copy()` takes a `ResultsTable` (a Textual widget) and reaches
+into `table.backend.source_data`. The five exporters underneath it are pure
+`pa.Table → file`. The column-deduplication step in between is data logic wearing a
+widget's clothes.
+
+---
+
+## 2. The four obstacles, stated plainly
+
+1. **No execution core exists.** It has to be extracted from the app before `hsql` can
+   have one, or we ship two implementations on day one.
+2. **Every import path leads to Textual.** Fixable, cheap, and measured — but it must
+   land before anything else, because it's also the guard that keeps the fix from
+   silently regressing.
+3. **Building the CLI requires importing every installed adapter.** The only unbounded
+   cost, and the only one that gets worse as the ecosystem grows.
+4. **Result rendering doesn't exist at all.** The TUI renders into a DataTable widget;
+   `export.py` writes columnar files via duckdb. Neither is a text formatter.
+
+---
+
+## 3. Target architecture
+
+Five new or reshaped libraries. Each owns a domain and has a stated interface; none of
+them is a bag of helpers.
+
+```
+harlequin/
+  query.py        NEW  execute SQL, get results, without a UI
+  formats.py      NEW  render a result set as text, incrementally
+  export.py       MOD  render a result set as a columnar file  (widget coupling removed)
+  config.py       MOD  + merging CLI values over a profile
+  plugins.py      MOD  + naming and loading one adapter without importing the rest
+  options.py      MOD  renderer imports deferred; declaration stays import-light
+  hsql/           NEW  the command
+    __init__.py        main()
+    cli.py             the click command and its two-phase adapter resolution
+    diagnostics.py     everything written to stderr, and the code we exit with
+```
+
+The one-line statement of the architecture, which is also a testable rule:
+
+> **stdout is written only by `harlequin.formats` and `harlequin.export`. stderr is
+> written only by `harlequin.hsql.diagnostics`.**
+
+### 3.1 `harlequin.query` — the execution core
+
+```python
+@dataclass(frozen=True)
+class Statement:
+    sql: str
+    index: int                 # 0-based position in the submitted script
+
+@dataclass(frozen=True)
+class RowLimit:
+    max_rows: int | None       # None = unlimited
+    detect_overflow: bool      # fetch one extra row so truncation is knowable
+
+@dataclass
+class ExecutedStatement:
+    statement: Statement
+    cursor: HarlequinCursor | None    # None for DDL/DML
+
+@dataclass
+class ResultSet:
+    statement: Statement
+    columns: list[tuple[str, str]]
+    row_count: int
+    truncated: bool
+    elapsed: float
+    def rows(self) -> Iterator[tuple[Any, ...]]: ...
+
+def split_statements(script: str) -> list[Statement]: ...
+def execute(
+    connection: HarlequinConnection,
+    statements: Sequence[Statement],
+    limit: RowLimit,
+    on_error: Literal["stop", "continue"] = "stop",
+) -> Iterator[ExecutedStatement]: ...
+def fetch(executed: ExecutedStatement, limit: RowLimit) -> ResultSet: ...
+```
+
+**`RowLimit` exists because truncation cannot otherwise be detected.** `set_limit(n)`
+followed by `fetchall()` returns *at most* n rows and tells you nothing about whether an
+n+1th existed. Getting exactly n rows is ambiguous. The only portable answer is to
+request `n + 1` and emit `n` — which is why the limit is a value object with an explicit
+`detect_overflow`, rather than an `int` that each caller handles its own way. It costs
+one row. Principle 5 of the product plan ("truncation must always be announced — never
+silent") is unimplementable without it.
+
+**`ResultSet.rows()` is where adapter output gets normalized.** `HarlequinCursor.fetchall()`
+returns `AutoBackendType`, which is `Any` — in practice a `pa.Table` (duckdb), a
+`RecordBatch`, a `Sequence[Iterable]` (sqlite), a `Mapping[str, Sequence]`, or a polars
+or pandas frame. Today `textual_fastdatatable.create_backend()` does this normalization,
+and it costs 265ms and imports Textual. `hsql` needs its own, and it belongs next to the
+result type rather than inside a formatter, so that every format gets identical row
+semantics. Deliberately an `Iterator`: it is the seam that lets M5 turn `ResultSet` into
+a stream of batches without touching any formatter.
+
+The TUI's two workers become thin wrappers: `_execute_query` calls `execute()`,
+`_fetch_data` calls `fetch()`, both still post the same messages. Both keep their
+`AutoBackendType` payload for the DataTable — the TUI never calls `rows()`.
+
+### 3.2 Statement splitting
+
+`hsql -f script.sql` needs to split SQL outside a running Textual app, and `;` inside a
+string literal is not hypothetical in real scripts.
+
+Three options: naive `;` split (wrong), reuse sqlfmt's lexer (already a dependency,
+~85ms, polyglot), or a conservative hand-rolled scanner that understands single and
+double quotes, dollar-quoting, and line and block comments (~60 lines, no new import,
+covers everything a script realistically contains).
+
+**Recommendation: spike sqlfmt's lexer first; fall back to the scanner.** sqlfmt is
+already a hard dependency and already maintained for exactly this class of problem, so
+if its analyzer can hand us top-level semicolon positions, that's strictly better than a
+second SQL scanner in this codebase. Budget half a day; if the answer isn't clean, write
+the scanner.
+
+**The TUI keeps its tree-sitter splitter.** It's more accurate and it's already there.
+That means two splitters, which is a drift risk — mitigated concretely by a **shared
+fixture corpus of tricky SQL** that both are tested against, so they can't diverge
+without a test failing. I'd rather have one honest, tested divergence than force the TUI
+onto a worse splitter for the sake of a symmetry nobody benefits from.
+
+### 3.3 `harlequin.formats` — text rendering
+
+```python
+@dataclass(frozen=True)
+class RenderOptions:
+    header: bool = True
+    footer: bool = True
+    aligned: bool = True
+    null_string: str | None = None    # None = per-format default
+    color: bool = False
+
+class ResultWriter(Protocol):
+    def write_result(self, result: ResultSet, out: TextIO) -> None: ...
+
+def get_writer(name: str, options: RenderOptions) -> ResultWriter: ...
+def format_names() -> list[str]: ...
+```
+
+Formats: `table`, `markdown`/`md`, `csv`, `tsv`, `json`, `jsonl`/`ndjson`, `vertical`,
+`none`. Columnar formats (`parquet`, `arrow`, `orc`) route to `export.py` instead, which
+needs a path and a materialized table.
+
+`RenderOptions` is what makes psql's flag algebra fall out for free: `-t` is
+`header=False, footer=False`, `-A` is `aligned=False`, and `-tA` needs no special case
+because it was never a special case — it's two independent options, which is exactly how
+psql users already think about it.
+
+**`table` cannot stream** — column widths require seeing every row. `csv`, `tsv`,
+`jsonl`, `vertical` can. That's inherent, not a defect; the Protocol is defined over a
+`ResultSet` whose `rows()` is an iterator, so the streaming formats are already written
+in the shape M5 needs.
+
+**Newlines are part of the contract.** Python text mode translates `\n` to `\r\n` on
+Windows, which would make `hsql -F csv` produce different bytes per platform and break
+determinism (principle 4). Every writer opens with `newline=""` and emits `\n`, and
+there's a test for it.
+
+**One accepted overlap:** `export.py` writes CSV via duckdb for the TUI's export dialog;
+`formats.py` writes CSV via the stdlib for `hsql`. Two CSV writers. Unifying them means
+either making the TUI's export dialog options (compression, quoting, encoding) part of
+the streaming path or dropping them, and neither is M1's business. Noted so it's a
+decision rather than an accident; revisit in M5.
+
+### 3.4 `harlequin.plugins` — naming an adapter without importing it
+
+```python
+def adapter_names() -> list[str]: ...                        # entry-point names only
+def load_adapter(name: str) -> type[HarlequinAdapter]: ...   # imports exactly one
+def load_adapter_plugins() -> dict[str, type[HarlequinAdapter]]: ...   # existing
+```
+
+`adapter_names()` reads entry-point *names* without calling `ep.load()`, so it costs
+nothing. That's what makes the two-phase parse in §3.6 possible, and it's the fix for
+obstacle 3.
+
+### 3.5 `harlequin.config` — merging CLI values over a profile
+
+The merge in `cli.py:315-327` (drop every parameter whose click source is `DEFAULT`,
+then `config.update(kwargs)`) is the precedence rule both commands must implement
+identically. It moves to `config.py`, which already owns `Profile`:
+
+```python
+def merge_profile_with_cli(
+    profile: Profile,
+    cli_values: Mapping[str, Any],
+    explicitly_set: Container[str],
+) -> Profile: ...
+```
+
+`explicitly_set` rather than a click `Context`, so the config library stays free of the
+CLI framework and is testable without one.
+
+Adapter *instantiation* stays in each command — it's five lines, and the two commands
+handle its failure differently (Rich panel and exit 2 vs. a plain line and exit 2). We
+share the precedence rule, which is the part that would drift; we don't share five lines
+of error handling that legitimately differ.
+
+### 3.6 `harlequin.hsql` — the command
+
+Two-phase parse, which is what obstacle 3 forces and what makes `hsql --help` cheap:
+
+1. Parse with `resilient_parsing` to find `-a/--adapter` and `-P/--profile`, using
+   `adapter_names()` — no adapter imported.
+2. Resolve the profile (a profile may name an adapter), pick the one adapter in play,
+   `load_adapter(name)`, and build the real command with only that adapter's options.
+
+An invocation only ever uses one adapter, so this is not a compromise — and
+`hsql --help` showing one adapter's connection options instead of all four is *better*
+for an agent, not worse. `hsql --help -a postgres` shows postgres'; `hsql info --json`
+(M2) enumerates everything.
+
+This contradicts one line in the product plan (§4: "It still carries the full adapter
+connection-option matrix; that's unavoidable and shared"). It turns out to be avoidable,
+and avoiding it is both a token saving and the fix for the unbounded startup cost. See
+§8.
+
+`harlequin` itself keeps its current all-adapters help. Changing it would alter published
+`--help` output and the docs built from it, for no benefit to a TUI that's already paying
+for Textual.
+
+`diagnostics.py` owns the stderr contract:
+
+```python
+class ExitCode(IntEnum):
+    OK = 0; QUERY = 1; USAGE = 2; CONNECTION = 3; TIMEOUT = 4; INTERRUPT = 130
+
+def exit_code_for(error: BaseException) -> ExitCode: ...
+def report_error(error: BaseException) -> None:          # "hsql: error: ..."
+def report_truncation(result: ResultSet, limit: RowLimit) -> None:
+def report_stats(...) -> None:                            # one line of JSON
+```
+
+Two things worth stating because they're easy to get wrong:
+
+- **The truncation notice fires under `-t`.** `-t` suppresses stdout chrome; it does not
+  suppress warnings. A flag that silently defeats truncation reporting would undo the
+  principle it's meant to coexist with.
+- **Exit codes are hsql's contract, not Harlequin's**, so the mapping lives here rather
+  than in `harlequin.exception`. `HarlequinQueryError → 1`, `HarlequinConnectionError → 3`,
+  `HarlequinConfigError → 2`, `KeyboardInterrupt → 130`.
+
+---
+
+## 4. Sequencing
+
+Two releases. The first contains no new user-facing surface at all; the second is the
+feature. Every PR in the first release is independently reviewable, independently
+testable, and behavior-neutral for the TUI.
+
+### Release A — the plumbing (2.9)
+
+**PR 1 — Import hygiene, and the guard that keeps it.**
+Lazy `harlequin/__init__.py` via PEP 562 `__getattr__`, preserving every current name.
+`AutoBackendType` under `TYPE_CHECKING` in `adapter.py`, `harlequin_duckdb`,
+`harlequin_sqlite`. `NewCatalog`/`NewCatalogItems` move to `harlequin/messages.py`, with
+a module-level `__getattr__` shim in `catalog.py` so existing imports keep working
+without importing Textual. Deferred renderer imports in `options.py`; `_CustomValidator`
+moves to `copy_widgets.py`, which is already the option-widgets library. Fix the two
+stdout leaks from §1.3. Add import-linter contracts and the cold-start benchmark script.
+
+Ships value on its own: importing `harlequin_duckdb` goes from 691ms to 56ms, which
+every adapter's test suite and every library consumer feels.
+
+**PR 2 — `harlequin.query`.** Extract the core; refactor `_execute_query` and
+`_fetch_data` onto it; delete the dead `_split_query_text`; land the splitter and its
+tricky-SQL corpus. Snapshot tests are the safety net for the TUI refactor.
+
+**PR 3 — `harlequin.formats`, and `export.py` decoupled from `ResultsTable`.** Golden
+files per format. No user-visible change; `formats.py` has no consumer until PR 5.
+
+**PR 4 — `merge_profile_with_cli`, `adapter_names`, `load_adapter`.** `harlequin`'s own
+CLI refactored onto the first; behavior-neutral, covered by the existing 392 lines of
+`test_cli.py`.
+
+*Why these land on main rather than accumulating on a feature branch:* they're
+behavior-neutral and individually tested, and the alternative is a long-lived branch
+rebasing against a moving TUI — which is where extraction refactors go to die.
+
+### Release B — the command (2.10)
+
+**PR 5 — `hsql`.** Console script, two-phase parse, `-c`/`-f`/stdin, `-o`, `-F` and the
+shorthands, `-t`/`-A`/`--no-header`/`--null-string`, `-P`, `-l` defaulting to 500,
+`--result`, `--on-error`, `--color`/`NO_COLOR`, `--stats`, exit codes, truncation
+notices, plain errors.
+
+**PR 6 — Discoverability.** Unknown-option handler on `harlequin` (`-c` → "did you mean
+`hsql -c`?"), and the `-t nord` hint on `hsql` when an unparseable conn_str matches a
+known theme name.
+
+**PR 7 — Docs.** The "Headless & Agents" topic (a PR against `tconbeer/harlequin-web`),
+README, changelog.
+
+**PR 8 — The agent eval suite.** Three tasks against fixture databases, scored on
+wrong-flag retries and completion. §13 of the product plan calls this the metric that
+actually matters; three tasks is enough to start and to expand against.
+
+**Ordering rationale.** Everything the output contract touches ships at once, in PR 5.
+The product plan's premise is that format and exit codes are a frozen API — a
+half-shipped `hsql -c` that we "improve later" is the one thing here that can't be
+undone. Internals can be improved after release; the contract can't.
+
+---
+
+## 5. Testing
+
+**Deterministic guards, not timing assertions.** The cold-start number is the headline,
+but a wall-clock assertion on a shared CI runner is a flaky test that gets deleted within
+a month. So:
+
+- *Deterministic and blocking:* import-linter contracts — the `hsql` module graph must
+  not contain `textual`, `questionary`, or `textual_fastdatatable`. Plus a subprocess
+  test asserting `"textual" not in sys.modules` after importing the headless core. Both
+  fail identically on every machine.
+- *Informational:* the benchmark reports `hsql -c "select 1"` against DuckDB into the
+  job summary, and fails only past a loose ceiling (600ms) that catches a real
+  regression without catching a busy runner.
+
+The import contract is the load-bearing one. Timing is downstream of it.
+
+Beyond that:
+
+- **`CliRunner` tests** for `hsql`, following the existing `test_cli.py` patterns and
+  its adapter-mocking fixtures.
+- **Golden files** per format against a fixture result set with nulls, unicode, wide
+  values, duplicate column names, and zero rows. Zero rows is the case that separates
+  "the query returned nothing" from "the query failed" — A3 in the product plan — and
+  it's the one most likely to be wrong in a format nobody exercised.
+- **stdout purity:** for each format, assert stdout bytes are identical with and without
+  `--stats`, and that a query error leaves stdout completely empty.
+- **Determinism:** identical bytes whether stdout is a pipe, a file, or a pty; `\n`
+  regardless of platform.
+- **`hsql -tAc "select count(*)"` returning a bare number and nothing else** as its own
+  named test. It's the idiom the scripting audience will try first.
+- **Truncation:** exactly-at-limit, one-over-limit, and under-limit, on both duckdb and
+  sqlite — the two adapters implement `set_limit` differently enough to matter.
+- **The tricky-SQL corpus** against both splitters.
+
+---
+
+## 6. Decisions I need from you
+
+1. **Should the TUI adopt overflow detection?** The core can tell the TUI that its
+   100,000-row limit bit, and it could show "100,000+ rows" instead of "100,000 rows".
+   More honest, costs one row, but it's a visible TUI change and it moves snapshots. My
+   inclination is yes, in PR 2 — but it's your product. Default if you don't care: leave
+   the TUI's display alone, `detect_overflow=False` there.
+2. **`hsql --help` showing only the selected adapter's options** — confirmed as an
+   improvement rather than a regression? It's what makes the startup cost bounded, and
+   I'd want to make the same call even if it weren't.
+3. **`--result` default.** The product plan says `all` for text formats and `last` for
+   data formats. That's context-dependent behavior, which cuts against determinism. I'd
+   rather default to `all` everywhere and let `json`/`csv` emit multiple documents when a
+   script produces multiple result sets — but "csv with two headers in it" is genuinely
+   awkward, so the plan's version may be the lesser evil. Weak opinion.
+4. **Splitter spike** — half a day on sqlfmt's lexer before hand-rolling. Confirm that's
+   worth the time, or say "just write the scanner" and I'll write the scanner.
+
+---
+
+## 7. Explicitly not in M1
+
+`--read-only`, `--timeout`, `--dry-run`, `--single-transaction` (M2 — the first three
+need adapter-interface additions and an ecosystem rollout). Every subcommand: `catalog`,
+`describe`, `fmt`, `spec`, `info`, `config`, `history`, `open`, `mcp`. Real streaming
+(M5 — designed for, not built). A separate lean `hsql` distribution (§4 of the product
+plan: near-reversible, indefinitely deferrable).
+
+Bare `hsql` with no arguments prints help and never launches the TUI, from the first
+release.
+
+---
+
+## 8. Corrections to the product plan
+
+- **§4 says the full adapter option matrix on `hsql --help` is "unavoidable and shared."**
+  It's avoidable, via the two-phase parse in §3.6, and avoiding it is both a token saving
+  and the fix for the only unbounded startup cost. The product plan should be amended.
+- **§12 lists cold start as a risk with "may need lazy entry-point resolution."** It's not
+  a maybe. `load_adapter_plugins()` imports every installed adapter on every invocation —
+  160ms with four installed, growing without bound. Lazy resolution is a requirement of
+  M1, not a contingency.
+- **§5's truncation guarantee needs the limit+1 fetch to be implementable at all.** Worth
+  stating in the product plan, because it's the kind of thing that gets designed out as
+  an implementation detail and then quietly breaks the promise.

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -12,6 +12,13 @@ shorthands, default `--limit 500`, truncation notices, `--stats`, exit codes,
 the seeded "Headless & Agents" docs topic. Closes
 [#524](https://github.com/tconbeer/harlequin/issues/524).
 
+**Bottom line up front.** A working prototype of the refactors below runs a
+`select … union all select …` against DuckDB — interpreter startup, config discovery,
+adapter load, connect, execute, fetch, normalize, render — in **220–242ms with Textual
+never imported**, down from a 1335ms floor today. Nothing in M1 needs new normalization
+or parsing code: the two hard pieces already exist in `textual-fastdatatable` and
+`tree-sitter-sql`, and both can be reached without Textual.
+
 ---
 
 ## 1. Where the code actually is today
@@ -39,10 +46,10 @@ concurrency model.
 
 `Harlequin._split_query_text` (`app.py:1135`) is a naive `text.split(";")`. **It is dead
 code** — nothing calls it. The live splitter is `CodeEditor.selected_queries()`
-(`components/code_editor.py:36`), which uses tree-sitter via textual-textarea and is
-therefore both correct and unavailable outside a running app. See §3.2.
+(`components/code_editor.py:36`), which uses tree-sitter through textual-textarea. See
+§3.2 — the grammar it uses is reachable without any of that.
 
-### 1.2 Cold start is 1.3 seconds, and the reason is structural
+### 1.2 Cold start is 1.3 seconds, and the reasons are structural
 
 ```
 $ time harlequin --version
@@ -50,16 +57,16 @@ harlequin, version 2.8.0
 real    0m1.335s
 ```
 
-That is the cheapest possible invocation of the current CLI. The 300ms target in the
-product plan is not a matter of shaving milliseconds; four separate things each pull in
-the whole TUI:
+That is the cheapest possible invocation of the current CLI. The 300ms target is not a
+matter of shaving milliseconds; five separate things each pull in the whole TUI:
 
 | # | Cause | Cost |
 | --- | --- | --- |
 | 1 | `harlequin/__init__.py` imports `harlequin.app` at module scope, so importing *any* `harlequin.*` submodule imports Textual, sqlfmt, prompt_toolkit and pyarrow | 660ms floor |
 | 2 | `harlequin/adapter.py:7` imports `textual_fastdatatable.backend` for `AutoBackendType`, which is `Any` | 265ms |
-| 3 | `harlequin/options.py` imports `questionary`, `textual.validation`, `textual.widget` and `harlequin.copy_widgets` at module scope, for `to_questionary()` and `to_widgets()` | 187ms |
-| 4 | `build_cli()` calls `load_adapter_plugins()`, which does `ep.load()` on **every installed adapter** to reach its `ADAPTER_OPTIONS` | 160ms for 4 adapters, unbounded |
+| 3 | `textual_fastdatatable/__init__.py` imports the `DataTable` widget, so the backend can't be reached without Textual | 58ms + 158 modules of the 265ms above |
+| 4 | `harlequin/options.py` imports `questionary`, `textual.validation`, `textual.widget` and `harlequin.copy_widgets` at module scope, for `to_questionary()` and `to_widgets()` | 187ms |
+| 5 | `build_cli()` calls `load_adapter_plugins()`, which does `ep.load()` on **every installed adapter** to reach its `ADAPTER_OPTIONS` | 160ms for 4 adapters, unbounded |
 
 Cause 2 recurs in the adapters themselves: `harlequin_duckdb/adapter.py:14` and
 `harlequin_sqlite/adapter.py` both import `textual_fastdatatable.backend` at module
@@ -68,28 +75,38 @@ adapter.
 
 `harlequin/catalog.py:6` imports `textual.message.Message` for `NewCatalog` and
 `NewCatalogItems` — two TUI-only messages sitting in a module every adapter imports.
+Neither is used outside `app.py` and `components/data_catalog/database_tree.py`.
 
-**I prototyped the fix and measured it.** With the package `__init__` made lazy
-(PEP 562 `__getattr__`), `AutoBackendType` moved under `TYPE_CHECKING` in core and in
-both first-party adapters, and the widget/questionary imports deferred into
-`to_widgets()` / `to_questionary()`:
+### 1.3 `textual-fastdatatable` is ours, and its backend has no Textual in it
 
-```
-headless core (adapter + options + config + plugins + rich_click):
-    115ms   textual=False  questionary=False  238 modules
-+ harlequin_duckdb:
-     56ms   textual=False
-```
+We control this package, which changes the answer to the hardest problem in M1 (§3.1).
+Measured on the installed 0.16.0:
 
-~171ms plus ~16ms of interpreter startup. Against a floor of 161ms for the runtime
-dependencies `hsql` genuinely needs (click, tomlkit, platformdirs, duckdb, pyarrow),
-that leaves real headroom under 300ms. `from harlequin import Harlequin` still works
-after the change, which matters — it's the documented import for every third-party
-adapter.
+- `backend.py`, `format.py`, and `column.py` contain **zero references to Textual**. The
+  imports are pyarrow and rich.
+- The only thing that pulls Textual is `textual_fastdatatable/__init__.py` importing
+  `data_table.DataTable`.
+- With that `__init__` made lazy: `from textual_fastdatatable.backend import create_backend`
+  drops from 265ms/359 modules/Textual to **217ms/201 modules/no Textual**.
+- Most of the remainder is `pyarrow.parquet`, imported at module scope but used only by
+  `ArrowBackend.from_parquet`. Deferring it into that classmethod takes the import to
+  **~140ms/183 modules**.
+- `textual>=7.3.0` is a *required* dist dependency. Nothing in the backend uses it. A
+  future lean `hsql` install would need that made an extra.
 
-Cause 4 is not fixed by import hygiene; see §3.4.
+### 1.4 tree-sitter is already installed, and usable without Textual
 
-### 1.3 Two places already write results to stdout that shouldn't
+`textual-textarea` requires `textual[syntax]`, which brings `tree-sitter` and
+`tree-sitter-sql`. The editor's separator query is one line
+(`code_editor.py:22`): `(";" @semicolon)`.
+
+Driving that grammar directly, with no Textual and no textual-textarea, measures at
+**28ms to import, 92 modules**, and 22ms to split a 2000-statement script. It gets
+string literals, line comments, block comments, quoted identifiers and unicode right.
+It gets `$$`-dollar-quoting wrong — and so does the TUI today, because it's the same
+grammar and the same query. See §3.2.
+
+### 1.5 Two places already write results to stdout that shouldn't
 
 - `harlequin/plugins.py:54` — a bare `print()` when a plug-in fails to import. Under
   `hsql -F csv > out.csv` that lands in the CSV.
@@ -99,12 +116,28 @@ Cause 4 is not fixed by import hygiene; see §3.4.
 `pretty_print_error` already gets this right, with a comment saying why. The contract
 exists in intent; M1 makes it true.
 
-### 1.4 Export is coupled to a widget
+### 1.6 Export is coupled to a widget
 
 `harlequin/export.py:20` `copy()` takes a `ResultsTable` (a Textual widget) and reaches
 into `table.backend.source_data`. The five exporters underneath it are pure
 `pa.Table → file`. The column-deduplication step in between is data logic wearing a
 widget's clothes.
+
+### 1.7 The prototype
+
+I applied the §1.2 fixes plus the §1.3 upstream fixes and ran a script that does what
+`hsql -c` will do — config discovery, single-adapter load, connect, execute with
+`set_limit(limit + 1)`, `create_backend(data, max_rows=limit)`, write CSV to stdout:
+
+```
+220ms  238ms  242ms      textual=False   306 modules
+```
+
+With `load_adapter_plugins()` left as-is (all four installed adapters imported) the same
+script takes 377–398ms — which is cause 5 measured in situ, and the reason §3.4 is not
+optional. `from harlequin import Harlequin` and `from textual_fastdatatable import DataTable`
+both still work after the changes; those are load-bearing for third-party adapters and
+for the TUI respectively. All patches were reverted.
 
 ---
 
@@ -112,26 +145,35 @@ widget's clothes.
 
 1. **No execution core exists.** It has to be extracted from the app before `hsql` can
    have one, or we ship two implementations on day one.
-2. **Every import path leads to Textual.** Fixable, cheap, and measured — but it must
-   land before anything else, because it's also the guard that keeps the fix from
-   silently regressing.
+2. **Every import path leads to Textual** — in this repo *and* one level upstream.
+   Fixable, cheap, measured; it must land first, because it's also the guard that keeps
+   the fix from silently regressing.
 3. **Building the CLI requires importing every installed adapter.** The only unbounded
    cost, and the only one that gets worse as the ecosystem grows.
-4. **Result rendering doesn't exist at all.** The TUI renders into a DataTable widget;
+4. **Result rendering doesn't exist.** The TUI renders into a DataTable widget;
    `export.py` writes columnar files via duckdb. Neither is a text formatter.
+
+Note what is *not* on this list: normalizing adapter output, and parsing SQL into
+statements. Both looked like new subsystems and turned out to be existing ones we
+already own.
 
 ---
 
 ## 3. Target architecture
 
-Five new or reshaped libraries. Each owns a domain and has a stated interface; none of
-them is a bag of helpers.
+Six new or reshaped libraries, plus one upstream change. Each owns a domain and has a
+stated interface; none of them is a bag of helpers.
 
 ```
+textual-fastdatatable
+  __init__.py     MOD  lazy DataTable, so `backend` is reachable without Textual
+  backend.py      MOD  pyarrow.parquet deferred into from_parquet()
+
 harlequin/
+  statements.py   NEW  locating statement boundaries in SQL text
   query.py        NEW  execute SQL, get results, without a UI
-  formats.py      NEW  render a result set as text, incrementally
-  export.py       MOD  render a result set as a columnar file  (widget coupling removed)
+  formats.py      NEW  serialize a result set as text, incrementally
+  export.py       MOD  serialize a result set as a columnar file  (widget coupling gone)
   config.py       MOD  + merging CLI values over a profile
   plugins.py      MOD  + naming and loading one adapter without importing the rest
   options.py      MOD  renderer imports deferred; declaration stays import-light
@@ -146,7 +188,7 @@ The one-line statement of the architecture, which is also a testable rule:
 > **stdout is written only by `harlequin.formats` and `harlequin.export`. stderr is
 > written only by `harlequin.hsql.diagnostics`.**
 
-### 3.1 `harlequin.query` — the execution core
+### 3.1 `harlequin.query` — the execution core, over the existing backend
 
 ```python
 @dataclass(frozen=True)
@@ -167,13 +209,14 @@ class ExecutedStatement:
 @dataclass
 class ResultSet:
     statement: Statement
-    columns: list[tuple[str, str]]
-    row_count: int
+    columns: list[tuple[str, str]]    # (name, short type) from cursor.columns()
+    backend: DataTableBackend         # from textual_fastdatatable
     truncated: bool
     elapsed: float
-    def rows(self) -> Iterator[tuple[Any, ...]]: ...
+    @property
+    def row_count(self) -> int: ...   # backend.row_count
+    def rows(self) -> Iterator[Sequence[Any]]: ...
 
-def split_statements(script: str) -> list[Statement]: ...
 def execute(
     connection: HarlequinConnection,
     statements: Sequence[Statement],
@@ -183,50 +226,82 @@ def execute(
 def fetch(executed: ExecutedStatement, limit: RowLimit) -> ResultSet: ...
 ```
 
-**`RowLimit` exists because truncation cannot otherwise be detected.** `set_limit(n)`
-followed by `fetchall()` returns *at most* n rows and tells you nothing about whether an
-n+1th existed. Getting exactly n rows is ambiguous. The only portable answer is to
-request `n + 1` and emit `n` — which is why the limit is a value object with an explicit
-`detect_overflow`, rather than an `int` that each caller handles its own way. It costs
-one row. Principle 5 of the product plan ("truncation must always be announced — never
-silent") is unimplementable without it.
+**`ResultSet` wraps a `DataTableBackend` rather than reimplementing one.**
+`HarlequinCursor.fetchall()` returns `AutoBackendType`, which is `Any` — in practice a
+`pa.Table` (duckdb), a `RecordBatch`, a `Sequence[Iterable]` (sqlite), a
+`Mapping[str, Sequence]`, or a polars or pandas frame. `create_backend()` already
+normalizes all of those, it is the normalization the TUI uses, and per §1.3 it needs no
+Textual to run. Writing a second normalizer for `hsql` would put the most drift-prone
+code in the codebase — "what counts as a row, what counts as null, how does a nested
+struct come out" — in two places, and the disagreement would surface as `hsql` and the
+TUI showing different data for the same query. That is the worst possible place for
+these two front doors to diverge.
 
-**`ResultSet.rows()` is where adapter output gets normalized.** `HarlequinCursor.fetchall()`
-returns `AutoBackendType`, which is `Any` — in practice a `pa.Table` (duckdb), a
-`RecordBatch`, a `Sequence[Iterable]` (sqlite), a `Mapping[str, Sequence]`, or a polars
-or pandas frame. Today `textual_fastdatatable.create_backend()` does this normalization,
-and it costs 265ms and imports Textual. `hsql` needs its own, and it belongs next to the
-result type rather than inside a formatter, so that every format gets identical row
-semantics. Deliberately an `Iterator`: it is the seam that lets M5 turn `ResultSet` into
-a stream of batches without touching any formatter.
+**Truncation falls out of the backend's `max_rows`, and needs `limit + 1` at the cursor.**
+`set_limit(n)` then `fetchall()` returns at most n rows and tells you nothing about
+whether an n+1th existed; exactly n is ambiguous. So `execute()` requests `limit + 1`,
+and `fetch()` calls `create_backend(data, max_rows=limit)`. `DataTableBackend` already
+distinguishes `row_count` (capped) from `source_row_count` (what it was handed), so
+`truncated = source_row_count > row_count` — the mechanism exists, we just have to feed
+it one extra row. This is why the limit is a value object with an explicit
+`detect_overflow` rather than an `int` each caller interprets: principle 5 of the product
+plan ("truncation must always be announced — never silent") is unimplementable without
+it, and it costs exactly one row.
+
+**Upstream first.** The two `textual-fastdatatable` changes in §3 are a prerequisite, and
+both are non-breaking: the lazy `__init__` keeps `from textual_fastdatatable import DataTable`
+working via PEP 562 `__getattr__`, and deferring `pyarrow.parquet` is invisible to
+callers. Making `textual` an optional extra is a bigger change — it would let a future
+lean `hsql` install skip Textual entirely, but it's a dependency break for existing
+users and buys M1 nothing, since `harlequin` needs Textual regardless. Deferred.
 
 The TUI's two workers become thin wrappers: `_execute_query` calls `execute()`,
-`_fetch_data` calls `fetch()`, both still post the same messages. Both keep their
-`AutoBackendType` payload for the DataTable — the TUI never calls `rows()`.
+`_fetch_data` calls `fetch()`, both still post the same messages, and the DataTable gets
+the same backend object it builds today.
 
-### 3.2 Statement splitting
+### 3.2 `harlequin.statements` — one grammar, one query, two slicers
 
-`hsql -f script.sql` needs to split SQL outside a running Textual app, and `;` inside a
-string literal is not hypothetical in real scripts.
+Driving tree-sitter directly (§1.4) is better than every alternative I costed: 28ms
+against sqlfmt's 85ms, no new SQL scanner to maintain, and — the part that matters —
+**it is the same grammar and the same query the TUI already uses**, so `hsql -f script.sql`
+and the editor cannot disagree about where a statement ends.
 
-Three options: naive `;` split (wrong), reuse sqlfmt's lexer (already a dependency,
-~85ms, polyglot), or a conservative hand-rolled scanner that understands single and
-double quotes, dollar-quoting, and line and block comments (~60 lines, no new import,
-covers everything a script realistically contains).
+```python
+SEMICOLON_QUERY = '(";" @semicolon)'          # one definition, both consumers
 
-**Recommendation: spike sqlfmt's lexer first; fall back to the scanner.** sqlfmt is
-already a hard dependency and already maintained for exactly this class of problem, so
-if its analyzer can hand us top-level semicolon positions, that's strictly better than a
-second SQL scanner in this codebase. Budget half a day; if the answer isn't clean, write
-the scanner.
+def tree_sitter_available() -> bool: ...
+def find_separators(text: str) -> list[int]: ...   # offset just past each separator
+def split(text: str) -> list[Statement]: ...       # separators -> trimmed statements
+```
 
-**The TUI keeps its tree-sitter splitter.** It's more accurate and it's already there.
-That means two splitters, which is a drift risk — mitigated concretely by a **shared
-fixture corpus of tricky SQL** that both are tested against, so they can't diverge
-without a test failing. I'd rather have one honest, tested divergence than force the TUI
-onto a worse splitter for the sake of a symmetry nobody benefits from.
+The editor keeps its own path, and that's correct rather than a compromise:
+`selected_queries()` needs to know which statements *intersect the selection*, so it
+works in `(row, column)` Locations against textual-textarea's already-parsed incremental
+tree. Reparsing the buffer through a second parser would be slower and no more accurate.
+What it stops owning is the query pattern and the fallback policy, which it imports from
+here. So: one grammar, one query constant, one definition of "empty statement", two
+slicers because there are genuinely two coordinate systems — and a shared fixture corpus
+of tricky SQL that both are tested against.
 
-### 3.3 `harlequin.formats` — text rendering
+**Two honest caveats.**
+
+*tree-sitter is optional.* It arrives via `textual[syntax]`, so in practice every
+Harlequin install has it, but the TUI has an explicit degraded path
+(`is_syntax_aware == False` → naive regex split plus a warning toast) because
+tree-sitter wheels aren't available everywhere — that's what the
+`harlequin.sh/docs/troubleshooting/tree-sitter` page is for. `hsql` mirrors it: naive
+split, plus a stderr warning saying that statement splitting may be wrong without
+tree-sitter. Promoting `tree-sitter`/`tree-sitter-sql` to hard dependencies of
+`harlequin` would delete the degraded path for everyone and is tempting at 28ms, but it
+would break installs on platforms without wheels. See §6.
+
+*Dollar-quoting is wrong.* `create function f() … $$ … ; … $$ …` splits inside the
+function body. The TUI has this bug today, identically, because it's the grammar's. It
+should be its own issue rather than M1 scope — and it's a good demonstration that
+sharing the grammar means `hsql` inherits the TUI's behavior including its bugs, which
+is the definition of no drift.
+
+### 3.3 `harlequin.formats` — serialization, deliberately not display
 
 ```python
 @dataclass(frozen=True)
@@ -245,13 +320,31 @@ def format_names() -> list[str]: ...
 ```
 
 Formats: `table`, `markdown`/`md`, `csv`, `tsv`, `json`, `jsonl`/`ndjson`, `vertical`,
-`none`. Columnar formats (`parquet`, `arrow`, `orc`) route to `export.py` instead, which
-needs a path and a materialized table.
+`none`. Columnar formats (`parquet`, `arrow`, `orc`) route to `export.py`, which needs a
+path and a materialized table.
 
 `RenderOptions` is what makes psql's flag algebra fall out for free: `-t` is
 `header=False, footer=False`, `-A` is `aligned=False`, and `-tA` needs no special case
-because it was never a special case — it's two independent options, which is exactly how
-psql users already think about it.
+because it was never a special case — two independent options, which is how psql users
+already think about them.
+
+**`hsql` never calls `cell_formatter`, and this is the one place we deliberately do not
+reuse the TUI's code.** `textual_fastdatatable.format.cell_formatter` is *display*
+formatting: it renders floats and ints as `f"{obj:n}"` (locale-aware thousands
+separators), booleans as `✓ True`, and strings as Rich markup. Correct for a data table
+a human is reading; catastrophic in a CSV. Serialization and display are different
+operations and conflating them is how `1,234,567` ends up in a numeric column.
+`hsql -F table` prints `1234567`, same as psql.
+
+The corollary is a live trap: **`hsql` must not call `set_locale()`.** The `harlequin`
+CLI does (`cli.py:339`), and inheriting it would make output vary with `LC_ALL` — a
+direct violation of principle 4's "identical output" promise, and one that would only
+show up on someone else's machine.
+
+For the same reason `hsql` computes its own column widths for `-F table`, rather than
+reusing `backend.column_content_widths`: that measures the *displayed* width of values
+we're not going to display that way. `max(len(s))` over the strings we actually emit is
+trivial and guaranteed consistent with the output.
 
 **`table` cannot stream** — column widths require seeing every row. `csv`, `tsv`,
 `jsonl`, `vertical` can. That's inherent, not a defect; the Protocol is defined over a
@@ -259,15 +352,14 @@ psql users already think about it.
 in the shape M5 needs.
 
 **Newlines are part of the contract.** Python text mode translates `\n` to `\r\n` on
-Windows, which would make `hsql -F csv` produce different bytes per platform and break
-determinism (principle 4). Every writer opens with `newline=""` and emits `\n`, and
-there's a test for it.
+Windows, which would make `hsql -F csv` produce different bytes per platform. Every
+writer opens with `newline=""` and emits `\n`, with a test.
 
 **One accepted overlap:** `export.py` writes CSV via duckdb for the TUI's export dialog;
-`formats.py` writes CSV via the stdlib for `hsql`. Two CSV writers. Unifying them means
-either making the TUI's export dialog options (compression, quoting, encoding) part of
-the streaming path or dropping them, and neither is M1's business. Noted so it's a
-decision rather than an accident; revisit in M5.
+`formats.py` writes CSV via the stdlib for `hsql`. Unifying them means either making the
+export dialog's options (compression, quoting, encoding) part of the streaming path or
+dropping them, and neither is M1's business. Noted so it's a decision rather than an
+accident; revisit in M5.
 
 ### 3.4 `harlequin.plugins` — naming an adapter without importing it
 
@@ -278,8 +370,8 @@ def load_adapter_plugins() -> dict[str, type[HarlequinAdapter]]: ...   # existin
 ```
 
 `adapter_names()` reads entry-point *names* without calling `ep.load()`, so it costs
-nothing. That's what makes the two-phase parse in §3.6 possible, and it's the fix for
-obstacle 3.
+nothing. That's what makes the two-phase parse in §3.6 possible, and per §1.7 it is worth
+~160ms of the prototype's runtime — the difference between 380ms and 220ms.
 
 ### 3.5 `harlequin.config` — merging CLI values over a profile
 
@@ -317,14 +409,9 @@ An invocation only ever uses one adapter, so this is not a compromise — and
 for an agent, not worse. `hsql --help -a postgres` shows postgres'; `hsql info --json`
 (M2) enumerates everything.
 
-This contradicts one line in the product plan (§4: "It still carries the full adapter
-connection-option matrix; that's unavoidable and shared"). It turns out to be avoidable,
-and avoiding it is both a token saving and the fix for the unbounded startup cost. See
-§8.
-
 `harlequin` itself keeps its current all-adapters help. Changing it would alter published
-`--help` output and the docs built from it, for no benefit to a TUI that's already paying
-for Textual.
+`--help` output and the docs built from it, for no benefit to a TUI already paying for
+Textual.
 
 `diagnostics.py` owns the stderr contract:
 
@@ -334,14 +421,14 @@ class ExitCode(IntEnum):
 
 def exit_code_for(error: BaseException) -> ExitCode: ...
 def report_error(error: BaseException) -> None:          # "hsql: error: ..."
-def report_truncation(result: ResultSet, limit: RowLimit) -> None:
+def report_truncation(result: ResultSet, limit: RowLimit) -> None: ...
 def report_stats(...) -> None:                            # one line of JSON
 ```
 
 Two things worth stating because they're easy to get wrong:
 
 - **The truncation notice fires under `-t`.** `-t` suppresses stdout chrome; it does not
-  suppress warnings. A flag that silently defeats truncation reporting would undo the
+  suppress warnings. A flag that silently defeated truncation reporting would undo the
   principle it's meant to coexist with.
 - **Exit codes are hsql's contract, not Harlequin's**, so the mapping lives here rather
   than in `harlequin.exception`. `HarlequinQueryError → 1`, `HarlequinConnectionError → 3`,
@@ -351,27 +438,39 @@ Two things worth stating because they're easy to get wrong:
 
 ## 4. Sequencing
 
-Two releases. The first contains no new user-facing surface at all; the second is the
-feature. Every PR in the first release is independently reviewable, independently
-testable, and behavior-neutral for the TUI.
+One upstream release, then two Harlequin releases. The first Harlequin release contains
+no new user-facing surface at all; the second is the feature. Every PR in the first is
+independently reviewable, independently testable, and behavior-neutral for the TUI.
+
+### Upstream — `textual-fastdatatable` (0.17)
+
+**PR 0.** Lazy `DataTable` in `__init__.py` via PEP 562; `pyarrow.parquet` deferred into
+`ArrowBackend.from_parquet`. Add a test asserting `"textual" not in sys.modules` after
+importing `textual_fastdatatable.backend` — otherwise the next contributor re-adds a
+convenience import at the top of `__init__` and nobody notices for a year. Both changes
+are non-breaking; harlequin then bumps its pin from `==0.16.0` to `==0.17.0`.
+
+Blocks PR 2 and PR 3. Doesn't block PR 1, so it can be running in parallel.
 
 ### Release A — the plumbing (2.9)
 
 **PR 1 — Import hygiene, and the guard that keeps it.**
-Lazy `harlequin/__init__.py` via PEP 562 `__getattr__`, preserving every current name.
+Lazy `harlequin/__init__.py` via PEP 562, preserving every current name.
 `AutoBackendType` under `TYPE_CHECKING` in `adapter.py`, `harlequin_duckdb`,
 `harlequin_sqlite`. `NewCatalog`/`NewCatalogItems` move to `harlequin/messages.py`, with
 a module-level `__getattr__` shim in `catalog.py` so existing imports keep working
 without importing Textual. Deferred renderer imports in `options.py`; `_CustomValidator`
 moves to `copy_widgets.py`, which is already the option-widgets library. Fix the two
-stdout leaks from §1.3. Add import-linter contracts and the cold-start benchmark script.
+stdout leaks from §1.5. Add import-linter contracts and the cold-start benchmark script.
 
 Ships value on its own: importing `harlequin_duckdb` goes from 691ms to 56ms, which
 every adapter's test suite and every library consumer feels.
 
-**PR 2 — `harlequin.query`.** Extract the core; refactor `_execute_query` and
-`_fetch_data` onto it; delete the dead `_split_query_text`; land the splitter and its
-tricky-SQL corpus. Snapshot tests are the safety net for the TUI refactor.
+**PR 2 — `harlequin.statements` and `harlequin.query`.** The tree-sitter splitter and its
+fallback; the editor refactored to import the shared query constant; the tricky-SQL
+corpus. Then the execution core, with `_execute_query` and `_fetch_data` refactored onto
+it. Delete the dead `_split_query_text`. Snapshot tests are the safety net for the TUI
+refactor.
 
 **PR 3 — `harlequin.formats`, and `export.py` decoupled from `ResultsTable`.** Golden
 files per format. No user-visible change; `formats.py` has no consumer until PR 5.
@@ -416,52 +515,62 @@ but a wall-clock assertion on a shared CI runner is a flaky test that gets delet
 a month. So:
 
 - *Deterministic and blocking:* import-linter contracts — the `hsql` module graph must
-  not contain `textual`, `questionary`, or `textual_fastdatatable`. Plus a subprocess
-  test asserting `"textual" not in sys.modules` after importing the headless core. Both
-  fail identically on every machine.
+  not contain `textual` or `questionary`. Plus subprocess tests asserting
+  `"textual" not in sys.modules` after importing the headless core, and the same test
+  upstream after importing `textual_fastdatatable.backend`. These fail identically on
+  every machine.
 - *Informational:* the benchmark reports `hsql -c "select 1"` against DuckDB into the
-  job summary, and fails only past a loose ceiling (600ms) that catches a real
-  regression without catching a busy runner.
+  job summary, failing only past a loose ceiling (600ms) that catches a real regression
+  without catching a busy runner.
 
-The import contract is the load-bearing one. Timing is downstream of it.
+The import contracts are load-bearing. Timing is downstream of them.
 
 Beyond that:
 
-- **`CliRunner` tests** for `hsql`, following the existing `test_cli.py` patterns and
-  its adapter-mocking fixtures.
+- **`CliRunner` tests** for `hsql`, following the existing `test_cli.py` patterns and its
+  adapter-mocking fixtures.
 - **Golden files** per format against a fixture result set with nulls, unicode, wide
   values, duplicate column names, and zero rows. Zero rows is the case that separates
   "the query returned nothing" from "the query failed" — A3 in the product plan — and
-  it's the one most likely to be wrong in a format nobody exercised.
-- **stdout purity:** for each format, assert stdout bytes are identical with and without
-  `--stats`, and that a query error leaves stdout completely empty.
+  the one most likely to be wrong in a format nobody exercised.
+- **stdout purity:** for each format, stdout bytes identical with and without `--stats`;
+  a query error leaves stdout completely empty.
 - **Determinism:** identical bytes whether stdout is a pipe, a file, or a pty; `\n`
-  regardless of platform.
+  regardless of platform; **identical bytes under `LC_ALL=de_DE.UTF-8`**, which is the
+  regression test for §3.3's locale trap.
 - **`hsql -tAc "select count(*)"` returning a bare number and nothing else** as its own
   named test. It's the idiom the scripting audience will try first.
 - **Truncation:** exactly-at-limit, one-over-limit, and under-limit, on both duckdb and
-  sqlite — the two adapters implement `set_limit` differently enough to matter.
-- **The tricky-SQL corpus** against both splitters.
+  sqlite — the two implement `set_limit` differently enough to matter.
+- **The tricky-SQL corpus** against both the editor's slicer and `statements.split()`,
+  including a skip-marked case for dollar-quoting so the known bug is recorded rather
+  than forgotten.
+- **Splitter fallback:** the naive path exercised with tree-sitter monkeypatched out, so
+  the degraded behavior stays tested on machines that have it.
 
 ---
 
 ## 6. Decisions I need from you
 
-1. **Should the TUI adopt overflow detection?** The core can tell the TUI that its
-   100,000-row limit bit, and it could show "100,000+ rows" instead of "100,000 rows".
-   More honest, costs one row, but it's a visible TUI change and it moves snapshots. My
-   inclination is yes, in PR 2 — but it's your product. Default if you don't care: leave
-   the TUI's display alone, `detect_overflow=False` there.
-2. **`hsql --help` showing only the selected adapter's options** — confirmed as an
-   improvement rather than a regression? It's what makes the startup cost bounded, and
-   I'd want to make the same call even if it weren't.
-3. **`--result` default.** The product plan says `all` for text formats and `last` for
+1. **Should the TUI adopt overflow detection?** The core can tell the TUI its
+   100,000-row limit bit, so it could show "100,000+ rows" instead of "100,000 rows".
+   More honest, costs one row, but it's a visible change and it moves snapshots. My
+   inclination is yes, in PR 2. Default if you don't care: leave the TUI's display alone,
+   `detect_overflow=False` there.
+2. **`tree-sitter` and `tree-sitter-sql` as hard dependencies of `harlequin`?** They're
+   installed for everyone today via `textual[syntax]`, and depending on them directly
+   would let us delete the degraded splitter path and its troubleshooting page. The
+   reason not to is the reason Textual made it an extra: platforms without wheels. You'll
+   know better than me how much traffic that troubleshooting page gets. My default is to
+   keep it optional and mirror the TUI's fallback.
+3. **`hsql --help` showing only the selected adapter's options** — confirmed as an
+   improvement rather than a regression? It's what makes startup cost bounded, and I'd
+   want to make the same call even if it weren't.
+4. **`--result` default.** The product plan says `all` for text formats and `last` for
    data formats. That's context-dependent behavior, which cuts against determinism. I'd
    rather default to `all` everywhere and let `json`/`csv` emit multiple documents when a
    script produces multiple result sets — but "csv with two headers in it" is genuinely
    awkward, so the plan's version may be the lesser evil. Weak opinion.
-4. **Splitter spike** — half a day on sqlfmt's lexer before hand-rolling. Confirm that's
-   worth the time, or say "just write the scanner" and I'll write the scanner.
 
 ---
 
@@ -470,8 +579,10 @@ Beyond that:
 `--read-only`, `--timeout`, `--dry-run`, `--single-transaction` (M2 — the first three
 need adapter-interface additions and an ecosystem rollout). Every subcommand: `catalog`,
 `describe`, `fmt`, `spec`, `info`, `config`, `history`, `open`, `mcp`. Real streaming
-(M5 — designed for, not built). A separate lean `hsql` distribution (§4 of the product
-plan: near-reversible, indefinitely deferrable).
+(M5 — designed for, not built). Making `textual` an optional extra of
+`textual-fastdatatable`, and the separate lean `hsql` distribution it would enable (§4
+of the product plan: near-reversible, indefinitely deferrable). Fixing dollar-quoted
+statement splitting (its own issue, affects the TUI equally).
 
 Bare `hsql` with no arguments prints help and never launches the TUI, from the first
 release.
@@ -482,11 +593,13 @@ release.
 
 - **§4 says the full adapter option matrix on `hsql --help` is "unavoidable and shared."**
   It's avoidable, via the two-phase parse in §3.6, and avoiding it is both a token saving
-  and the fix for the only unbounded startup cost. The product plan should be amended.
-- **§12 lists cold start as a risk with "may need lazy entry-point resolution."** It's not
-  a maybe. `load_adapter_plugins()` imports every installed adapter on every invocation —
-  160ms with four installed, growing without bound. Lazy resolution is a requirement of
-  M1, not a contingency.
-- **§5's truncation guarantee needs the limit+1 fetch to be implementable at all.** Worth
-  stating in the product plan, because it's the kind of thing that gets designed out as
-  an implementation detail and then quietly breaks the promise.
+  and the fix for the only unbounded startup cost.
+- **§12 lists cold start as a risk with "may need lazy entry-point resolution."** Not a
+  maybe: it's worth 160ms of a 380ms invocation with four adapters installed, and it
+  grows without bound. A requirement of M1, not a contingency.
+- **§12's cold-start risk should name `textual-fastdatatable`, not just "Textual creeping
+  in."** The 265ms the adapter interface pays today is upstream of this repo, and an
+  import-linter rule here would never have caught it.
+- **§5's truncation guarantee needs the `limit + 1` fetch to be implementable at all.**
+  Worth stating in the product plan, because it's exactly the kind of thing that gets
+  designed out as an implementation detail and then quietly breaks the promise.

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -778,6 +778,10 @@ release.
 
 ## 8. Corrections to the product plan
 
+All of these are **applied** in `harlequin-for-agents.md` in the same PR as this
+document; they're recorded here so the reasoning behind each change is written down
+somewhere.
+
 - **§4 says the full adapter option matrix on `hsql --help` is "unavoidable and shared."**
   It's avoidable. `hsql --help` lists adapter *names* and points at `--help -a X`, which
   is both a token saving and the fix for the only unbounded startup cost (§3.6).

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -253,6 +253,14 @@ it one extra row. This is why the limit is a value object with an explicit
 plan ("truncation must always be announced — never silent") is unimplementable without
 it, and it costs exactly one row.
 
+**No adapter-interface change for limits in M1.** The clean long-term answer is for the
+cursor to say whether more rows exist — a `has_more()`, or a `set_limit()` that reports
+back — instead of us inferring it from an extra row. That's a fifteen-adapter rollout for
+a problem the existing API already solves, so it waits. `set_limit()` and the backend's
+`max_rows` are both existing features, used as they are; the only thing `hsql` does
+differently is pass `limit + 1`. If a later milestone adds a real capability, `RowLimit`
+is the single place that changes.
+
 **Upstream first.** The two `textual-fastdatatable` changes in §3 are a prerequisite, and
 both are non-breaking: the lazy `__init__` keeps `from textual_fastdatatable import DataTable`
 working via PEP 562 `__getattr__`, and deferring `pyarrow.parquet` is invisible to
@@ -637,23 +645,29 @@ Beyond that:
 
 ---
 
-## 6. Decisions I need from you
+## 6. Decisions
 
-1. **Should the TUI adopt overflow detection?** The core can tell the TUI its
-   100,000-row limit bit, so it could show "100,000+ rows" instead of "100,000 rows".
-   More honest, costs one row, but it's a visible change and it moves snapshots. My
-   inclination is yes, in PR 2. Default if you don't care: leave the TUI's display alone,
-   `detect_overflow=False` there.
-2. **`tree-sitter` and `tree-sitter-sql` as hard dependencies of `harlequin`?** They're
+**Settled.**
+
+- *Limits stay on the existing machinery.* `cursor.set_limit()` and the backend's
+  `max_rows`, exactly as they are — no new adapter-interface method for truncation in M1
+  (see §3.1).
+- *The TUI keeps its current row-count display.* `detect_overflow=False` there; only
+  `hsql` pays the extra row. No snapshot churn in PR 2.
+- *Streaming is out.* Not designed around, not partially built — see §3.3 and §7.
+
+**Still open.**
+
+1. **`tree-sitter` and `tree-sitter-sql` as hard dependencies of `harlequin`?** They're
    installed for everyone today via `textual[syntax]`, and depending on them directly
    would let us delete the degraded splitter path and its troubleshooting page. The
    reason not to is the reason Textual made it an extra: platforms without wheels. You'll
    know better than me how much traffic that troubleshooting page gets. My default is to
    keep it optional and mirror the TUI's fallback.
-3. **`hsql --help` showing only the selected adapter's options** — confirmed as an
+2. **`hsql --help` showing only the selected adapter's options** — confirmed as an
    improvement rather than a regression? It's what makes startup cost bounded, and I'd
    want to make the same call even if it weren't.
-4. **`--result` default.** The product plan says `all` for text formats and `last` for
+3. **`--result` default.** The product plan says `all` for text formats and `last` for
    data formats. That's context-dependent behavior, which cuts against determinism. I'd
    rather default to `all` everywhere and let `json`/`csv` emit multiple documents when a
    script produces multiple result sets — but "csv with two headers in it" is genuinely
@@ -695,6 +709,6 @@ release.
 - **§5 says "Large results stream" and lists it as an M1 concern.** Nothing streams in
   M1, and it can't: `HarlequinCursor.fetchall()` materializes the whole result before any
   writer exists, so the format layer is downstream of the problem. Streaming is an M5
-  change to the cursor interface. The M1 commitment should be narrowed to "the format
-  layer doesn't make streaming harder later," which is what `rows()` returning an
-  iterator buys.
+  change to the cursor interface, and M1 doesn't design around it — `rows()` returns an
+  iterator because that's the natural shape, not as a hedge. Agreed with Ted; the product
+  plan's §5 bullet should move to M5 outright.

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -150,12 +150,16 @@ for the TUI respectively. All patches were reverted.
    the fix from silently regressing.
 3. **Building the CLI requires importing every installed adapter.** The only unbounded
    cost, and the only one that gets worse as the ecosystem grows.
-4. **Result rendering doesn't exist.** The TUI renders into a DataTable widget;
-   `export.py` writes columnar files via duckdb. Neither is a text formatter.
+4. **Text layout doesn't exist, and is coupled to a widget where it does.** The TUI
+   renders into a DataTable; `export.py` writes files but only from a `ResultsTable`.
+   Nothing arranges a result as `table`, `markdown` or `vertical` text.
 
-Note what is *not* on this list: normalizing adapter output, and parsing SQL into
-statements. Both looked like new subsystems and turned out to be existing ones we
-already own.
+Note what is *not* on this list, though earlier drafts of this plan had all three:
+normalizing adapter output, parsing SQL into statements, and serializing values. Each
+looked like a new subsystem and turned out to be an existing one we already own —
+`create_backend`, `tree-sitter-sql`, and duckdb respectively. The residual work in M1 is
+smaller than it first appears, and the parts that remain are the parts that are genuinely
+ours: the CLI, the execution flow, and three text layouts.
 
 ---
 
@@ -172,8 +176,8 @@ textual-fastdatatable
 harlequin/
   statements.py   NEW  locating statement boundaries in SQL text
   query.py        NEW  execute SQL, get results, without a UI
-  formats.py      NEW  serialize a result set as text, incrementally
-  export.py       MOD  serialize a result set as a columnar file  (widget coupling gone)
+  layout.py       NEW  arranging already-serialized text for a reader
+  export.py       MOD  writing a result set to a file, serialized by duckdb/pyarrow
   config.py       MOD  + merging CLI values over a profile
   plugins.py      MOD  + naming and loading one adapter without importing the rest
   options.py      MOD  renderer imports deferred; declaration stays import-light
@@ -185,7 +189,7 @@ harlequin/
 
 The one-line statement of the architecture, which is also a testable rule:
 
-> **stdout is written only by `harlequin.formats` and `harlequin.export`. stderr is
+> **stdout is written only by `harlequin.layout` and `harlequin.export`. stderr is
 > written only by `harlequin.hsql.diagnostics`.**
 
 ### 3.1 `harlequin.query` — the execution core, over the existing backend
@@ -216,6 +220,7 @@ class ResultSet:
     @property
     def row_count(self) -> int: ...   # backend.row_count
     def rows(self) -> Iterator[Sequence[Any]]: ...
+    def text_columns(self) -> pa.Table: ...   # every value CAST AS VARCHAR; see §3.3
 
 def execute(
     connection: HarlequinConnection,
@@ -301,65 +306,136 @@ should be its own issue rather than M1 scope — and it's a good demonstration t
 sharing the grammar means `hsql` inherits the TUI's behavior including its bugs, which
 is the definition of no drift.
 
-### 3.3 `harlequin.formats` — serialization, deliberately not display
+### 3.3 Output — duckdb serializes, `hsql` lays out
 
 ```python
+**`hsql` writes no value-serialization code at all. duckdb is the serializer; `hsql`
+only does layout.** That is the whole of §3.3, and everything below follows from it.
+
+The temptation is to reach for the stdlib `csv` module, and on plain strings it is
+indistinguishable — I diffed duckdb's writer against `csv.writer` on embedded commas,
+embedded quotes, embedded newlines, nulls and unicode and got byte-identical output.
+The divergence isn't escaping, it's **types**:
+
+| value | `export.py` (duckdb) | stdlib `csv` + `str()` |
+| --- | --- | --- |
+| `timestamptz` | `2024-03-01 12:30:00+00` | `2024-03-01 12:30:00+00:00` |
+| `boolean` | `true` | `True` |
+| `blob` | `\x00\x01\xFF` | `b'\x00\x01\xff'` |
+
+The third row is the argument. `b'\x00\x01\xff'` is a Python repr in a data file. A
+hand-rolled writer doesn't just have to get RFC 4180 right, it has to own a rendering for
+every type any of fifteen adapters can return — dates, intervals, decimals, blobs, lists,
+structs, maps — and it will get them subtly wrong in ways nobody notices until an agent
+parses one.
+
+So the format table becomes:
+
+| Format | Serialized by | Via |
+| --- | --- | --- |
+| `csv`, `tsv` | duckdb | `relation.write_csv(sep=…)` |
+| `json`, `jsonl`/`ndjson` | duckdb | `COPY … (FORMAT JSON[, ARRAY TRUE])` |
+| `parquet`, `orc`, `arrow`/`feather` | duckdb / pyarrow | the existing exporters |
+| `table`, `markdown`/`md`, `vertical` | duckdb, then `hsql` lays it out | `CAST(col AS VARCHAR)` |
+| `none` | — | rows discarded, status only |
+
+`write_csv` already takes `sep`, `na_rep`, `header`, `quotechar`, `escapechar`, `quoting`,
+`encoding` — so `tsv` is `sep="\t"`, `--no-header` is `header=False`, and
+`--null-string` is `na_rep`. Nothing new needed. duckdb's JSON writer emits unquoted
+numbers, bare `true`/`false`, real `null`, and preserves nested structs — the array-of-row-objects
+shape §5 of the product plan asks for, with `ARRAY TRUE`, and jsonl without it.
+
+**`ResultSet.text_columns()` is `CAST(col AS VARCHAR)`, and it's what keeps `-F table`
+honest.** The human-facing layouts need strings, and if they derived them any other way
+they would disagree with `-F csv` about what a timestamp or a blob looks like. Casting
+through duckdb returns `1234.5600`, `true`, `\x00\xFF` — the same text `write_csv`
+produces — with SQL `NULL` arriving as Python `None`, so it stays distinguishable from
+the literal string `"NULL"` and `--null-string` works properly. `hsql` then does padding,
+pipes and alignment, and nothing else.
+
+**One serializer across every adapter is a feature, not a side effect.** Routing a
+Postgres result through duckdb means Postgres, BigQuery and DuckDB timestamps print
+identically — which is story A2 in the product plan ("the flags, output shape, and exit
+codes are identical, so I don't relearn a CLI per database"). Getting that from a shared
+serializer rather than from discipline is the cheap way to get it.
+
+*Robustness:* everything reaches duckdb via `duckdb.from_arrow()`, so an arrow type
+duckdb can't ingest would break the path. I tested large_string, dictionary-encoded,
+duration, map and fixed-size-binary — all fine. There's still a `str()`-based fallback
+with a stderr warning, as belt and braces rather than an expected path.
+
+**`hsql` never calls `cell_formatter`, and this is the one place we deliberately don't
+reuse the TUI's code.** `textual_fastdatatable.format.cell_formatter` is *display*
+formatting: floats and ints as `f"{obj:n}"` (locale-aware thousands separators), booleans
+as `✓ True`, strings as Rich markup. Correct for a data table a human is reading;
+catastrophic in a CSV. Display and serialization are different operations, and conflating
+them is how `1,234,567` ends up in a numeric column.
+
+The corollary is a live trap: **`hsql` must not call `set_locale()`.** The `harlequin` CLI
+does (`cli.py:339`), and inheriting it would make output vary with `LC_ALL` — a direct
+violation of principle 4's "identical output" promise, visible only on someone else's
+machine. `CAST AS VARCHAR` is locale-independent; `f"{obj:n}"` is not.
+
+Column widths for `-F table` are `max(len(s))` over the strings from `text_columns()`,
+not `backend.column_content_widths` — the latter measures the width of the *displayed*
+form we're not displaying.
+
+### Consequences worth stating plainly
+
+**Nothing streams in M1, including CSV.** duckdb's writers are file-producing, so `-o PATH`
+hands duckdb the path and stdout writes to a temp file and copies it out. My earlier
+draft claimed csv and jsonl would stream; that was wrong twice over, because `fetchall()`
+has already materialized the whole result before any writer sees it. Streaming is
+uniformly an M5 problem that starts at the cursor, not at the formatter — which is
+simpler than a format layer where some writers stream and some don't.
+
+**One code path to stdout, not two.** `/dev/stdout` works on Linux and I verified it, but
+it doesn't exist on Windows, and a platform-conditional output path is two paths to test
+for no benefit. Temp file then `copyfileobj` everywhere. At the default `--limit 500`
+it's unmeasurable; at `-l 0` duckdb writing a temp file beats building strings in Python.
+
+**Newlines are still part of the contract.** duckdb writes `\n`; the copy to stdout must
+be binary so Python's text-mode translation doesn't turn it into `\r\n` on Windows. Same
+test as before, and now it covers every format at once.
+
+**The overlap I flagged last draft is gone.** There was going to be one CSV writer for the
+TUI's export dialog and another for `hsql`. There's one, and the export dialog's options
+(compression, quoting, encoding) are already in its vocabulary.
+
+### `harlequin.export` and `harlequin.layout`
+
+Given the above, the split isn't text-versus-columnar, it's **who serializes**:
+
+```python
+# harlequin/export.py — writing a result set to a file, serialized by duckdb or pyarrow
+def write_file(data: pa.Table, path: Path, format_name: str, options: Mapping[str, Any]) -> None: ...
+def file_format_names() -> list[str]: ...
+
+# harlequin/layout.py — arranging already-serialized text for a reader
 @dataclass(frozen=True)
-class RenderOptions:
+class LayoutOptions:
     header: bool = True
     footer: bool = True
     aligned: bool = True
-    null_string: str | None = None    # None = per-format default
+    null_string: str | None = None
     color: bool = False
 
-class ResultWriter(Protocol):
-    def write_result(self, result: ResultSet, out: TextIO) -> None: ...
+class Layout(Protocol):
+    def write(self, result: ResultSet, out: TextIO) -> None: ...
 
-def get_writer(name: str, options: RenderOptions) -> ResultWriter: ...
-def format_names() -> list[str]: ...
+def get_layout(name: str, options: LayoutOptions) -> Layout: ...
+def layout_names() -> list[str]: ...
 ```
 
-Formats: `table`, `markdown`/`md`, `csv`, `tsv`, `json`, `jsonl`/`ndjson`, `vertical`,
-`none`. Columnar formats (`parquet`, `arrow`, `orc`) route to `export.py`, which needs a
-path and a materialized table.
+`export.py` keeps its name and its job, loses the `ResultsTable` coupling from §1.6, and
+gains `tsv` and `jsonl` as thin option variants of formats it already writes. `layout.py`
+is new and small: three layouts, no type knowledge, no duckdb.
 
-`RenderOptions` is what makes psql's flag algebra fall out for free: `-t` is
+`LayoutOptions` is what makes psql's flag algebra fall out for free: `-t` is
 `header=False, footer=False`, `-A` is `aligned=False`, and `-tA` needs no special case
-because it was never a special case — two independent options, which is how psql users
-already think about them.
-
-**`hsql` never calls `cell_formatter`, and this is the one place we deliberately do not
-reuse the TUI's code.** `textual_fastdatatable.format.cell_formatter` is *display*
-formatting: it renders floats and ints as `f"{obj:n}"` (locale-aware thousands
-separators), booleans as `✓ True`, and strings as Rich markup. Correct for a data table
-a human is reading; catastrophic in a CSV. Serialization and display are different
-operations and conflating them is how `1,234,567` ends up in a numeric column.
-`hsql -F table` prints `1234567`, same as psql.
-
-The corollary is a live trap: **`hsql` must not call `set_locale()`.** The `harlequin`
-CLI does (`cli.py:339`), and inheriting it would make output vary with `LC_ALL` — a
-direct violation of principle 4's "identical output" promise, and one that would only
-show up on someone else's machine.
-
-For the same reason `hsql` computes its own column widths for `-F table`, rather than
-reusing `backend.column_content_widths`: that measures the *displayed* width of values
-we're not going to display that way. `max(len(s))` over the strings we actually emit is
-trivial and guaranteed consistent with the output.
-
-**`table` cannot stream** — column widths require seeing every row. `csv`, `tsv`,
-`jsonl`, `vertical` can. That's inherent, not a defect; the Protocol is defined over a
-`ResultSet` whose `rows()` is an iterator, so the streaming formats are already written
-in the shape M5 needs.
-
-**Newlines are part of the contract.** Python text mode translates `\n` to `\r\n` on
-Windows, which would make `hsql -F csv` produce different bytes per platform. Every
-writer opens with `newline=""` and emits `\n`, with a test.
-
-**One accepted overlap:** `export.py` writes CSV via duckdb for the TUI's export dialog;
-`formats.py` writes CSV via the stdlib for `hsql`. Unifying them means either making the
-export dialog's options (compression, quoting, encoding) part of the streaming path or
-dropping them, and neither is M1's business. Noted so it's a decision rather than an
-accident; revisit in M5.
+because it was never one — two independent options, which is how psql users already think
+about them. `--no-header` and `--null-string` also reach `export.py` as `header` and
+`na_rep`, so the same four flags mean the same thing in every format.
 
 ### 3.4 `harlequin.plugins` — naming an adapter without importing it
 
@@ -472,8 +548,10 @@ corpus. Then the execution core, with `_execute_query` and `_fetch_data` refacto
 it. Delete the dead `_split_query_text`. Snapshot tests are the safety net for the TUI
 refactor.
 
-**PR 3 — `harlequin.formats`, and `export.py` decoupled from `ResultsTable`.** Golden
-files per format. No user-visible change; `formats.py` has no consumer until PR 5.
+**PR 3 — `export.py` decoupled from `ResultsTable`, plus `harlequin.layout`.** Extend
+`export.py` with `tsv` and `jsonl` (option variants of formats it already writes) and the
+temp-file-to-stream path; add the three layouts and `ResultSet.text_columns()`. Golden
+files per format. No user-visible change; neither has a consumer until PR 5.
 
 **PR 4 — `merge_profile_with_cli`, `adapter_names`, `load_adapter`.** `harlequin`'s own
 CLI refactored onto the first; behavior-neutral, covered by the existing 392 lines of
@@ -533,11 +611,20 @@ Beyond that:
   values, duplicate column names, and zero rows. Zero rows is the case that separates
   "the query returned nothing" from "the query failed" — A3 in the product plan — and
   the one most likely to be wrong in a format nobody exercised.
+- **A type-coverage fixture** — timestamp, timestamptz, date, decimal, float, boolean,
+  blob, list, struct, map, and null in each — rendered into every format, as golden
+  files. This is the table in §3.3 turned into a test: it's what would catch a change in
+  duckdb's rendering, and it's the reason `-F table` and `-F csv` can be asserted to
+  agree cell for cell.
+- **`text_columns()` agreement:** for that fixture, the strings `-F table` prints are the
+  same strings `-F csv` writes.
 - **stdout purity:** for each format, stdout bytes identical with and without `--stats`;
   a query error leaves stdout completely empty.
 - **Determinism:** identical bytes whether stdout is a pipe, a file, or a pty; `\n`
-  regardless of platform; **identical bytes under `LC_ALL=de_DE.UTF-8`**, which is the
-  regression test for §3.3's locale trap.
+  regardless of platform, which now means the temp-file copy is binary; **identical bytes
+  under `LC_ALL=de_DE.UTF-8`**, the regression test for §3.3's locale trap.
+- **`-o PATH` and `> PATH` produce identical bytes** for every format — the one thing the
+  temp-file path could plausibly get wrong.
 - **`hsql -tAc "select count(*)"` returning a bare number and nothing else** as its own
   named test. It's the idiom the scripting audience will try first.
 - **Truncation:** exactly-at-limit, one-over-limit, and under-limit, on both duckdb and
@@ -578,8 +665,10 @@ Beyond that:
 
 `--read-only`, `--timeout`, `--dry-run`, `--single-transaction` (M2 — the first three
 need adapter-interface additions and an ecosystem rollout). Every subcommand: `catalog`,
-`describe`, `fmt`, `spec`, `info`, `config`, `history`, `open`, `mcp`. Real streaming
-(M5 — designed for, not built). Making `textual` an optional extra of
+`describe`, `fmt`, `spec`, `info`, `config`, `history`, `open`, `mcp`. Streaming of any
+kind — it starts at the cursor interface, not the format layer (M5; see §3.3 and §8).
+Unifying the TUI's export dialog onto `write_file` (mechanical, but it moves a UI).
+Making `textual` an optional extra of
 `textual-fastdatatable`, and the separate lean `hsql` distribution it would enable (§4
 of the product plan: near-reversible, indefinitely deferrable). Fixing dollar-quoted
 statement splitting (its own issue, affects the TUI equally).
@@ -603,3 +692,9 @@ release.
 - **§5's truncation guarantee needs the `limit + 1` fetch to be implementable at all.**
   Worth stating in the product plan, because it's exactly the kind of thing that gets
   designed out as an implementation detail and then quietly breaks the promise.
+- **§5 says "Large results stream" and lists it as an M1 concern.** Nothing streams in
+  M1, and it can't: `HarlequinCursor.fetchall()` materializes the whole result before any
+  writer exists, so the format layer is downstream of the problem. Streaming is an M5
+  change to the cursor interface. The M1 commitment should be narrowed to "the format
+  layer doesn't make streaming harder later," which is what `rows()` returning an
+  iterator buys.


### PR DESCRIPTION
Relates to #524. Follows #1013, which added the product plan.

**What** are the key elements of this solution?

Adds `docs/plans/m1-hsql-technical-plan.md` — the implementation plan for M1 of the agents product plan — and applies to `docs/plans/harlequin-for-agents.md` the corrections that writing it turned up.

The technical plan covers where the code is today (measured, not estimated), the module architecture, and an eight-PR sequence across one upstream release and two Harlequin releases. Release A is four behavior-neutral refactors with no new user-facing surface; Release B is `hsql` itself, shipped in one piece because the output format and exit codes are meant to be a frozen API.

Everything load-bearing was verified against a prototype rather than reasoned about:

- `harlequin --version` takes **1.335s** today — the cheapest possible invocation. Five separate things each pull in the whole TUI, listed in §1.2.
- With the refactors applied, a script doing what `hsql -c` will do — startup, config discovery, single-adapter load, connect, execute, fetch, normalize, render — runs in **220–242ms with Textual never imported**. All patches were reverted; nothing in this PR touches `src/`.
- `load_adapter_plugins()` imports every installed adapter on every invocation. That's 160ms of the above with four installed, and unbounded as the ecosystem grows.

Three things that looked like new subsystems turned out to be existing ones:

- **Adapter output normalization** → `create_backend()`. `textual-fastdatatable`'s backend contains zero references to Textual; only its package `__init__` importing the DataTable widget does. Two small upstream changes make it reachable for ~140ms instead of ~215–245ms, filed as [tconbeer/textual-fastdatatable#162](https://github.com/tconbeer/textual-fastdatatable/issues/162).
- **Statement splitting** → tree-sitter directly, 28ms, the same grammar and query the editor already uses.
- **Value serialization** → duckdb. `write_csv` for csv/tsv, `COPY … FORMAT JSON` for json/jsonl, `CAST AS VARCHAR` for the text layouts. `hsql` writes layout code only.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The plan's central risk is the one §12 of the product plan names: two front doors that drift. Every design choice here is downstream of picking the option with fewer implementations of the same thing.

- **Statement splitting** — costed a hand-rolled scanner, sqlfmt's lexer (85ms), and tree-sitter (28ms). Tree-sitter wins on speed, but the real argument is that it's the grammar the editor already uses, so `hsql -f` and the editor cannot disagree. With tree-sitter as a required dependency there is one splitter, and `SEMICOLON_QUERY`, `prepare_query`, `query_syntax_tree` and the `is_syntax_aware` fallback branch all get deleted. The trade is losing textual-textarea's incremental tree: reparsing measures 0.6ms on a realistic buffer, on a submit-time path.
- **CSV** — the stdlib `csv` module matches duckdb byte for byte on embedded commas, quotes, newlines, nulls and unicode. It diverges on types: `True` vs `true`, and `b'\x00\x01\xff'` vs `\x00\x01\xFF` — a Python repr in a data file. duckdb owns serialization for every format, which also means Postgres and BigQuery timestamps print identically.
- **`--help`** — showing the default adapter's connection options would mislead a Postgres user into thinking those were the only ones, so `hsql --help` lists adapter names and points at `hsql --help -a <adapter>`. Renders without importing any adapter.
- **The one deliberate non-reuse** is `cell_formatter`, which is display formatting: locale-aware thousands separators, `✓ True`, Rich markup. Correct in a data table, corrupting in a CSV. The corollary is that `hsql` must not call `set_locale()`, or output would vary with `LC_ALL`.

Two findings worth flagging independently of this plan:

- **A live unicode bug in `main`.** Tree-sitter's `Point.column` is a byte offset; `get_text_range()` takes character columns; `code_editor.py:159` passes one into the other. `select '日本語';select 2` splits into `select '日本語';select` and `2`, both syntax errors. Narrow — it needs non-ASCII before the semicolon and no space after, or `.strip()` absorbs the off-by-one — but reproducible. PR 2 fixes it as a side effect of sharing the splitter; it deserves its own issue.
- `harlequin/plugins.py:54` prints plug-in import failures to **stdout** with a bare `print()`, and `pretty_print_warning` does the same via `rich.print`. Both would land inside `hsql -F csv > out.csv`.

Corrections applied to the product plan are listed in §8 of the new document, with the reasoning for each. The largest is that `hsql -l` is a *hard* fetch limit while `harlequin --limit` is a *soft* display cap over a full fetch — which is why the TUI can report an exact `Showing 100,000 of 3,412,887` and `hsql` reports `500 of 500+`.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: two changes, both belonging to later PRs in the sequence rather than to this one. PR 7 adds the "Headless & Agents" topic, and retires `troubleshooting/tree-sitter`, which will describe a degraded mode that no longer exists once tree-sitter is a required dependency.

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary. Documentation only — no files outside `docs/plans/` are touched. The testing strategy for the code is §5 of the new document.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. — Not applicable: planning documents only, no user-facing change. The PRs in the sequence carry their own entries; §4 notes that PR 2 is the only one in Release A with user-visible behavior.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.