### PR TITLE
perf: keep Textual out of the adapter API's import graph (#524)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,3 +36,17 @@ jobs:
           uv run --no-sync ruff format . --diff
           uv run --no-sync ruff check .
           uv run --no-sync mypy --no-incremental
+          uv run --no-sync lint-imports
+
+      # Informational: the deterministic guards are the import-linter contracts
+      # above and tests/unit_tests/test_import_hygiene.py. A wall-clock
+      # assertion on a shared runner would just be a flaky test.
+      - name: Report cold start
+        run: |
+          {
+            echo '### Cold start'
+            echo
+            echo '```'
+            uv run --no-sync python scripts/cold_start.py
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,25 @@ uv run --python 3.12 --group test pytest -m 'py12 and not online' --snapshot-upd
 - Async tests need `@pytest.mark.asyncio`. Await `wait_for_workers(app)` (fixture) rather than sleeping — it skips the catalog background loader, which never finishes on its own.
 - Shared fixtures: `tests/conftest.py` builds throwaway DuckDB/SQLite databases (`tiny_*`, `small_*`) and app instances (`app`, `app_all_adapters`, `app_small_duck`, …); `app_all_adapters` is parametrized so one test body covers both bundled adapters.
 
+## Import hygiene
+
+The headless CLI (`hsql`, planned in `docs/plans/`) has to reach a database without paying for the TUI, so **the adapter-facing modules must stay free of Textual, questionary, prompt_toolkit and sqlfmt at import time.** Concretely:
+
+- `harlequin/__init__.py` resolves its public names through a PEP 562 `__getattr__`. Never add a module-scope import there — importing *any* `harlequin.*` submodule executes it, so one eager import puts the whole app behind every consumer.
+- Type-only imports of Textual (e.g. `AutoBackendType`) go under `if TYPE_CHECKING:`; every module involved already has `from __future__ import annotations`.
+- Renderer imports in `options.py` (`questionary`, `harlequin.colors`, `harlequin.copy_widgets`) are deferred into `to_widgets()` / `to_questionary()`. Declaring an option stays cheap; rendering one pays.
+- **stdout belongs to query output.** Diagnostics — including plug-in load failures and `pretty_print_warning` — go to stderr, or they contaminate piped output.
+
+Two guards, and they check different things:
+
+```bash
+uv run lint-imports                 # import-linter contracts in pyproject.toml
+uv run pytest tests/unit_tests/test_import_hygiene.py    # what actually happens at run time
+uv run python scripts/cold_start.py # informational: ms and module count per import
+```
+
+import-linter reads the *static* graph, so it cannot tell a deferred import from a module-scope one — the deliberate deferrals are listed in `ignore_imports` with a comment each. The subprocess tests are what prove a deferral actually defers, so a new deferral needs an entry in both places.
+
 ## Architecture
 
 ### Packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Performance
+
+- Importing Harlequin's adapter API no longer imports the TUI ([#524](https://github.com/tconbeer/harlequin/issues/524)). `import harlequin_duckdb` drops from ~770ms to ~120ms, and `import harlequin_sqlite` from ~700ms to ~65ms, since neither pulls in Textual, questionary, prompt_toolkit or sqlfmt any more. Adapter authors feel this on every test run; the TUI's own start-up is unchanged.
+
+### Bug Fixes
+
+- A plug-in that fails to import now reports it on stderr instead of stdout, so the message can no longer contaminate piped output.
+- Warnings raised while setting the locale or installing the Windows timezone database now go to stderr, for the same reason. Errors already did.
+
 ### Dependencies
 
 - Reserves the `hsql` name on PyPI for Harlequin's planned headless CLI ([#524](https://github.com/tconbeer/harlequin/issues/524)). `hsql` is a metapackage that only depends on `harlequin`; it ships no modules and no `hsql` command yet, so `pip install hsql` simply installs Harlequin.
+- Upgrades `textual-fastdatatable` to 0.16.1 (from 0.16.0), which makes the `DataTable` widget a lazy import and defers `pyarrow.parquet`, so the backend Harlequin's adapter interface types against can be imported without Textual.
 
 ## [2.8.0] - 2026-08-06
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ check:
 	uv run --python 3.12 --group test pytest -m 'py12 and ($(TEST_MARKERS))'
 	uv sync --group test --group static
 	uv run mypy
+	uv run lint-imports
 
 .PHONY: lint
 lint:
@@ -18,6 +19,12 @@ lint:
 	uv run ruff format .
 	uv run ruff check . --fix
 	uv run mypy
+	uv run lint-imports
+
+.PHONY: cold-start
+cold-start:
+	uv sync --group test --group static
+	uv run python scripts/cold_start.py
 
 .PHONY: serve
 serve:

--- a/docs/plans/m1-hsql-technical-plan.md
+++ b/docs/plans/m1-hsql-technical-plan.md
@@ -202,29 +202,34 @@ The one-line statement of the architecture, which is also a testable rule:
 @dataclass(frozen=True)
 class Statement:
     sql: str
-    index: int                 # 0-based position in the submitted script
+    index: int  # 0-based position in the submitted script
+
 
 @dataclass(frozen=True)
 class RowLimit:
-    max_rows: int | None       # None = unlimited
-    detect_overflow: bool      # fetch one extra row so truncation is knowable
+    max_rows: int | None  # None = unlimited
+    detect_overflow: bool  # fetch one extra row so truncation is knowable
+
 
 @dataclass
 class ExecutedStatement:
     statement: Statement
-    cursor: HarlequinCursor | None    # None for DDL/DML
+    cursor: HarlequinCursor | None  # None for DDL/DML
+
 
 @dataclass
 class ResultSet:
     statement: Statement
-    columns: list[tuple[str, str]]    # (name, short type) from cursor.columns()
-    backend: DataTableBackend         # from textual_fastdatatable
+    columns: list[tuple[str, str]]  # (name, short type) from cursor.columns()
+    backend: DataTableBackend  # from textual_fastdatatable
     truncated: bool
     elapsed: float
+
     @property
-    def row_count(self) -> int: ...   # backend.row_count
+    def row_count(self) -> int: ...  # backend.row_count
     def rows(self) -> Iterator[Sequence[Any]]: ...
-    def text_columns(self) -> pa.Table: ...   # every value CAST AS VARCHAR; see §3.3
+    def text_columns(self) -> pa.Table: ...  # every value CAST AS VARCHAR; see §3.3
+
 
 def execute(
     connection: HarlequinConnection,
@@ -308,8 +313,10 @@ against sqlfmt's 85ms, no new SQL scanner to maintain, and — the part that mat
 and the editor cannot disagree about where a statement ends.
 
 ```python
-def find_separators(text: str) -> list[Point]: ...  # (row, character column) past each ";"
-def split(text: str) -> list[Statement]: ...        # separators -> trimmed statements
+def find_separators(
+    text: str,
+) -> list[Point]: ...  # (row, character column) past each ";"
+def split(text: str) -> list[Statement]: ...  # separators -> trimmed statements
 ```
 
 **`tree-sitter` and `tree-sitter-sql` become explicit, required dependencies of
@@ -491,9 +498,9 @@ about them. `--no-header` and `--null-string` also reach `export.py` as `header`
 ### 3.4 `harlequin.plugins` — naming an adapter without importing it
 
 ```python
-def adapter_names() -> list[str]: ...                        # entry-point names only
-def load_adapter(name: str) -> type[HarlequinAdapter]: ...   # imports exactly one
-def load_adapter_plugins() -> dict[str, type[HarlequinAdapter]]: ...   # existing
+def adapter_names() -> list[str]: ...  # entry-point names only
+def load_adapter(name: str) -> type[HarlequinAdapter]: ...  # imports exactly one
+def load_adapter_plugins() -> dict[str, type[HarlequinAdapter]]: ...  # existing
 ```
 
 `adapter_names()` reads entry-point *names* without calling `ep.load()`, so it costs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 dependencies = [
     # textual and component libraries
     "textual==8.2.8",
-    "textual-fastdatatable==0.16.0",
+    # 0.16.1 makes the DataTable widget a lazy import, so `backend` -- which is
+    # what the adapter interface types against -- is reachable without Textual.
+    "textual-fastdatatable==0.16.1",
     "textual-textarea==0.18.1",
 
     # click
@@ -74,6 +76,7 @@ static = [
     "mypy==2.0.0,<3",
     "pandas-stubs>=2,<3",
     "boto3-stubs>=1.34.23,<2",
+    "import-linter>=2.5",
 ]
 test = [
     "pytest>=9.0.2,<9.1.0",
@@ -199,3 +202,64 @@ markers = [
     "use_cache: override the autouse fixture the disables the buffer cache",
     "py12: Only run on Python 3.12 or higher",
 ]
+
+
+[tool.importlinter]
+
+root_packages = ["harlequin", "harlequin_duckdb", "harlequin_sqlite"]
+include_external_packages = true
+exclude_type_checking_imports = true
+
+
+[[tool.importlinter.contracts]]
+
+name = "The adapter API is reachable without the TUI"
+type = "forbidden"
+source_modules = [
+    "harlequin.adapter",
+    "harlequin.autocomplete",
+    "harlequin.catalog",
+    "harlequin.exception",
+    "harlequin.keymap",
+    "harlequin.options",
+    "harlequin.plugins",
+    "harlequin.transaction_mode",
+    "harlequin_duckdb",
+    "harlequin_sqlite",
+]
+forbidden_modules = [
+    "questionary",
+    "textual",
+    "textual_fastdatatable",
+    "textual_textarea",
+    "harlequin.app",
+    "harlequin.colors",
+    "harlequin.components",
+    "harlequin.copy_widgets",
+    "harlequin.keys_app",
+    "harlequin.messages",
+]
+# import-linter reads the static graph, so it cannot see that these four are
+# deferred into the function that needs them -- but a reader of this list can,
+# and every one of them is a deliberate deferral with a comment at the import
+# site. Any *new* route to Textual fails the contract instead of joining them.
+# `tests/unit_tests/test_import_hygiene.py` is what proves the deferrals hold at
+# run time.
+ignore_imports = [
+    "harlequin.exception -> harlequin.colors",       # pretty_print_warning()
+    "harlequin.options -> harlequin.copy_widgets",   # to_widgets()
+    "harlequin.options -> harlequin.colors",         # to_questionary()
+    "harlequin.options -> questionary",              # to_questionary()
+]
+
+
+[[tool.importlinter.contracts]]
+
+# Importing any harlequin.* submodule executes this package's __init__, so a
+# single eager import there puts the whole TUI behind every consumer. The
+# public names are resolved by a PEP 562 __getattr__ instead.
+name = "The package root does not import either app"
+type = "forbidden"
+source_modules = ["harlequin"]
+forbidden_modules = ["harlequin.app", "harlequin.keys_app"]
+unmatched_ignore_imports_alerting = "error"

--- a/scripts/cold_start.py
+++ b/scripts/cold_start.py
@@ -1,0 +1,112 @@
+"""Measure what an import costs before anyone has done any work.
+
+Cold start is the budget the headless CLI has to live inside, and it is spent
+almost entirely on imports: the modules a front end touches on its way to a
+connection, not the query. This reports the wall time and the module count for
+each step, so a regression points at the import that caused it.
+
+Usage:
+    uv run python scripts/cold_start.py
+    uv run python scripts/cold_start.py --runs 10
+    uv run python scripts/cold_start.py --json      # for CI job summaries
+
+The numbers are informational. The blocking guards are the import-linter
+contracts in pyproject.toml and tests/unit_tests/test_import_hygiene.py, which
+fail identically on every machine; a wall clock on a shared CI runner does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+# (label, statement). Ordered cheapest to dearest, which is also roughly the
+# order a headless invocation touches them.
+STEPS: list[tuple[str, str]] = [
+    ("interpreter only", "pass"),
+    ("harlequin", "import harlequin"),
+    ("harlequin.catalog", "import harlequin.catalog"),
+    ("harlequin.options", "import harlequin.options"),
+    ("harlequin.config", "import harlequin.config"),
+    ("harlequin.plugins", "import harlequin.plugins"),
+    (
+        "fastdatatable backend",
+        "from textual_fastdatatable.backend import create_backend",
+    ),
+    ("harlequin_sqlite", "import harlequin_sqlite"),
+    ("harlequin_duckdb", "import harlequin_duckdb"),
+    ("harlequin.cli", "import harlequin.cli"),
+    ("the TUI", "from harlequin import Harlequin"),
+]
+
+PROBE = """
+{statement}
+import sys
+print(len(sys.modules), "textual" in sys.modules, sep=",")
+"""
+
+
+def measure(statement: str, runs: int) -> tuple[float, int, bool]:
+    """Returns (best milliseconds, module count, whether Textual was imported).
+
+    The best of N, not the mean: we want the floor the import costs, and a
+    shared runner only ever adds noise on top of it.
+    """
+    best = float("inf")
+    modules = 0
+    imported_textual = False
+    for _ in range(runs):
+        start = time.perf_counter()
+        proc = subprocess.run(
+            [sys.executable, "-c", PROBE.format(statement=statement)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        best = min(best, (time.perf_counter() - start) * 1000)
+        count, textual = proc.stdout.strip().split(",")
+        modules = int(count)
+        imported_textual = textual == "True"
+    return best, modules, imported_textual
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runs", type=int, default=5, help="iterations per step (best wins)"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit JSON instead of a table"
+    )
+    args = parser.parse_args()
+
+    results = []
+    for label, statement in STEPS:
+        elapsed, modules, textual = measure(statement, args.runs)
+        results.append(
+            {
+                "step": label,
+                "statement": statement,
+                "ms": round(elapsed, 1),
+                "modules": modules,
+                "textual": textual,
+            }
+        )
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return 0
+
+    print(f"{'step':<24}{'ms':>8}{'modules':>10}  textual")
+    print("-" * 52)
+    for row in results:
+        flag = "yes" if row["textual"] else "no"
+        print(f"{row['step']:<24}{row['ms']:>8}{row['modules']:>10}  {flag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/harlequin/__init__.py
+++ b/src/harlequin/__init__.py
@@ -1,10 +1,28 @@
-from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
-from harlequin.app import Harlequin
-from harlequin.autocomplete import HarlequinCompletion
-from harlequin.keymap import HarlequinKeyBinding, HarlequinKeyMap
-from harlequin.keys_app import HarlequinKeys
-from harlequin.options import HarlequinAdapterOption, HarlequinCopyFormat
-from harlequin.transaction_mode import HarlequinTransactionMode
+"""Harlequin's public API.
+
+Every name below is exported lazily (PEP 562). Importing this package -- which
+happens implicitly when importing *any* `harlequin.*` submodule -- used to pull
+in `harlequin.app`, and with it Textual, sqlfmt, prompt_toolkit and pyarrow. That
+put a ~660ms floor under every consumer, including adapters that never touch the
+TUI. Attribute access still resolves the same names from the same modules, so
+`from harlequin import Harlequin` works exactly as before; it just pays for the
+app only when the app is what you asked for.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from harlequin.adapter import (
+        HarlequinAdapter,
+        HarlequinConnection,
+        HarlequinCursor,
+    )
+    from harlequin.app import Harlequin
+    from harlequin.autocomplete import HarlequinCompletion
+    from harlequin.keymap import HarlequinKeyBinding, HarlequinKeyMap
+    from harlequin.keys_app import HarlequinKeys
+    from harlequin.options import HarlequinAdapterOption, HarlequinCopyFormat
+    from harlequin.transaction_mode import HarlequinTransactionMode
 
 __all__ = [
     "Harlequin",
@@ -19,3 +37,34 @@ __all__ = [
     "HarlequinKeyMap",
     "HarlequinKeyBinding",
 ]
+
+_LAZY_ATTRS = {
+    "Harlequin": "harlequin.app",
+    "HarlequinAdapter": "harlequin.adapter",
+    "HarlequinAdapterOption": "harlequin.options",
+    "HarlequinCompletion": "harlequin.autocomplete",
+    "HarlequinConnection": "harlequin.adapter",
+    "HarlequinCopyFormat": "harlequin.options",
+    "HarlequinCursor": "harlequin.adapter",
+    "HarlequinTransactionMode": "harlequin.transaction_mode",
+    "HarlequinKeys": "harlequin.keys_app",
+    "HarlequinKeyMap": "harlequin.keymap",
+    "HarlequinKeyBinding": "harlequin.keymap",
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name = _LAZY_ATTRS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    # cache on the module so subsequent lookups skip __getattr__ entirely
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Sequence
-
-from textual_fastdatatable.backend import AutoBackendType
+from typing import TYPE_CHECKING, Any, Sequence
 
 from harlequin.autocomplete.completion import HarlequinCompletion
 from harlequin.catalog import Catalog
 from harlequin.options import HarlequinAdapterOption, HarlequinCopyFormat
 from harlequin.transaction_mode import HarlequinTransactionMode
+
+if TYPE_CHECKING:
+    # `AutoBackendType` is an alias for `Any`, and importing it at run time costs
+    # every adapter ~265ms of pyarrow and (before 0.17) Textual.
+    from textual_fastdatatable.backend import AutoBackendType
 
 
 class HarlequinCursor(ABC):

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -46,8 +46,6 @@ from harlequin.catalog import (
     Catalog,
     CatalogItem,
     Interaction,
-    NewCatalog,
-    NewCatalogItems,
     TCatalogItem_contra,
 )
 from harlequin.catalog_cache import (
@@ -90,7 +88,7 @@ from harlequin.exception import (
     pretty_print_error,
 )
 from harlequin.history import History
-from harlequin.messages import WidgetMounted
+from harlequin.messages import NewCatalog, NewCatalogItems, WidgetMounted
 from harlequin.plugins import load_keymap_plugins
 from harlequin.transaction_mode import HarlequinTransactionMode
 

--- a/src/harlequin/catalog.py
+++ b/src/harlequin/catalog.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Generic, Protocol, Sequence, TypeVar
 
-from textual.message import Message
-
 if TYPE_CHECKING:
     from harlequin.adapter import HarlequinConnection
     from harlequin.driver import HarlequinDriver
@@ -102,16 +100,3 @@ class Catalog:
     """
 
     items: list[CatalogItem]
-
-
-class NewCatalog(Message):
-    def __init__(self, catalog: Catalog) -> None:
-        self.catalog = catalog
-        super().__init__()
-
-
-class NewCatalogItems(Message):
-    def __init__(self, parent: CatalogItem, items: list[CatalogItem]) -> None:
-        self.parent = parent
-        self.items = items
-        super().__init__()

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -17,10 +17,9 @@ from harlequin.catalog import (
     Catalog,
     CatalogItem,
     InteractiveCatalogItem,
-    NewCatalogItems,
 )
 from harlequin.components.data_catalog.tree import HarlequinTree
-from harlequin.messages import WidgetMounted
+from harlequin.messages import NewCatalogItems, WidgetMounted
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/harlequin/copy_widgets.py
+++ b/src/harlequin/copy_widgets.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from textual.validation import ValidationResult, Validator
 from textual.widgets import Input as Input
 from textual.widgets import Label
 from textual.widgets import Select as Select
@@ -7,3 +12,31 @@ from textual_textarea import PathInput as PathInput
 
 class NoFocusLabel(Label, can_focus=False):
     pass
+
+
+class CustomValidator(Validator):
+    """Adapts an option's `validator` callable to Textual's Validator interface.
+
+    Lives here rather than in `options.py` because subclassing `Validator` binds
+    Textual at class-definition time, which would make declaring an option cost
+    the framework.
+    """
+
+    def __init__(
+        self,
+        validator: Callable[[str], tuple[bool, str | None]] | None = None,
+        failure_description: str | None = None,
+    ) -> None:
+        super().__init__(failure_description)
+        self.validator = validator or (lambda _: (True, ""))
+
+    def validate(self, value: str) -> ValidationResult:
+        try:
+            is_valid, message = self.validator(value)
+        except Exception as e:
+            return self.failure(str(e))
+
+        if is_valid:
+            return self.success()
+        else:
+            return self.failure(message or "Validation failed.")

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -66,11 +66,13 @@ def pretty_error_message(error: HarlequinError) -> Panel:
 
 
 def pretty_print_warning(title: str, message: str) -> None:
-    from rich import print as rich_print
+    from rich.console import Console
 
     from harlequin.colors import GREEN
 
-    rich_print(
+    # Warnings go to stderr for the same reason errors do: rich.print would put
+    # them on stdout and contaminate piped output.
+    Console(stderr=True).print(
         Panel.fit(
             message,
             title=title,

--- a/src/harlequin/messages.py
+++ b/src/harlequin/messages.py
@@ -5,8 +5,23 @@ from textual.message import Message
 if TYPE_CHECKING:
     from textual.widget import Widget
 
+    from harlequin.catalog import Catalog, CatalogItem
+
 
 class WidgetMounted(Message):
     def __init__(self, widget: "Widget") -> None:
         super().__init__()
         self.widget = widget
+
+
+class NewCatalog(Message):
+    def __init__(self, catalog: "Catalog") -> None:
+        self.catalog = catalog
+        super().__init__()
+
+
+class NewCatalogItems(Message):
+    def __init__(self, parent: "CatalogItem", items: "list[CatalogItem]") -> None:
+        self.parent = parent
+        self.items = items
+        super().__init__()

--- a/src/harlequin/options.py
+++ b/src/harlequin/options.py
@@ -3,42 +3,18 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Callable, Generator, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Sequence
 
 import click
-import questionary
-from textual.validation import ValidationResult, Validator
-from textual.widget import Widget
 
-from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
-from harlequin.copy_widgets import (
-    Input,
-    NoFocusLabel,
-    PathInput,
-    Select,
-    Switch,
-)
+if TYPE_CHECKING:
+    import questionary
+    from textual.widget import Widget
 
-
-class _CustomValidator(Validator):
-    def __init__(
-        self,
-        validator: Callable[[str], tuple[bool, str | None]] | None = None,
-        failure_description: str | None = None,
-    ) -> None:
-        super().__init__(failure_description)
-        self.validator = validator or (lambda _: (True, ""))
-
-    def validate(self, value: str) -> ValidationResult:
-        try:
-            is_valid, message = self.validator(value)
-        except Exception as e:
-            return self.failure(str(e))
-
-        if is_valid:
-            return self.success()
-        else:
-            return self.failure(message or "Validation failed.")
+# Declaring an option must stay cheap: every adapter imports this module, and
+# `questionary` (130ms) and Textual (150ms, plus 264ms for the themes that
+# `harlequin.colors` pulls in) are only needed to *render* one. `to_widgets()`
+# and `to_questionary()` import what they need when they are called.
 
 
 def concatenate(first: str, second: str) -> str:
@@ -212,15 +188,21 @@ class TextOption(AbstractOption):
         )
 
     def to_widgets(self) -> Generator[Widget, None, None]:
+        from harlequin.copy_widgets import CustomValidator, Input, NoFocusLabel
+
         yield NoFocusLabel(f"{self.label}:", classes="input_label")
         yield Input(
             value=self.default or "",
             placeholder=self.placeholder or "",
             id=self.name,
-            validators=[_CustomValidator(self.validator)],
+            validators=[CustomValidator(self.validator)],
         )
 
     def to_questionary(self, existing_value: Any | None = None) -> questionary.Question:
+        import questionary
+
+        from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
+
         def _q_validator(raw: str) -> bool | str | None:
             if self.validator is not None:
                 result = self.validator(raw)
@@ -292,6 +274,10 @@ class ListOption(AbstractOption):
         raise NotImplementedError("No widget for ListOption.")
 
     def to_questionary(self, existing_value: Any | None = None) -> questionary.Question:
+        import questionary
+
+        from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
+
         if isinstance(existing_value, str):
             safe_existing_value = existing_value
         elif isinstance(existing_value, Iterable):
@@ -406,6 +392,8 @@ class PathOption(AbstractOption):
         )
 
     def to_widgets(self) -> Generator[Widget, None, None]:
+        from harlequin.copy_widgets import NoFocusLabel, PathInput
+
         yield NoFocusLabel(f"{self.label}:", classes="input_label")
         yield PathInput(
             value=self.default or "",
@@ -418,6 +406,10 @@ class PathOption(AbstractOption):
         )
 
     def to_questionary(self, existing_value: Any | None = None) -> questionary.Question:
+        import questionary
+
+        from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
+
         def _path_validator(raw_path: str) -> bool | str:
             try:
                 p = Path(raw_path)
@@ -508,6 +500,8 @@ class SelectOption(AbstractOption):
         )
 
     def to_widgets(self) -> Generator[Widget, None, None]:
+        from harlequin.copy_widgets import NoFocusLabel, Select
+
         choices: list[tuple[str, str]] = []
         for choice in self.choices:
             if isinstance(choice, str):
@@ -523,6 +517,10 @@ class SelectOption(AbstractOption):
         )
 
     def to_questionary(self, existing_value: Any | None = None) -> questionary.Question:
+        import questionary
+
+        from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
+
         try:
             safe_existing_value = str(existing_value)
         except (ValueError, TypeError):
@@ -589,10 +587,16 @@ class FlagOption(AbstractOption):
         )
 
     def to_widgets(self) -> Generator[Widget, None, None]:
+        from harlequin.copy_widgets import NoFocusLabel, Switch
+
         yield NoFocusLabel(f"{self.label}:", classes="switch_label")
         yield Switch(value=self.default, id=self.name)
 
     def to_questionary(self, existing_value: Any | None = None) -> questionary.Question:
+        import questionary
+
+        from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
+
         try:
             safe_existing_value = bool(existing_value)
         except (ValueError, TypeError):

--- a/src/harlequin/plugins.py
+++ b/src/harlequin/plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from importlib.metadata import entry_points
 from typing import Literal, Sequence, overload
 
@@ -51,8 +52,12 @@ def _load_plugins(
         try:
             ep_class = ep.load()
         except ImportError as e:
+            # stderr, not stdout: a plug-in failing to load must not end up in
+            # piped output.
             print(
-                f"Harlequin could not load the installed plug-in named {e.name}.\n\n{e}"
+                f"Harlequin could not load the installed plug-in named "
+                f"{e.name}.\n\n{e}",
+                file=sys.stderr,
             )
         else:
             plugins[ep.name] = ep_class

--- a/src/harlequin_duckdb/adapter.py
+++ b/src/harlequin_duckdb/adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import duckdb
 
@@ -10,8 +10,6 @@ try:
     from duckdb.sqltypes import DuckDBPyType
 except ImportError:
     from duckdb.typing import DuckDBPyType  # type: ignore[import-not-found,no-redef]
-
-from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
 from harlequin.autocomplete.completion import HarlequinCompletion
@@ -24,6 +22,9 @@ from harlequin.exception import (
 from harlequin_duckdb.catalog import DatabaseCatalogItem
 from harlequin_duckdb.cli_options import DUCKDB_OPTIONS
 from harlequin_duckdb.completions import get_completion_data
+
+if TYPE_CHECKING:
+    from textual_fastdatatable.backend import AutoBackendType
 
 IN_MEMORY_CONN_STR = (":memory:",)
 

--- a/src/harlequin_sqlite/adapter.py
+++ b/src/harlequin_sqlite/adapter.py
@@ -4,10 +4,8 @@ import sqlite3
 from contextlib import suppress
 from itertools import cycle, zip_longest
 from pathlib import Path
-from typing import Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 from urllib.parse import unquote, urlparse
-
-from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
 from harlequin.autocomplete.completion import HarlequinCompletion
@@ -22,6 +20,9 @@ from harlequin.transaction_mode import HarlequinTransactionMode
 from harlequin_sqlite.catalog import DatabaseCatalogItem
 from harlequin_sqlite.cli_options import SQLITE_OPTIONS
 from harlequin_sqlite.completions import get_completion_data
+
+if TYPE_CHECKING:
+    from textual_fastdatatable.backend import AutoBackendType
 
 IN_MEMORY_CONN_STR = (":memory:",)
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Callable
+
+import pytest
+
+
+@pytest.fixture
+def run_python() -> Callable[[str], subprocess.CompletedProcess[str]]:
+    """Run a snippet in a fresh interpreter and capture its streams.
+
+    In-process assertions can't see the state these tests care about: which
+    modules an import pulled in, and which stream something was written to.
+    Both are properties of a clean interpreter, and pytest has already imported
+    half the world by the time a test runs.
+    """
+
+    def _run(code: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    return _run

--- a/tests/unit_tests/test_exception.py
+++ b/tests/unit_tests/test_exception.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Callable
+
+
+def test_pretty_print_warning_goes_to_stderr(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """stdout belongs to query output; diagnostics go to stderr.
+
+    `pretty_print_error` has always got this right. `pretty_print_warning` used
+    `rich.print`, which writes to stdout -- and it is reached from the CLI path
+    by both the locale manager and the Windows tzdata installer.
+    """
+    proc = run_python(
+        "from harlequin.exception import pretty_print_warning\n"
+        "pretty_print_warning(title='A Title', message='A message.')\n"
+    )
+    assert proc.stdout == ""
+    assert "A message." in proc.stderr

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -1,0 +1,95 @@
+"""Run-time guards for the import hygiene the headless CLI depends on.
+
+The import-linter contracts in `pyproject.toml` read the static graph, so they
+cannot tell a module-scope import from one deferred into the function that needs
+it. These tests run the real thing in a subprocess and look at `sys.modules`,
+which is the only way to prove a deferral actually defers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Callable
+
+import pytest
+
+# Importing any of these must not drag in the TUI. They are the modules an
+# adapter -- or a headless front end -- reaches for.
+HEADLESS_IMPORTS = [
+    "import harlequin",
+    "import harlequin.adapter",
+    "import harlequin.autocomplete",
+    "import harlequin.catalog",
+    "import harlequin.config",
+    "import harlequin.exception",
+    "import harlequin.keymap",
+    "import harlequin.options",
+    "import harlequin.plugins",
+    "import harlequin.transaction_mode",
+    "import harlequin_duckdb",
+    "import harlequin_sqlite",
+    "from textual_fastdatatable.backend import create_backend",
+]
+
+FORBIDDEN = ("textual", "questionary", "prompt_toolkit", "sqlfmt")
+
+
+@pytest.mark.parametrize("statement", HEADLESS_IMPORTS)
+def test_headless_imports_do_not_load_the_tui(
+    statement: str, run_python: Callable[[str], subprocess.CompletedProcess[str]]
+) -> None:
+    proc = run_python(
+        f"{statement}\n"
+        "import sys\n"
+        f"print(','.join(m for m in {FORBIDDEN!r} if m in sys.modules))\n"
+    )
+    leaked = [m for m in proc.stdout.strip().split(",") if m]
+    assert not leaked, f"{statement!r} imported {leaked}"
+
+
+def test_public_names_still_resolve() -> None:
+    """Every name `harlequin/__init__.py` exported before it went lazy.
+
+    Each must resolve to the same object as a direct import from its home
+    module, and resolve to the *same* object twice (the second lookup is served
+    from the module globals, not `__getattr__`).
+    """
+    import harlequin
+    from harlequin.adapter import (
+        HarlequinAdapter,
+        HarlequinConnection,
+        HarlequinCursor,
+    )
+    from harlequin.app import Harlequin
+    from harlequin.autocomplete import HarlequinCompletion
+    from harlequin.keymap import HarlequinKeyBinding, HarlequinKeyMap
+    from harlequin.keys_app import HarlequinKeys
+    from harlequin.options import HarlequinAdapterOption, HarlequinCopyFormat
+    from harlequin.transaction_mode import HarlequinTransactionMode
+
+    expected = {
+        "Harlequin": Harlequin,
+        "HarlequinAdapter": HarlequinAdapter,
+        "HarlequinAdapterOption": HarlequinAdapterOption,
+        "HarlequinCompletion": HarlequinCompletion,
+        "HarlequinConnection": HarlequinConnection,
+        "HarlequinCopyFormat": HarlequinCopyFormat,
+        "HarlequinCursor": HarlequinCursor,
+        "HarlequinTransactionMode": HarlequinTransactionMode,
+        "HarlequinKeys": HarlequinKeys,
+        "HarlequinKeyMap": HarlequinKeyMap,
+        "HarlequinKeyBinding": HarlequinKeyBinding,
+    }
+    assert sorted(expected) == sorted(harlequin.__all__)
+    for name, obj in expected.items():
+        assert getattr(harlequin, name) is obj
+        assert getattr(harlequin, name) is getattr(harlequin, name)
+
+    assert sorted(dir(harlequin)) == sorted(harlequin.__all__)
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    import harlequin
+
+    with pytest.raises(AttributeError):
+        _ = harlequin.NotAThing

--- a/tests/unit_tests/test_plugins.py
+++ b/tests/unit_tests/test_plugins.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Callable
+
 import pytest
 
 from harlequin.cli import DEFAULT_KEYMAP_NAMES
@@ -19,3 +24,20 @@ def test_do_not_load_keymaps_that_duplicate_plugin_names() -> None:
     with pytest.raises(HarlequinConfigError) as exc_info:
         _ = load_keymap_plugins(user_defined_keymaps=[my_map])
     assert "vscode" in str(exc_info)
+
+
+def test_plugin_load_failure_goes_to_stderr(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """A plug-in that won't import must not contaminate piped output."""
+    proc = run_python(
+        "from unittest.mock import MagicMock, patch\n"
+        "ep = MagicMock()\n"
+        "ep.name = 'broken'\n"
+        "ep.load.side_effect = ImportError('no module named nope', name='nope')\n"
+        "with patch('harlequin.plugins.entry_points', return_value=[ep]):\n"
+        "    from harlequin.plugins import load_adapter_plugins\n"
+        "    load_adapter_plugins()\n"
+    )
+    assert proc.stdout == ""
+    assert "could not load the installed plug-in" in proc.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,108 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/73/ce58881177b003def779c87b5e10f396deef068933c97d6d206bd46d4cb7/grimp-3.15.tar.gz", hash = "sha256:91b57d4d801dc107ebfb5a7040d4777a152c579b5dc202426e1185e50931fe1e", size = 831734, upload-time = "2026-07-03T12:09:36.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/25/98a2c934f1cd57183379c742538c82c5b12be5019d347b7312c1858d24fe/grimp-3.15-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:daa46ccb1c6bb158bf1060f314a535136ae6f735a40014f9a42d9bd1a5d9dccb", size = 2141874, upload-time = "2026-07-03T12:08:46.926Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/40/a63edd7506e55d131274e70ac17ee39f367ceb30311ca5a11853bd23faaf/grimp-3.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6f0ef0b5f44bdd1e859c3019e325dc5fb5360e922b69fd2d29fc0b1ff98867fd", size = 2098011, upload-time = "2026-07-03T12:08:40.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/92/33adfc894474384c3ce8c2e4d2829f3c854a8fb5ffd70b9e899c17cd4694/grimp-3.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57bc558882a643811442b7cb88976af497a2b24096d251f2000d1d5caffd4eec", size = 2262954, upload-time = "2026-07-03T12:07:31.57Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1a/20191dece2ca62f0b57d623b43af745041df9bb52a7f541e4b68627c34c1/grimp-3.15-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4f4db552d3b4e62da6c223fb9b66eac7776db1369dd9b6795713dcb629ed26d", size = 2196652, upload-time = "2026-07-03T12:07:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/559f205a057aa9a997576d6431d6ac33a4ccc8c09c097e9b9ddb1cf4ba84/grimp-3.15-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ad1a9d1244aa4b6d60015d9f655dc91c113c5bedf3b454ee4aad51de3eae416", size = 2350845, upload-time = "2026-07-03T12:08:14.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/eb/c0824cea19d9d7890f62c28ce1589e5b7f1728e9e279771d61aefe80f280/grimp-3.15-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c0fa41d0bcb3f762f323d3d0ce2569c69f83053cd56be1270f3691feb8b3ba9", size = 2610304, upload-time = "2026-07-03T12:07:52.343Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ae/96d4ccfa7964af6662a6f90e3dd7d1fe5ee003699a292cbee03dabb4f64e/grimp-3.15-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2ca52d0505d6d7b59655e76f1dd4cc32b516ad7a388a1a2dcb0c583d0d8b6ff", size = 2331251, upload-time = "2026-07-03T12:08:03.246Z" },
+    { url = "https://files.pythonhosted.org/packages/53/8a/4a948cf4e8781851f9a3d4de6e3bd00f82a5eb928a2144c89b3d9d449868/grimp-3.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bba4bac2fdf6cd30967fdf7c71f200736c0340d8b3636f0aec1e2c4ae813805", size = 2278246, upload-time = "2026-07-03T12:08:27.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6e/f9674ca5dc379a564ab880796f11259b821e5322a82e5c66082838e631b1/grimp-3.15-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1661b1b4ad695c3126964635443699ed4cd994f240ea0758a5f3fc67a21b8111", size = 2440493, upload-time = "2026-07-03T12:08:54.511Z" },
+    { url = "https://files.pythonhosted.org/packages/79/77/4394d93f7b8068e26976bcc065d4c8271e507bee0b27406b7ba4d43850aa/grimp-3.15-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e66609ee48af343a909084838168f535f31fbe8cd23cc10518da4600139dfd3f", size = 2471830, upload-time = "2026-07-03T12:09:05.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/f207c2aa33a1401113db4b8e5824cbaf318046354ca5890643484ef7c50f/grimp-3.15-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:659962cc29f90ec23d42313c5aac15928242e7ed3113ac130ee4b7fc0624cbb2", size = 2511431, upload-time = "2026-07-03T12:09:15.034Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d6/d6697cb2a49cb3e2a6be58b4fe5e0bc645cafc7c4818d66ce0e77d75495f/grimp-3.15-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8a462896e003e5b4f71ef171901c0f6285137a8bbea7f5e01b887a8976acaf0d", size = 2520347, upload-time = "2026-07-03T12:09:25.574Z" },
+    { url = "https://files.pythonhosted.org/packages/71/85/5dc1948b6f1f1750c0299282c3292580e92e56c6676360fc00e2bff5bfc5/grimp-3.15-cp310-cp310-win32.whl", hash = "sha256:a209cc5618cb7657fa9659eb45c23b6f47e9c8b4da682369069892c534e9e0b6", size = 1856818, upload-time = "2026-07-03T12:09:45.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7a/be9cae20a270c25d1dc23a08e178bc66ab0a0a70a830bdda068170e26894/grimp-3.15-cp310-cp310-win_amd64.whl", hash = "sha256:9e3af741f8136452a7c29373c717ca8877e492b8efdf3da232391e9dbbb5dbe3", size = 1988060, upload-time = "2026-07-03T12:09:37.491Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/06/dd37dd3e282e90856215ea406415ba0c18cb77cf3150ffa47bd1137c8daf/grimp-3.15-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:cc467bdf890b26545989994c5f91d99fb2b911bbc09d48cebf906082fb2c01d1", size = 2140928, upload-time = "2026-07-03T12:08:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b0/9329b8df4916cd60a1b358e527fcb9239604a1eca88483deb68ab95d9d5a/grimp-3.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:571d62c2f2e264ed83a9b283b0c1e322902ea3af8a9ad20d9f7cc5be3049be25", size = 2097876, upload-time = "2026-07-03T12:08:41.571Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ff/4352eb0a6549faefeaae1514f2994f6d9148b12db10e49d94935109cd4cd/grimp-3.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0c36369902389e080f708560621f29e2b64957a6bfa5afb06c13b74105039d6", size = 2262242, upload-time = "2026-07-03T12:07:33Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/a7ddecd677891070277f92e71bc41c10c423a3317eb412f9636b4cbb32e3/grimp-3.15-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:44a3a576bb0c5d0754108f0b6cedbeaee66a123112c71a8f4796656c9e52c5cd", size = 2196892, upload-time = "2026-07-03T12:07:43.574Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e2/8a7502011e324902853df7daecc3d6d651464920aad93a1a7ad9bd833105/grimp-3.15-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80b833af82a197371c0b0b69ec600413d9b50109fec2f8e1e1317b1c226a3e07", size = 2348919, upload-time = "2026-07-03T12:08:16.589Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/0570ff9ea16c8280de2e84b52006dd588b208716e73794cb332c43d1eb72/grimp-3.15-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6167c3d6e30ac8ff0a32260edf51fad5c22ec77b04e85a8a0042c1ba78bf6846", size = 2609501, upload-time = "2026-07-03T12:07:53.841Z" },
+    { url = "https://files.pythonhosted.org/packages/33/14/34482976316834848df5eb68ec2283c13f84bfab12b21b8c11e4f3442e77/grimp-3.15-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e6c18582eb87e148da11ad6549ec006186460ed29959afb15e093c34696d0134", size = 2329567, upload-time = "2026-07-03T12:08:04.663Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1b/2803b1234cf5e663c00b9fb2318a93b8db3831942ff053276234fa6731ab/grimp-3.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c941ed53672f9d136f898bf41557062dc4ed4c4fd10c88e47499e7db1c436ec", size = 2277972, upload-time = "2026-07-03T12:08:29.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd25b4a61851db6ca82d4007e1981d9832dff7c34c7b02a975e0bf3da89f/grimp-3.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4d46417bd6fffa56814b1cf8ffe756fe761d8e5eb691f1d7aaa8a0aba37af05a", size = 2440215, upload-time = "2026-07-03T12:08:56.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/44/d065613d4cbdc108c33db5978351303cfcedfa2f6d55dcff432c722b3568/grimp-3.15-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1f39ca69733dc9cc2f4e7c6647ebbb9a85e1b615b6b808187b0fc6dc6f3a9354", size = 2471902, upload-time = "2026-07-03T12:09:06.502Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/1eb96d3b2f61d04a5bfe0502216e248cfa0dfe34697cf56ab74e762983d7/grimp-3.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dcbea03a4502291b6014530267a6447365557a7870524202034a9ceac4f26fdd", size = 2509411, upload-time = "2026-07-03T12:09:16.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b6/89a69f121848b2324403ace3e3487c0074bf1257507b743fbebd281d270f/grimp-3.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c88386fac08a96933387d4058ef246b191872f7bd75a01c8655b70c8d1a0433a", size = 2519817, upload-time = "2026-07-03T12:09:26.999Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/18/9916c71ad9039e74148d9d3b8da4b6cf87900290edc0e7be1a891c840b66/grimp-3.15-cp311-cp311-win32.whl", hash = "sha256:788e1f019052fd6b4dc24ed9892de4f0f24e8e845bd01d146ee549515f70a9bc", size = 1856929, upload-time = "2026-07-03T12:09:46.611Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/6b349a4aee939b52a244c87e49f584ecad7ca4db67aea70d2d49c7709c26/grimp-3.15-cp311-cp311-win_amd64.whl", hash = "sha256:bfe2d28a94eb97db739382c4d377c8c014020eb6cc1599bcf950c9a2a60fce9d", size = 1988289, upload-time = "2026-07-03T12:09:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/44/66/621abde26d8ece0d34ba611ca94bc62bf8c9c4389760d8909b0d96964878/grimp-3.15-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:915ea140cf55107fd6825c3e9eae2c4fda18aa19b87e8eee05d510b4d44ab928", size = 2143914, upload-time = "2026-07-03T12:08:50.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/76/a27fff8de84dbf46db9d6da937fe772f04a0e21e057a4863fd30e6fcaa55/grimp-3.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ae2d4d958d871792a9686ad51845e9e1e0886e9db13ecc47a9475899f4b27db", size = 2089296, upload-time = "2026-07-03T12:08:42.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3d/fe38a0881ce7e00ef8590745853bccff5d337a943dc0d1d0735b0eb605f9/grimp-3.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19a1039d50ed6a9b221f44b32c7b07cb43dda70971e892fe8149995c0e9c1840", size = 2254829, upload-time = "2026-07-03T12:07:34.365Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a2/ef18989048e8f0c92171eabb15dffe9cd72de6404b86e3a37553f7d16dd6/grimp-3.15-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b7b649f2a34278897237670b6650073c9ab0fc1abf56821301bda28cb5c4256", size = 2193553, upload-time = "2026-07-03T12:07:45.06Z" },
+    { url = "https://files.pythonhosted.org/packages/85/22/82303539d21068021cc28c526be5e1b1cc0b7a61704c1663909497dd9b8a/grimp-3.15-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:020a8875c0cb67f407eb019b7be65b574d49071653f155c243f801aa87a1fd4d", size = 2345941, upload-time = "2026-07-03T12:08:18.082Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/20/3c66e7c814ba2b6b0cd230ca2445825c605f28242f4f3a658e5bb9adda73/grimp-3.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f0a0705cf9a10648c4aea71edde8fe3dfbf1cf05bd434ef38c813ad7c544886", size = 2604369, upload-time = "2026-07-03T12:07:55.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/2f642969950e096a67a43909ba66f33cb4750974e30c2c771e293aeb787c/grimp-3.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c36373cd0a2d4c9b53fabefbaa9edcc4c511ad2d335fb1296484f6ca550e4f82", size = 2326619, upload-time = "2026-07-03T12:08:05.931Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/99/98d39545e54e239a52a54d8e96752780778b11b5ebc78096dfa090f9d2ac/grimp-3.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:477ac0abcd12c697a0bd01b40875605f7f0db97332df6148e4d4057ee3ad199d", size = 2272955, upload-time = "2026-07-03T12:08:30.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/02/fabd5ae2b12276530f4bae038ffcf3a556ac2c9b9fa271f83fbeb4036a08/grimp-3.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:017e493fee9962d50db6f7a8b5d49ad2ae508484a06078d700adbef30f1ff1f0", size = 2431271, upload-time = "2026-07-03T12:08:57.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c8/fa3ec84df9c3ccc2b08177be41a48b76178e9e5773f4471f1caff4fc5c46/grimp-3.15-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e77982dd5b0977945034fa328f65cfb62ff589cb0da97a0f6042de78525c5c73", size = 2466937, upload-time = "2026-07-03T12:09:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/52d3acd2bbd6cebdf2ee6546c334f50f6358c25ae58624ae63d2ec3ad30b/grimp-3.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d129a8c57b7a19a44e8da94caf38a02753f1c9953aaba8c1a4633747f097164f", size = 2504734, upload-time = "2026-07-03T12:09:17.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/ad27750eb8b4a0c3ecb5ca7d78c7230f0f5e814515ed6f8986be527117ff/grimp-3.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba25002e92b1792f13391295a1f805d2e09781b846d92ec1a791ff9ed89298b6", size = 2514448, upload-time = "2026-07-03T12:09:28.401Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c0/8cc474a24198c1c2936269c5854be92af41787bd76d3190af584a9cebca7/grimp-3.15-cp312-cp312-win32.whl", hash = "sha256:232bf7a4c7536f62a99478eeb01de63c455261add35ee00c6ec9f04f280f853e", size = 1855806, upload-time = "2026-07-03T12:09:48.396Z" },
+    { url = "https://files.pythonhosted.org/packages/91/11/e46139fd43dd5714fae93f09f1c858fb2dc83a575d5f8cb1daf8a15a261b/grimp-3.15-cp312-cp312-win_amd64.whl", hash = "sha256:13be2285e358a7687c0f3b798ac9d4819f275976ad8d651297966e5a75bfafb9", size = 1985556, upload-time = "2026-07-03T12:09:40.786Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/6a/3e0a0760cc509cd09764d128de78a1f329740306c74e42dba82c58a99118/grimp-3.15-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f19b957053d1c736aaa0015eed2d4855bb2511637c5360d32b3c5ea045904e7a", size = 2143197, upload-time = "2026-07-03T12:08:51.685Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2e/127cbce04a5603d382c6a2bbc1a19b6889be49d60b88864bcdb174c8926d/grimp-3.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6480472c2d1f7f6a903906c92e9897d4e3dee5d69ce3881f04368d4ec6d2dde", size = 2088342, upload-time = "2026-07-03T12:08:44.227Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/36/af9df683bf6c8711e0e9136876ca130f9971102d945ff3a36d0c45dae2ec/grimp-3.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c14b64dbf2e4397df2e35fa8aa7028533621ecf1f8ea7ec24bc296a9c695ea4", size = 2254509, upload-time = "2026-07-03T12:07:35.809Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f5/e712633b68ea14d04e7de84ede4f8ddbba763d5f2d29ae8d6af721f84870/grimp-3.15-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26364c2c9f7db88243365299b4d1c4d948b74304ff03c8a6e4f028147fed3b22", size = 2193831, upload-time = "2026-07-03T12:07:46.309Z" },
+    { url = "https://files.pythonhosted.org/packages/13/74/151bdd73d6a60bd77d4b956f36d03dd558dd46a9b5ec8f5ad15921b503d7/grimp-3.15-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69331e1be693415596c6084342059b9ba3ecf1cfe2e3b1c761598dd2fe14d522", size = 2345289, upload-time = "2026-07-03T12:08:19.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b8/3fc950fa73b757cbc35f77542bd662f431b9a8f360e63196ded640771a33/grimp-3.15-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe397991c269868c2fb08114099b2aa4f1bc803d03fadaaf97e006019f9e5da2", size = 2604407, upload-time = "2026-07-03T12:07:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d8/98916b9dc0b89a3e89e0d714ce0872be859fff40ceee3e2cb6886b106eb4/grimp-3.15-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d556bd62664ee044c47cff64d737be132408064d4ba68ca9f756cb29b41cc2d", size = 2326769, upload-time = "2026-07-03T12:08:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/63/51/39595c5857f609e976e0bba1f19c1f45182ee4d8d2ea5cdfab72841eafbc/grimp-3.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9061c5b6f01130ff8639c49c80176d29d921acc36741b2ae0b763a7668106082", size = 2272498, upload-time = "2026-07-03T12:08:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/a44cc9db500ae80c45425238ee44d9556796aa88b8c0649cfa613fb88d14/grimp-3.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a9d04c195f0c6da4476361560d3d206a6a784b9eb0da7156fc6974511337e2e3", size = 2431075, upload-time = "2026-07-03T12:08:58.935Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/41/544f197ddb44990789683c25740ffa72474a57f0b16bc6b4a544edf9a2a9/grimp-3.15-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:01fd68c74cfd08b110bfd338d77efaa470670530f7179e6977764f44cd74d5cc", size = 2467361, upload-time = "2026-07-03T12:09:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b1/8261018b9f1ab47fffbb7739d7af3f04c8b529555b7fb2ae8b742d42d3db/grimp-3.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bd1ddd428a124d6730bed49ea60fb2ca6c8e0640c8f5abe1d0f6fc27a92fd8bc", size = 2503500, upload-time = "2026-07-03T12:09:19.585Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d6/99a2421c4c0de9f203a7e246030b13b676766e62e48504883863942646fb/grimp-3.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07e645e9d45ed43bb8ea8da5982c19eacf13ee685d8440e3dc280064c005599c", size = 2513834, upload-time = "2026-07-03T12:09:29.758Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a5/263729e23d64541cd99d36dbb592e29c1ecea803deb3bb5c0c463b43c2ec/grimp-3.15-cp313-cp313-win32.whl", hash = "sha256:473646e0a74a554b4ab071d7fcbf5f442eb8cf87561770dae269818636b8edf2", size = 1855743, upload-time = "2026-07-03T12:09:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/a072bbea2e2e94da38f90bd8794037c90fb4eba389b49d01cdd2bb85e13c/grimp-3.15-cp313-cp313-win_amd64.whl", hash = "sha256:dbc2c15a1fbca2ff358f86cc90067176096dd73bec27d002515521b3125ba507", size = 1984546, upload-time = "2026-07-03T12:09:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4f/311bd40c02d61eee0182cb8c9b6ded37d42bed9a334e5ba4dacbe1c4c997/grimp-3.15-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6db0b30683612be4571b6b6208e1b39b77faa54566c5ca4f086d64cc783e4864", size = 2144799, upload-time = "2026-07-03T12:08:53.215Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/86e941cc26bd3419b5e2abb8b48fa35b850e5508f14e033f3ce28bfce608/grimp-3.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e731a1f8a192a802e04d4018d6cce9f4a12ce48b6b73f43014bd4e0a5d04a8e9", size = 2090802, upload-time = "2026-07-03T12:08:45.489Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/09/bcb4e380596e533ef9ebb3f164ad3cc113fde62318ca5af71a27886b1612/grimp-3.15-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cb607ee3e16440fc59ec2b49eef1b6dbbe701af9e99990b6491e6f120bd60b5", size = 2255870, upload-time = "2026-07-03T12:07:37.207Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/84/361cebbd7b14ce15d93bfb65e2b0ff30287252ffa6ab0b7fe08e029eae6c/grimp-3.15-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0492b9f1120176146d81e51aa0691aa6c004cdf5192ab309a221f9b223dedfc", size = 2193359, upload-time = "2026-07-03T12:07:47.548Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d6/c4dd785e149c3c66494822c8b46f0a36cbdf5a5400eeb2172e0a8b029d0f/grimp-3.15-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1bb3dbb0471179e732400fdf31c8c8d0299c88d13dd3a3bbe77ce54fb3f1b545", size = 2346350, upload-time = "2026-07-03T12:08:20.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4b/470922cb9d0a4b0436bb298801f770c98c6953374ff84e545dd7a196aa66/grimp-3.15-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b578512dbaee7eba2900d8078eaf1f7f78aa7616c609b0849b8403012ffddda", size = 2604959, upload-time = "2026-07-03T12:07:58.924Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e1/061dd80f5f0abb3ac53b29ade25ffac3e464e6853e8ce31dc6c6a33a06a9/grimp-3.15-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1a550a14cd2f8123fb06814b705f3af093fa1728b244f21ebcccc8d0da0f851", size = 2327185, upload-time = "2026-07-03T12:08:10.142Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/32281e7b5fcd5622f4666b36003b9931ca0e112f2955f09458f198a30f65/grimp-3.15-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db5ebb94ec356eaa5242145c993bc84c4b52d0d2c6980dfcd12b22d51c5b2c46", size = 2273241, upload-time = "2026-07-03T12:08:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/b4f6ae15484541decbe4f12cf39a4a769352cb06332e428cc8e64aed4a32/grimp-3.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e03331418d7fee746e2447ecf5296986e6f094ef15fd25125efad2328844edf7", size = 2433114, upload-time = "2026-07-03T12:09:00.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a2/7bdc628435a1e908aa53b351ce031a6134efd18245c4a5a4c28e1e6d19aa/grimp-3.15-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4cc91cb69e73e7899feb6ce73747f4dc092c2bfe2653f6cba69a398cd1dfc6ea", size = 2467235, upload-time = "2026-07-03T12:09:10.677Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/18/77853f5693d607d5f49c7e3cd58e482ef8362ea9cf86d0fcb108e4168195/grimp-3.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a848d5b4b656c1e3a28cce0d399f2790ecbeb2eeb78bb49896018614c87219f3", size = 2506552, upload-time = "2026-07-03T12:09:20.908Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bd/a094d7dd7115e8764e8069d5d3a44045c333b41d98a5746e99ec712b4b18/grimp-3.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:208ef56397cabfab52864b3d8a461fb5015a056fede1be4587e4453b13aa8c2f", size = 2514255, upload-time = "2026-07-03T12:09:31.383Z" },
+    { url = "https://files.pythonhosted.org/packages/85/68/013c640df50968b5d25802a5f01b157514d4e0ccd48c37c63947610a0e05/grimp-3.15-cp314-cp314-win32.whl", hash = "sha256:74d32fae3d222888f6b61579998043579dd810ed948785896e552906cbfdfcb7", size = 1856182, upload-time = "2026-07-03T12:09:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0b/648a1d77dfc5c2fd24fbdca0a45ee1c24669d981d12652424f5c34e3352c/grimp-3.15-cp314-cp314-win_amd64.whl", hash = "sha256:6b36e179d485c797e7fa234803620af752039fa27a8c7e3182333d7c96041f70", size = 1985451, upload-time = "2026-07-03T12:09:43.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c6/fd88ea799d181c22ab47c6cb328e7be3e196c8395444af89fd8da401cf6b/grimp-3.15-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9107d1037ee6e250ab7a15e1b758e0af76c841c19838b3cc688885a0b3817b5", size = 2253182, upload-time = "2026-07-03T12:07:39.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d9/25377ba259772edfa97e35e265d89eb89b966a82652967c8479902741067/grimp-3.15-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b88975b2882edc55e8946640f7b36dfb83cce1303cff5f8528c3f4819d7fbb07", size = 2191822, upload-time = "2026-07-03T12:07:48.721Z" },
+    { url = "https://files.pythonhosted.org/packages/23/64/cae8ca43e05aa5217ca2e17ffbda77e86cb215c1a9a03592c110c0162f27/grimp-3.15-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0fe01a5393e415e3d99b22c7dc6c6a9cc1b633714707d1c6b56ecbaccc2132f5", size = 2344413, upload-time = "2026-07-03T12:08:21.976Z" },
+    { url = "https://files.pythonhosted.org/packages/39/32/feea8fec71e62394013865314854ccb3d7bb54f226564fd267e6662f509a/grimp-3.15-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd4d70a0de010a9b452b59326a00574f7488dd1333d003df624114e5e00e877e", size = 2602856, upload-time = "2026-07-03T12:08:00.263Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ab/46ccdeb698398264d774273a9b8d9b013c8d23127d05371489b22dcf3ea5/grimp-3.15-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:204beed673ff43ab4ebe52ff4efd29b80025ec777136a62109afb69792d7fae0", size = 2326095, upload-time = "2026-07-03T12:08:11.432Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ae/f98c2c964a850ab80341d02576ef8681e75178f893ba2c73dc03e6563925/grimp-3.15-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1602be339f8a4d368d71758814e5505200cf665818eb0f9a2cc74d71ecc8cf1c", size = 2274375, upload-time = "2026-07-03T12:08:34.598Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/38/9355cdb28fab458fb8defca6406de303d78af617aa0d8c9ae5253b4e5a8b/grimp-3.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:077c27a1e6ff3baf23a8caaa1d74cbbac27024b069956dd6ca5fc3acd43ddb4b", size = 2430307, upload-time = "2026-07-03T12:09:02.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/06/edfa7f8064c1a3502fe4aba56c07bd122e94e329188939d52c02bd7e85b6/grimp-3.15-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:5516fc38899f4396eff68e6b1997310b4de2d0155e3fad9f545e666c993985b3", size = 2464014, upload-time = "2026-07-03T12:09:12.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c2/153b5cc3106814504b4195c7d4c178d85732d35b8895185a02112b8f9a03/grimp-3.15-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:dbe8e14cc61af4eea8e7ed6f2108828101f57fe86273d5b61cff044b69e6c6b5", size = 2502010, upload-time = "2026-07-03T12:09:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3f/ae4ba51cf484030e3d15b3304eb7ab9039fe91fb35ff5e90d60fde135bff/grimp-3.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1763b7b48ed6c9e6de838d0d64f19510a392235266cf2240c9be9cc25ca7c54b", size = 2514787, upload-time = "2026-07-03T12:09:33Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5f/0fb2d2bc9fe6bce899947802c94531c24e581c715db19216b941c1b2422f/grimp-3.15-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:116c3a6dba61bd302919b82cb5d603f5977e321d80d7de3c7a1265357ab9dd66", size = 2345635, upload-time = "2026-07-03T12:08:23.406Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ac/05d859a62ed9282f43a0f0962da230c46a2eb3d3ecb5b39117b3b4888405/grimp-3.15-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcc2e5065d35047729e41a55c9c3eb99810cf322fe3b3e89fa126f306ce6b3b5", size = 2273647, upload-time = "2026-07-03T12:08:36.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/dd/f726316f54e29da4f24d545d6299e1ea0accfbbf52729077fd4a619de055/grimp-3.15-cp315-cp315t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b38327673df49203cff0ebcbbf078999a80f0b11bb654760059f6f00f56f64d6", size = 2344080, upload-time = "2026-07-03T12:08:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/56/523a8f969f0a0b0a8ce43fbe8bc7a04e90f52724efc85f3305f1e07ae626/grimp-3.15-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:965b37dad2f73164a103381c9fd1255bb3b2f6021ca2f38ffe70dd00fdc0fc55", size = 2275041, upload-time = "2026-07-03T12:08:37.582Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/562e56ba1abecc40169aa40fbf62ba5dcda0f56d953b53eeeb5e43535fb2/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:391bca4c4f1c4dc58f10fadd8e4bba1ca1dbf848a5adb4e66907258135aa0b26", size = 2263708, upload-time = "2026-07-03T12:07:40.836Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6a/2fe608f847630675b06a4e635024771b897f4ea9d1c0d3063f83ed1b7fc8/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:08f7e663a465b524c5c0e121e6dd759f282ce35f406bc95bd68deda63a604361", size = 2198790, upload-time = "2026-07-03T12:07:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/31/49/8365239abbe735d8e103dc19f485e57383f8a435a0ae3b2ba7576e2d8bb7/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5625a037e9fc04c6371effb213efb827d225f5a64e04bff5f448adf180193da9", size = 2352309, upload-time = "2026-07-03T12:08:26.377Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/76/c1679a9eb0ac4ac2fc943fdcf47c1d59a200fd8daac3db6bd72c63e45cf9/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4651d29d4ee69bd5a1d9aa963ac73e420da1386f0a2263b8acbc0ae495fda12c", size = 2611854, upload-time = "2026-07-03T12:08:01.912Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/cf/56e47ded5188088ad0b9455cd74182c536a2f6fed29f1d4c0d7b20617b5d/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f73dcb7fb94b3a450dea3a95d63e179a715f315e2e0ff5b78aedf8b3dad8707c", size = 2331437, upload-time = "2026-07-03T12:08:12.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c8/47cb1dcf0819506915bb5a20dff70bddd518199808c67e1aba730a2fedbc/grimp-3.15-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:228e044bc458ee840ab20e1839efbecdecdd151d22ae3902a0f03aa94de772df", size = 2279755, upload-time = "2026-07-03T12:08:38.982Z" },
+    { url = "https://files.pythonhosted.org/packages/38/90/6202e5fa8ffd3648b2fbcd1d6028c6224a278f557073cc3f8094f0a01cd5/grimp-3.15-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:bbaa9053652d29733ff88277b554e716e5acc40b37d12841c972779196d2c0ef", size = 2441806, upload-time = "2026-07-03T12:09:03.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b6/2d82c6b6161169b0cb87ccb746e3a590c5a9fb54cb7c59d6c657ed731394/grimp-3.15-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:12fd9e675e6fcf633a5d14f6cbeee4b667a3d3307c91653ccc1a5aef03f53ec6", size = 2472941, upload-time = "2026-07-03T12:09:13.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/36/fb2906ed60288b236867829f9b3ced558a2725225ec0ed2354a7124a0474/grimp-3.15-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:0012653561d80b4e4972ac246deb569051a1fbf3880d620a9475e7159722bbab", size = 2513392, upload-time = "2026-07-03T12:09:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d2/ec5f501d9623fe8eb2d517ab7528708b672dba51322a931515b58b659f6f/grimp-3.15-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e438ae00dfd554c6262e92c945ec233c5e311cc99fdb0d602c6063b4f5fc3d9c", size = 2522530, upload-time = "2026-07-03T12:09:34.518Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1267,6 +1369,7 @@ dev = [
 ]
 static = [
     { name = "boto3-stubs" },
+    { name = "import-linter" },
     { name = "mypy" },
     { name = "pandas-stubs" },
     { name = "ruff" },
@@ -1303,7 +1406,7 @@ requires-dist = [
     { name = "rich-click", specifier = "==1.9.8" },
     { name = "shandy-sqlfmt", specifier = ">=0.28.2" },
     { name = "textual", specifier = "==8.2.8" },
-    { name = "textual-fastdatatable", specifier = "==0.16.0" },
+    { name = "textual-fastdatatable", specifier = "==0.16.1" },
     { name = "textual-textarea", specifier = "==0.18.1" },
     { name = "tomlkit", specifier = ">=0.12.5,<0.14.0" },
 ]
@@ -1319,6 +1422,7 @@ dev = [
 ]
 static = [
     { name = "boto3-stubs", specifier = ">=1.34.23,<2" },
+    { name = "import-linter", specifier = ">=2.5" },
     { name = "mypy", specifier = "==2.0.0,<3" },
     { name = "pandas-stubs", specifier = ">=2,<3" },
     { name = "ruff", specifier = ">=0.14.1" },
@@ -1538,6 +1642,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/c6/42962eb043df4d6984c1540220735b20442572fe37dab5e65ac807c939b9/import_linter-2.13.tar.gz", hash = "sha256:13af4a1d6b06044c58ea784e8732fd7fe48eec821a75feb4d6a1a2de36dd5c27", size = 1279761, upload-time = "2026-07-03T14:00:31.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/13/e7725e6eb32607fd4af51ccf3edfe835826e5cdf783b4d7fdc8f459196ae/import_linter-2.13-py3-none-any.whl", hash = "sha256:c0372e7ee5e15657bc06a8e841445e13237afd738a672d26863dc927af9f0bf5", size = 638185, upload-time = "2026-07-03T14:00:29.676Z" },
 ]
 
 [[package]]
@@ -3361,7 +3481,7 @@ wheels = [
 
 [[package]]
 name = "textual-fastdatatable"
-version = "0.16.0"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -3370,9 +3490,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/78/f03f3a2ef4f47b1e2d1143b5ab04964bb08619854bc1fab793db8623aa71/textual_fastdatatable-0.16.0.tar.gz", hash = "sha256:9d91f6d257bde25e244379d03b3fbcc92edafcfae983d8270ad34b0f344f1d97", size = 36203, upload-time = "2026-08-05T02:39:57.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/9c/1f53a1eee8a3e4b7e305b7d67986253f23bbbc1b87015f39eab0a493b30c/textual_fastdatatable-0.16.1.tar.gz", hash = "sha256:b9ad8af9f839c7151b16b0a49fd8a8c5790e4593ff69598520aa74c145a8751b", size = 36676, upload-time = "2026-08-07T02:16:18.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d8/9e7358e413d8fb1b371e8fea243b70e063acc6d8bd81517a083376ee7ce2/textual_fastdatatable-0.16.0-py3-none-any.whl", hash = "sha256:8df93215fbccec8e2a41b55f4df2bedceaaa4471e5323f36cbf4a9e73b18f63e", size = 33760, upload-time = "2026-08-05T02:39:56.669Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5e/9faba936d546143e1265587db7227ed20aa26ad51496837fa9ae8d77b283/textual_fastdatatable-0.16.1-py3-none-any.whl", hash = "sha256:893dcf34b70d489e6aee79502c61e819ce0aefa272bfe58fa6b0ee0a625c66dd", size = 34065, upload-time = "2026-08-07T02:16:17.307Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Toward #524. This is **PR 1 of the M1 `hsql` plan** — "Import hygiene, and the guard that keeps it" (`docs/plans/m1-hsql-technical-plan.md` §4). The value is that the adapter API becomes importable without the TUI, which is the precondition for everything else in Release A.

**What** are the key elements of this solution?

Each bullet is one of the five causes in §1.2 of the plan:

1. **`harlequin/__init__.py` resolves its public names through a PEP 562 `__getattr__`.** Importing *any* `harlequin.*` submodule executes this `__init__`, which imported `harlequin.app` at module scope — a ~660ms floor under every consumer, including adapters that never touch the TUI. All eleven exported names still resolve, from the same modules, and are cached in module globals on first access.
2. **`AutoBackendType` moves under `TYPE_CHECKING`** in `adapter.py`, `harlequin_duckdb`, and `harlequin_sqlite`. It is an alias for `Any`, and importing it cost every adapter `textual_fastdatatable.backend`.
3. **`NewCatalog`/`NewCatalogItems` move to `harlequin/messages.py`.** They are Textual messages that lived in `catalog.py`, which every adapter imports. Nothing imports them but the app, so they move with no shim and no deprecation.
4. **`options.py` defers its renderer imports** into `to_widgets()` and `to_questionary()`. Declaring an option no longer costs `questionary` (130ms) or Textual (150ms, plus 264ms for the themes `harlequin.colors` pulls in). `_CustomValidator` becomes `copy_widgets.CustomValidator`, because subclassing `Validator` binds Textual at class-definition time and can't be deferred in place.
5. **The two stdout leaks from §1.5 are fixed** — a plug-in that fails to import, and `pretty_print_warning` — both now write to stderr, as `pretty_print_error` already did.

Cause 3 in §1.2 is upstream, so this also **bumps `textual-fastdatatable` to 0.16.1**, the release that makes the `DataTable` widget a lazy import and defers `pyarrow.parquet`. Without it, moving `AutoBackendType` under `TYPE_CHECKING` would still leave the backend unreachable without Textual.

Plus the guards the plan asks for: two import-linter contracts, `tests/unit_tests/test_import_hygiene.py`, and `scripts/cold_start.py` (with a `make cold-start` target and a CI step that writes the table to the job summary).

Measured best-of-five against `origin/main` at the same commit, on a quiet machine:

| import | before | after | Textual? |
| --- | --- | --- | --- |
| `harlequin_duckdb` | 768ms | **121ms** | no |
| `harlequin_sqlite` | 699ms | **65ms** | no |
| `harlequin` | — | **21ms** | no |
| `from harlequin import Harlequin` (the TUI) | 685ms | 685ms | yes, as it should |

`import duckdb` alone is 85ms of that 121ms, so Harlequin's own share is ~36ms. Re-measured against the released 0.16.1 wheel as a paired before/after run, the ratios hold: 6.1x for duckdb and 11.9x for sqlite, with identical module counts.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**The two guards check different things, and both are needed.** import-linter reads the static graph, so it cannot distinguish a module-scope import from one deferred into the function that needs it — every deferral introduced here shows up as a contract violation. Rather than weaken the contract, the four deliberate deferrals are listed in `ignore_imports`, one commented line each, so a reviewer sees exactly what is exempt and any *new* route to Textual still fails. The subprocess tests are what prove the deferrals actually defer: they import each module for real and read `sys.modules`. A new deferral needs an entry in both places, which is the point.

Timing is deliberately not asserted. §5 of the plan is explicit that a wall-clock assertion on a shared runner is a flaky test that gets deleted within a month, so `cold_start.py` is informational and reports into the job summary; the blocking guards are the deterministic ones.

**Deferred imports have a real readability cost**, and they are confined to the three functions where the money is: two renderer methods and one warning printer. `click` stays at module scope in `options.py` — it is 21ms net, and both commands need it.

Note for review
- **The first commit is `ruff format` on the M1 plan doc, and is unrelated to this work.** ruff 0.16 formats Python code blocks inside Markdown and the lockfile pins 0.16.1, so `ruff format . --diff` — which the static workflow runs — already fails on `main` as merged. I verified that against a clean `origin/main` worktree. It's a whitespace-only change to code blocks, no prose touched; it's in its own commit so it can be dropped or landed separately.
- `AGENTS.md` gains an "Import hygiene" section stating the invariant and both guards, since this is exactly the kind of rule a future contributor would undo by accident.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

- `tests/unit_tests/test_import_hygiene.py` — the thirteen headless import paths, and the lazy package root: all eleven public names resolving to the same objects as a direct import, and `AttributeError` still raised for anything else.
- `tests/unit_tests/test_plugins.py`, `tests/unit_tests/test_exception.py` — the two stdout leaks, each with the module it covers. The subprocess runner they share is a fixture in the new `tests/unit_tests/conftest.py`.

Full suite: 205 passed, 6 skipped, 140 snapshots passed on 3.10; 3 passed on the `py12` selection. `ruff`, `mypy --no-incremental` and `lint-imports` all clean.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [ ] I acknowledge Harlequin's MIT license. I do not own my contribution.