### PR TITLE
refactor: extract the statement splitter and execution core (#524)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,16 @@ import-linter reads the *static* graph, so it cannot tell a deferred import from
 
 `plugins.py` loads both groups via `importlib.metadata.entry_points`; a plugin that fails to import prints a warning instead of taking down the app.
 
+### The execution core (`statements.py`, `query.py`)
+
+Both front ends run queries through here, and neither may grow its own copy.
+
+`statements.split()` and `statements.find_separators()` are the **only** SQL splitter. They drive `tree-sitter-sql` directly — no Textual, no textual-textarea — through the one-line `(";" @semicolon)` query the Query Editor has always used, so `-f script.sql` and the editor cannot disagree about where a statement ends. Tree-sitter reports **byte** columns; everything this module returns is in characters, and that conversion belongs here and nowhere else.
+
+`query.execute()` runs statements and `query.fetch()` drains one cursor into a `ResultSet`. Keep them two phases: that split is what lets the app say "query executed" before data materializes. `fetch()` normalizes through `textual_fastdatatable.create_backend()` — a second normalizer would put "what counts as a row, what counts as null" in two places, and the disagreement would show up as two front ends rendering the same query differently.
+
+`RowLimit` carries `detect_overflow` because Harlequin has two different limits: the app's `--limit` is a *soft display cap over a full fetch*, so it knows the exact total; a headless caller wants the *hard* one, and can only learn it was truncated by asking for one row more than it keeps.
+
 ### The adapter contract (`adapter.py`, `catalog.py`, `driver.py`)
 
 `HarlequinAdapter` (built from CLI/config options) → `connect()` → `HarlequinConnection` (execute, get_catalog, optional copy/cancel/transaction-mode/completions) → `HarlequinCursor` (columns, set_limit, fetchall). Adapters must tolerate receiving both subsets and supersets of their declared options, and must not rely on option defaults.
@@ -91,6 +101,8 @@ Changing anything in `adapter.py`, `catalog.py`, or `driver.py` is a public API 
 ### App and threading model (`app.py`)
 
 `Harlequin(AppBase)` composes `DataCatalog | (EditorCollection, RunQueryBar, ResultsViewer)` plus a footer. The invariant to preserve: **all database work happens in `@work(thread=True, exclusive=True, exit_on_error=False, group=...)` workers that never mutate widgets.** Workers `post_message(...)`; `@on(...)` handlers on `Harlequin` own all state changes. The query path is `QuerySubmitted → _execute_query → QueriesExecuted → (fetch) → ResultsFetched`, with parallel flows for `DatabaseConnected`, `NewCatalog`/`NewCatalogItems`, `CompletersReady`, and `TransactionModeChanged`.
+
+Both query workers are thin wrappers over the execution core above: `_execute_query` calls `query.execute()`, `_fetch_data` calls `query.fetch()`. New query behavior belongs in the core, where `hsql` can reach it, not in the worker.
 
 Adapters are third-party code: a raw driver exception (not a `HarlequinQueryError`) must surface as an error modal, never crash the app.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Running a selection no longer splits in the wrong place when a line has non-ASCII text before a semicolon ([#1018](https://github.com/tconbeer/harlequin/issues/1018)). `select '日本語';select 2` ran as `select '日本語';select` and `2`, both syntax errors, because tree-sitter reports columns in bytes and the editor read them as characters.
 - A plug-in that fails to import now reports it on stderr instead of stdout, so the message can no longer contaminate piped output.
 - Warnings raised while setting the locale or installing the Windows timezone database now go to stderr, for the same reason. Errors already did.
 
 ### Dependencies
+
+- `tree-sitter` and `tree-sitter-sql` are now direct dependencies of Harlequin ([#524](https://github.com/tconbeer/harlequin/issues/524)). Both were already installed for everyone, transitively via `textual[syntax]`; Harlequin now drives the SQL grammar itself to split statements, so it depends on them explicitly. Consequently the Query Editor no longer has a degraded, regex-based splitting mode, and no longer warns that tree-sitter is unavailable — statements split correctly even when the editor cannot syntax-highlight.
 
 - Reserves the `hsql` name on PyPI for Harlequin's planned headless CLI ([#524](https://github.com/tconbeer/harlequin/issues/524)). `hsql` is a metapackage that only depends on `harlequin`; it ships no modules and no `hsql` command yet, so `pip install hsql` simply installs Harlequin.
 - Upgrades `textual-fastdatatable` to 0.16.1 (from 0.16.0), which makes the `DataTable` widget a lazy import and defers `pyarrow.parquet`, so the backend Harlequin's adapter interface types against can be imported without Textual.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Running a selection no longer splits in the wrong place when a line has non-ASCII text before a semicolon ([#1018](https://github.com/tconbeer/harlequin/issues/1018)). `select '日本語';select 2` ran as `select '日本語';select` and `2`, both syntax errors, because tree-sitter reports columns in bytes and the editor read them as characters.
+- Running a selection no longer splits in the wrong place when a line has non-ASCII text before a semicolon ([#1015](https://github.com/tconbeer/harlequin/issues/1015)). `select 'café';select 2` ran as `select 'café';s` and `elect 2`, both syntax errors, because tree-sitter reports columns in bytes and the editor read them as characters.
 - A plug-in that fails to import now reports it on stderr instead of stdout, so the message can no longer contaminate piped output.
 - Warnings raised while setting the locale or installing the Windows timezone database now go to stderr, for the same reason. Errors already did.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,8 +263,8 @@ ignore_imports = [
 [[tool.importlinter.contracts]]
 
 # The headless execution core. It may reach `textual_fastdatatable.backend` --
-# that is where result normalization lives, and as of 0.17 it costs no Textual
-# -- but nothing here may reach Textual itself or any part of the app.
+# that is where result normalization lives, and as of 0.16.1 it costs no
+# Textual -- but nothing here may reach Textual itself or any part of the app.
 name = "The execution core is reachable without the TUI"
 type = "forbidden"
 source_modules = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,13 @@ dependencies = [
     # 1.9 is the first release compatible with click 8.2's Parameter.make_metavar()
     "rich-click==1.9.8",
 
+    # statement splitting. Both arrive anyway, transitively, via
+    # textual-textarea's `textual[syntax]` -- but `harlequin.statements` drives
+    # the grammar directly, without Textual, so the dependency is declared here
+    # rather than relied on incidentally.
+    "tree-sitter>=0.25,<0.27",
+    "tree-sitter-sql>=0.3.11,<0.4",
+
     # other deps
     "duckdb>=1.1.1; python_version < '3.14'",
     "shandy-sqlfmt>=0.28.2",
@@ -251,6 +258,31 @@ ignore_imports = [
     "harlequin.options -> harlequin.colors",         # to_questionary()
     "harlequin.options -> questionary",              # to_questionary()
 ]
+
+
+[[tool.importlinter.contracts]]
+
+# The headless execution core. It may reach `textual_fastdatatable.backend` --
+# that is where result normalization lives, and as of 0.17 it costs no Textual
+# -- but nothing here may reach Textual itself or any part of the app.
+name = "The execution core is reachable without the TUI"
+type = "forbidden"
+source_modules = [
+    "harlequin.query",
+    "harlequin.statements",
+]
+forbidden_modules = [
+    "questionary",
+    "textual",
+    "textual_textarea",
+    "harlequin.app",
+    "harlequin.colors",
+    "harlequin.components",
+    "harlequin.copy_widgets",
+    "harlequin.keys_app",
+    "harlequin.messages",
+]
+unmatched_ignore_imports_alerting = "error"
 
 
 [[tool.importlinter.contracts]]

--- a/scripts/cold_start.py
+++ b/scripts/cold_start.py
@@ -28,6 +28,7 @@ import time
 STEPS: list[tuple[str, str]] = [
     ("interpreter only", "pass"),
     ("harlequin", "import harlequin"),
+    ("harlequin.statements", "import harlequin.statements"),
     ("harlequin.catalog", "import harlequin.catalog"),
     ("harlequin.options", "import harlequin.options"),
     ("harlequin.config", "import harlequin.config"),
@@ -36,6 +37,7 @@ STEPS: list[tuple[str, str]] = [
         "fastdatatable backend",
         "from textual_fastdatatable.backend import create_backend",
     ),
+    ("harlequin.query", "import harlequin.query"),
     ("harlequin_sqlite", "import harlequin_sqlite"),
     ("harlequin_duckdb", "import harlequin_duckdb"),
     ("harlequin.cli", "import harlequin.cli"),

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     Dict,
-    List,
     Optional,
     Sequence,
     Type,
@@ -33,11 +32,10 @@ from textual.widget import AwaitMount, Widget
 from textual.widgets import Button, Footer, Input
 from textual.worker import Worker, WorkerState
 from textual_fastdatatable import DataTable
-from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin import HarlequinConnection
 from harlequin.actions import HARLEQUIN_ACTIONS
-from harlequin.adapter import HarlequinAdapter, HarlequinCursor
+from harlequin.adapter import HarlequinAdapter
 from harlequin.app_base import AppBase
 from harlequin.autocomplete import completer_factory
 from harlequin.autocomplete.completers import MemberCompleter, WordCompleter
@@ -90,6 +88,8 @@ from harlequin.exception import (
 from harlequin.history import History
 from harlequin.messages import NewCatalog, NewCatalogItems, WidgetMounted
 from harlequin.plugins import load_keymap_plugins
+from harlequin.query import ExecutedStatement, ResultSet, RowLimit, execute, fetch
+from harlequin.statements import Statement
 from harlequin.transaction_mode import HarlequinTransactionMode
 
 if TYPE_CHECKING:
@@ -129,7 +129,7 @@ class QueriesExecuted(Message):
     def __init__(
         self,
         query_count: int,
-        cursors: Dict[str, tuple[HarlequinCursor, str]],
+        cursors: Dict[str, ExecutedStatement],
         submitted_at: float,
         ddl_queries: list[str],
     ) -> None:
@@ -147,14 +147,14 @@ class QueriesCanceled(Message):
 class ResultsFetched(Message):
     def __init__(
         self,
-        cursors: Dict[str, tuple[HarlequinCursor, str]],
-        data: Dict[str, tuple[list[tuple[str, str]], AutoBackendType | None, str]],
+        cursors: Dict[str, ExecutedStatement],
+        results: Dict[str, ResultSet],
         errors: list[tuple[BaseException, str]],
         elapsed: float,
     ) -> None:
         super().__init__()
         self.cursors = cursors
-        self.data = data
+        self.results = results
         self.errors = errors
         self.elapsed = elapsed
 
@@ -668,14 +668,10 @@ class Harlequin(AppBase):
 
     @on(ResultsFetched)
     async def load_tables(self, message: ResultsFetched) -> None:
-        for id_, (cols, data, query_text) in message.data.items():
-            table = await self.results_viewer.push_table(
-                table_id=id_,
-                column_labels=cols,
-                data=data,
-            )
+        for id_, result in message.results.items():
+            table = await self.results_viewer.push_table(table_id=id_, result=result)
             self.append_to_history(
-                query_text=query_text,
+                query_text=result.statement.sql,
                 result_row_count=table.source_row_count,
                 elapsed=message.elapsed,
             )
@@ -705,7 +701,7 @@ class Harlequin(AppBase):
             self.results_viewer.show_table(did_run=False)
         else:
             self.results_viewer.show_table(did_run=True)
-            if message.data:
+            if message.results:
                 self.results_viewer.focus()
 
     @on(WidgetMounted)
@@ -1075,25 +1071,26 @@ class Harlequin(AppBase):
     def _execute_query(self, message: QuerySubmitted) -> None:
         if self.connection is None:
             return
-        cursors: Dict[str, tuple[HarlequinCursor, str]] = {}
-        queries = message.queries
+        cursors: Dict[str, ExecutedStatement] = {}
         ddl_queries: list[str] = []
-        for q in queries:
-            try:
-                cur = self.connection.execute(q)
-            # adapters are supposed to raise HarlequinQueryError, but a raw
-            # driver exception must not take down the app.
-            except Exception as e:
-                self.post_message(QueryError(query_text=q, error=e))
-                break
+        statements = [Statement(sql=q, index=i) for i, q in enumerate(message.queries)]
+        # the Run Query Bar's limit is a hard fetch limit. The app's own
+        # `--limit` is a soft display cap and is applied in _fetch_data; since
+        # the app fetches every row, it knows the exact total and needs no
+        # overflow detection.
+        for executed in execute(
+            connection=self.connection,
+            statements=statements,
+            limit=RowLimit(max_rows=message.limit, detect_overflow=False),
+        ):
+            if executed.error is not None:
+                self.post_message(
+                    QueryError(query_text=executed.statement.sql, error=executed.error)
+                )
+            elif executed.cursor is not None:
+                cursors[f"t{hash(executed.cursor)}"] = executed
             else:
-                if cur is not None:
-                    if message.limit is not None:
-                        cur = cur.set_limit(message.limit)
-                    table_id = f"t{hash(cur)}"
-                    cursors[table_id] = (cur, q)
-                else:
-                    ddl_queries.append(q)
+                ddl_queries.append(executed.statement.sql)
         self.post_message(
             QueriesExecuted(
                 query_count=len(cursors) + len(ddl_queries),
@@ -1129,10 +1126,6 @@ class Harlequin(AppBase):
             return []
         return self.editor.selected_queries()
 
-    @staticmethod
-    def _split_query_text(query_text: str) -> List[str]:
-        return [q for q in query_text.split(";") if q.strip()]
-
     def _push_error_modal(self, title: str, header: str, error: BaseException) -> None:
         self.push_screen(
             ErrorModal(
@@ -1151,22 +1144,26 @@ class Harlequin(AppBase):
     )
     def _fetch_data(
         self,
-        cursors: Dict[str, tuple[HarlequinCursor, str]],
+        cursors: Dict[str, ExecutedStatement],
         submitted_at: float,
     ) -> None:
         errors: list[tuple[BaseException, str]] = []
-        data: Dict[str, tuple[list[tuple[str, str]], AutoBackendType | None, str]] = {}
-        for id_, (cur, q) in cursors.items():
+        results: Dict[str, ResultSet] = {}
+        # the app's `--limit` is a soft display cap over a full fetch, so the
+        # backend keeps `max_results` rows but knows the true total.
+        limit = RowLimit(max_rows=self.max_results, detect_overflow=False)
+        for id_, executed in cursors.items():
             try:
-                cur_data = cur.fetchall()
-                cols = cur.columns()
+                results[id_] = fetch(executed, limit=limit)
             except BaseException as e:
-                errors.append((e, q))
-            else:
-                data[id_] = (cols, cur_data, q)
+                errors.append((e, executed.statement.sql))
+        # each ResultSet times its own fetch; the app reports the batch,
+        # measured from the moment the query was submitted.
         elapsed = time.monotonic() - submitted_at
         self.post_message(
-            ResultsFetched(cursors=cursors, data=data, errors=errors, elapsed=elapsed)
+            ResultsFetched(
+                cursors=cursors, results=results, errors=errors, elapsed=elapsed
+            )
         )
 
     def extend_completers(self, parent: CatalogItem, items: list[CatalogItem]) -> None:

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -16,11 +16,10 @@ from harlequin.autocomplete import MemberCompleter, WordCompleter
 from harlequin.components.error_modal import ErrorModal
 from harlequin.editor_cache import BufferState, load_cache
 from harlequin.messages import WidgetMounted
+from harlequin.statements import find_separators
 
 
 class CodeEditor(TextEditor, inherit_bindings=False):
-    SEMICOLON_QUERY = '(";" @semicolon)'
-
     class Submitted(Message, bubble=True):
         """Posted when user runs the query.
 
@@ -44,7 +43,7 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         if ";" not in self.text:
             return [self.text]
 
-        separators = self._query_separators()
+        separators = find_separators(self.text)
         if not separators:
             # a semicolon could be in a string literal,
             # so there may not be query separators even if
@@ -92,8 +91,6 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         self.post_message(EditorCollection.EditorSwitched(active_editor=self))
         self.post_message(WidgetMounted(widget=self))
         self.has_shown_clipboard_error = False
-        self.has_shown_tree_sitter_error = False
-        self._semicolon_query = self.prepare_query(self.SEMICOLON_QUERY)
 
     def on_unmount(self) -> None:
         self.post_message(EditorCollection.EditorSwitched(active_editor=None))
@@ -141,46 +138,6 @@ class CodeEditor(TextEditor, inherit_bindings=False):
     def action_focus_data_catalog(self) -> None:
         if hasattr(self.app, "action_focus_data_catalog"):
             self.app.action_focus_data_catalog()
-
-    def _query_separators(self) -> list[Location]:
-        """
-        Return a sorted list of tuples that represent the row and col
-        positions of query separators (semicolons) in the buffer text.
-        """
-        if self.text_input is None:
-            return []
-
-        if self.text_input.is_syntax_aware:
-            assert self._semicolon_query is not None
-            query_result = self.query_syntax_tree(query=self._semicolon_query)
-            # tree-sitter captures nodes in the order its patterns match them,
-            # which is not the order they appear in the buffer.
-            return sorted(
-                (n.end_point.row, n.end_point.column)
-                for n in query_result.get("semicolon", [])
-            )
-
-        else:
-            # tree-sitter is not installed. naively split on semicolons and
-            # show a warning.
-            import re
-
-            if not self.has_shown_tree_sitter_error:
-                self.app.notify(
-                    "Tree-sitter is not installed. Syntax highlighting and query "
-                    "splitting may not work as expected.\n"
-                    "See https://harlequin.sh/docs/troubleshooting/tree-sitter",
-                    severity="warning",
-                    timeout=10,
-                )
-                self.has_shown_tree_sitter_error = True
-
-            semicolons: list[Location] = []
-            for i, line in enumerate(self.text.splitlines()):
-                for pos in [m.span()[1] for m in re.finditer(";", line)]:
-                    semicolons.append((i, pos))
-
-            return semicolons
 
 
 class EditorCollection(TabbedContent):

--- a/src/harlequin/components/results_viewer.py
+++ b/src/harlequin/components/results_viewer.py
@@ -12,13 +12,14 @@ from textual.widgets import (
     Tabs,
 )
 from textual_fastdatatable import DataTable
-from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin.messages import WidgetMounted
 
 if TYPE_CHECKING:
     from textual_fastdatatable.backend import DataTableBackend
     from textual_fastdatatable.data_table import CursorType
+
+    from harlequin.query import ResultSet
 
 
 class ResultsTable(DataTable, inherit_bindings=False):
@@ -129,22 +130,18 @@ class ResultsViewer(TabbedContent, can_focus=True):
             except NoMatches:
                 return None
 
-    async def push_table(
-        self,
-        table_id: str,
-        column_labels: list[tuple[str, str]],
-        data: AutoBackendType,
-    ) -> ResultsTable:
+    async def push_table(self, table_id: str, result: ResultSet) -> ResultsTable:
         formatted_labels = [
             self._format_column_label(col_name, col_type)
-            for col_name, col_type in column_labels
+            for col_name, col_type in result.columns
         ]
         table = ResultsTable(
             id=table_id,
             column_labels=formatted_labels,  # type: ignore
-            plain_column_labels=[col_name for (col_name, _) in column_labels],
-            data=data,
-            max_rows=self.max_results,
+            plain_column_labels=[col_name for (col_name, _) in result.columns],
+            # the backend was built by `harlequin.query.fetch()`, which already
+            # applied `max_results` as its row cap.
+            backend=result.backend,
             cursor_type="range",
             max_column_content_width=self.max_col_width,
             null_rep="[dim]∅ null[/]",

--- a/src/harlequin/query.py
+++ b/src/harlequin/query.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence
+from typing import TYPE_CHECKING, Iterator, Literal, Sequence
 
 from textual_fastdatatable.backend import create_backend
 
@@ -98,11 +98,13 @@ class ResultSet:
     def row_count(self) -> int:
         return 0 if self.backend is None else self.backend.row_count
 
-    def rows(self) -> Iterator[Sequence[Any]]:
-        if self.backend is None:
-            return
-        for i in range(self.backend.row_count):
-            yield self.backend.get_row_at(i)
+    # Deliberately no row iterator. Every consumer of a result set works
+    # columnwise -- the file formats hand `backend.source_data` to duckdb or
+    # pyarrow, and the text layouts read a VARCHAR-cast Arrow table -- so a
+    # row-at-a-time accessor would be a slow path with no callers. Reach for
+    # `backend.source_data` instead; `get_row_at()` costs an Arrow slice and a
+    # dict per row (1.8s vs 0.34s over 100k rows) and materializes the whole
+    # result as Python objects, which is what `--limit` exists to avoid.
 
 
 def execute(

--- a/src/harlequin/query.py
+++ b/src/harlequin/query.py
@@ -1,0 +1,176 @@
+"""Executing SQL and collecting its results, without a UI.
+
+This is the core both front ends run queries through. It keeps the two-phase
+shape the Textual app has always had -- execute every statement, *then* fetch
+every result -- rather than flattening it, because that split is what lets the
+app report "query executed" before any data materializes.
+
+Results are normalized by `textual_fastdatatable.create_backend()`, the same
+call the app's results viewer makes. A second normalizer would put the most
+drift-prone question in the codebase (what counts as a row, what counts as
+null, how a nested struct comes out) in two places, and the disagreement would
+surface as two front ends showing different data for the same query.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence
+
+from textual_fastdatatable.backend import create_backend
+
+from harlequin.statements import Statement
+
+if TYPE_CHECKING:
+    from textual_fastdatatable.backend import DataTableBackend
+
+    from harlequin.adapter import HarlequinConnection, HarlequinCursor
+
+OnError = Literal["stop", "continue"]
+
+
+@dataclass(frozen=True)
+class RowLimit:
+    """How many rows to ask for, and whether to detect that there were more.
+
+    Harlequin has two different limits and they are not interchangeable. The
+    app's `--limit` is a *soft* display cap: it fetches everything and caps what
+    is loaded into the viewer, which is why it can report an exact total. A
+    headless caller wants the *hard* one -- fewer rows leave the database --
+    and so can never learn the true total.
+
+    That is what `detect_overflow` is for: `set_limit(n)` followed by
+    `fetchall()` returns at most n rows and says nothing about whether an n+1th
+    existed, so exactly n is ambiguous. Asking for one row more than we intend
+    to keep is what makes truncation knowable, and it costs exactly one row.
+    """
+
+    max_rows: int | None = None
+    """None means unlimited."""
+
+    detect_overflow: bool = False
+
+    @property
+    def fetch_limit(self) -> int | None:
+        """The limit to hand `HarlequinCursor.set_limit()`."""
+        if self.max_rows is None:
+            return None
+        return self.max_rows + 1 if self.detect_overflow else self.max_rows
+
+
+@dataclass
+class ExecutedStatement:
+    """One statement, after the database has been asked to run it.
+
+    Exactly one of `cursor` and `error` is meaningful: a `cursor` for a query
+    with a result set, an `error` if the database refused it, and neither for
+    DDL/DML, which returns no cursor and raises nothing.
+    """
+
+    statement: Statement
+    cursor: HarlequinCursor | None = None
+    error: BaseException | None = None
+
+    @property
+    def has_result_set(self) -> bool:
+        return self.cursor is not None
+
+
+@dataclass
+class ResultSet:
+    """The data a single statement returned."""
+
+    statement: Statement
+    columns: list[tuple[str, str]]
+    """(name, short type) pairs, in the order the data is returned."""
+
+    backend: DataTableBackend | None
+    """None when the statement returned no rows at all."""
+
+    truncated: bool
+    """Whether the database had more rows than this result set holds."""
+
+    elapsed: float
+    """Seconds spent fetching, not including execution."""
+
+    @property
+    def row_count(self) -> int:
+        return 0 if self.backend is None else self.backend.row_count
+
+    def rows(self) -> Iterator[Sequence[Any]]:
+        if self.backend is None:
+            return
+        for i in range(self.backend.row_count):
+            yield self.backend.get_row_at(i)
+
+
+def execute(
+    connection: HarlequinConnection,
+    statements: Sequence[Statement],
+    limit: RowLimit | None = None,
+    on_error: OnError = "stop",
+) -> Iterator[ExecutedStatement]:
+    """Run each statement, yielding one `ExecutedStatement` per statement.
+
+    Yields lazily, so a caller that stops consuming stops the script. Nothing
+    is fetched here; pass each yielded statement to `fetch()` for that.
+
+    A statement the database refuses is yielded with its `error` set rather
+    than raising, so the caller keeps the statement it belongs to. Under the
+    default `on_error="stop"` no further statement is run; under `"continue"`
+    the script runs to the end. `KeyboardInterrupt` is not an error in this
+    sense and propagates.
+    """
+    limit = limit if limit is not None else RowLimit()
+    fetch_limit = limit.fetch_limit
+    for statement in statements:
+        try:
+            cursor = connection.execute(statement.sql)
+        # adapters are supposed to raise HarlequinQueryError, but a raw driver
+        # exception must not take down the caller.
+        except Exception as e:
+            yield ExecutedStatement(statement=statement, error=e)
+            if on_error == "stop":
+                return
+        else:
+            if cursor is not None and fetch_limit is not None:
+                cursor = cursor.set_limit(fetch_limit)
+            yield ExecutedStatement(statement=statement, cursor=cursor)
+
+
+def fetch(executed: ExecutedStatement, limit: RowLimit | None = None) -> ResultSet:
+    """Drain one executed statement's cursor into a `ResultSet`.
+
+    `limit.max_rows` caps the rows the result set holds, which is not
+    necessarily the number fetched: under `detect_overflow` `execute()` asked
+    for one more than this, and the extra row is what `truncated` is inferred
+    from.
+
+    Raises whatever the adapter raises; a caller that runs several statements
+    decides for itself whether one failure ends the batch.
+    """
+    if executed.cursor is None:
+        raise ValueError(
+            f"Statement {executed.statement.index} has no cursor to fetch from."
+        )
+
+    limit = limit if limit is not None else RowLimit()
+    started_at = time.monotonic()
+    data = executed.cursor.fetchall()
+    columns = executed.cursor.columns()
+    elapsed = time.monotonic() - started_at
+
+    # a cursor with no rows returns None, which is not a shape `create_backend`
+    # can normalize -- and there is nothing to normalize.
+    backend = None if data is None else create_backend(data, max_rows=limit.max_rows)
+
+    return ResultSet(
+        statement=executed.statement,
+        columns=columns,
+        backend=backend,
+        truncated=(
+            backend is not None and backend.source_row_count > backend.row_count
+        ),
+        elapsed=elapsed,
+    )

--- a/src/harlequin/statements.py
+++ b/src/harlequin/statements.py
@@ -1,0 +1,141 @@
+"""Locating statement boundaries in SQL text.
+
+Both front ends split a script here, through the same tree-sitter grammar and
+the same one-line query the Query Editor has always used, so a script run with
+`-f` and the same script in the editor cannot disagree about where a statement
+ends.
+
+Tree-sitter reports positions as **byte** offsets. Everything this module
+returns is in **characters**, because that is what both callers slice with:
+`str` for `split()`, and Textual's `Document.get_text_range()` for
+`find_separators()`. Owning that conversion once, here, is the point -- doing
+it at the call site is what produced the mis-slicing described in
+`find_separators()` below.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from dataclasses import dataclass
+
+import tree_sitter_sql
+from tree_sitter import Language, Parser, Query, QueryCursor
+
+SEMICOLON_QUERY = '(";" @semicolon)'
+"""Capture every semicolon the grammar considers a statement separator.
+
+Semicolons inside string literals, comments and quoted identifiers are part of
+those nodes, so they are not captured.
+"""
+
+Point = tuple[int, int]
+"""A (row, character column) position in a buffer. Both are 0-indexed."""
+
+
+@dataclass(frozen=True)
+class Statement:
+    """A single statement, split out of a submitted script."""
+
+    sql: str
+    index: int
+    """0-based position in the script this statement was split from."""
+
+
+_LANGUAGE: Language | None = None
+_QUERY: Query | None = None
+
+
+def _grammar() -> tuple[Language, Query]:
+    """Load the grammar and prepare the query once, on first use.
+
+    Together they cost ~16ms, which nothing that never splits SQL should pay --
+    `hsql --help` being the case that matters. The `Query` is reused across
+    calls, as tree-sitter intends; the `Parser` is not, since it holds the tree
+    it last produced.
+    """
+    global _LANGUAGE, _QUERY
+    if _LANGUAGE is None or _QUERY is None:
+        _LANGUAGE = Language(tree_sitter_sql.language())
+        _QUERY = Query(_LANGUAGE, SEMICOLON_QUERY)
+    return _LANGUAGE, _QUERY
+
+
+def _separator_offsets(text: str) -> list[int]:
+    """Character offsets in `text` just past each statement separator."""
+    if ";" not in text:
+        # cheap, and the common case for a single statement.
+        return []
+
+    language, query = _grammar()
+    encoded = text.encode("utf-8")
+    tree = Parser(language).parse(encoded)
+    captures = QueryCursor(query).captures(tree.root_node)
+    # tree-sitter captures nodes in the order its patterns match them, which is
+    # not the order they appear in the buffer.
+    byte_offsets = sorted(node.end_byte for node in captures.get("semicolon", []))
+
+    if text.isascii():
+        return byte_offsets
+
+    # decode the gaps between offsets rather than the prefix of each, so a
+    # script with thousands of statements stays linear in its length.
+    offsets: list[int] = []
+    byte_cursor = 0
+    char_cursor = 0
+    for byte_offset in byte_offsets:
+        char_cursor += len(encoded[byte_cursor:byte_offset].decode("utf-8"))
+        byte_cursor = byte_offset
+        offsets.append(char_cursor)
+    return offsets
+
+
+def split(text: str) -> list[Statement]:
+    """Split a script into its statements, in order.
+
+    Each statement's `sql` is stripped of surrounding whitespace and keeps its
+    trailing semicolon; statements that are empty after stripping are dropped,
+    so trailing separators and blank lines do not produce empty statements.
+    """
+    statements: list[Statement] = []
+    start = 0
+    for end in [*_separator_offsets(text), len(text)]:
+        sql = text[start:end].strip()
+        if sql:
+            statements.append(Statement(sql=sql, index=len(statements)))
+        start = end
+    return statements
+
+
+def find_separators(text: str) -> list[Point]:
+    """Locate each statement separator, as a (row, character column) `Point`.
+
+    The point sits immediately *past* the semicolon, so it is the end of the
+    statement it terminates.
+
+    Rows and columns are those of `str.splitlines()`, which is how Textual's
+    `Document` splits a buffer -- so a `Point` can be handed straight to
+    `Document.get_text_range()`. That is the whole reason this returns
+    characters: tree-sitter's own `Point.column` is a byte offset, and feeding
+    one to `get_text_range()` shifts the cut by one position per non-ASCII
+    character earlier on the line, splitting `select '日本語';select 2` into
+    `select '日本語';select` and `2`.
+    """
+    offsets = _separator_offsets(text)
+    if not offsets:
+        return []
+
+    lines = text.splitlines(keepends=True)
+    # `line_starts[row]` is the character offset of the start of that row; the
+    # final entry is the end of the buffer.
+    line_starts = [0]
+    for line in lines:
+        line_starts.append(line_starts[-1] + len(line))
+
+    points: list[Point] = []
+    for offset in offsets:
+        # a separator is never the first character of a row -- the character
+        # before it is a semicolon -- so it only lands on a `line_starts` entry
+        # when it is at the very end of the buffer.
+        row = min(bisect_right(line_starts, offset) - 1, len(lines) - 1)
+        points.append((row, offset - line_starts[row]))
+    return points

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -412,7 +412,8 @@ async def test_selected_queries_split_on_character_columns(
     app: Harlequin,
     wait_for_workers: Callable[[Harlequin], Awaitable[None]],
 ) -> None:
-    """The editor and `harlequin.statements` split at the same place.
+    """Regression test for #1015: the editor and `harlequin.statements` split
+    at the same place.
 
     tree-sitter reports columns in bytes, and the editor used to feed one
     straight to `get_text_range()`, which wants characters. Any non-ASCII

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -10,6 +10,7 @@ from textual.widgets.text_area import Selection
 
 from harlequin import Harlequin
 from harlequin.app import QuerySubmitted
+from harlequin.statements import find_separators, split
 
 
 @pytest.mark.asyncio
@@ -244,11 +245,20 @@ async def test_member_autocomplete(
 
 
 @pytest.mark.asyncio
-async def test_no_tree_sitter(
+async def test_splitting_survives_a_text_area_without_syntax_awareness(
     app: Harlequin,
     monkeypatch: pytest.MonkeyPatch,
     wait_for_workers: Callable[[Harlequin], Awaitable[None]],
 ) -> None:
+    """Splitting no longer depends on the editor widget's syntax tree.
+
+    It used to: with Textual's tree-sitter unavailable the editor fell back to
+    a regex over semicolons and warned the user that query splitting might
+    misbehave. `harlequin.statements` drives the grammar itself, so a text area
+    that cannot highlight still splits exactly, and there is nothing to warn
+    about -- which is the degraded mode the tree-sitter troubleshooting page
+    described.
+    """
     import textual.document._syntax_aware_document
     import textual.widgets._text_area
 
@@ -264,7 +274,8 @@ async def test_no_tree_sitter(
 
         assert app.editor is not None
         assert app.editor.text_input is not None
-        app.editor.text = "select 1; select 2"
+        # a semicolon in a string literal, which the old regex fallback split on
+        app.editor.text = "select 'a;b'; select 2"
 
         assert not app.editor.text_input.is_syntax_aware
 
@@ -276,21 +287,14 @@ async def test_no_tree_sitter(
         submitted_msg = next(
             iter(filter(lambda m: isinstance(m, QuerySubmitted), messages))
         )
-        assert submitted_msg
         assert isinstance(submitted_msg, QuerySubmitted)
-        assert len(submitted_msg.queries) == 2
+        assert submitted_msg.queries == ["select 'a;b';", "select 2"]
 
-        text_area_warning = next(
-            iter(
-                filter(
-                    lambda m: (
-                        isinstance(m, Notify) and m.notification.severity == "warning"
-                    ),
-                    messages,
-                )
-            )
-        )
-        assert text_area_warning
+        assert not [
+            m
+            for m in messages
+            if isinstance(m, Notify) and "tree-sitter" in m.notification.message.lower()
+        ]
 
 
 @pytest.mark.asyncio
@@ -359,7 +363,12 @@ async def test_selected_queries(
         await pilot.pause()
 
         # tree-sitter does not capture the semicolons in buffer order
-        assert app.editor._query_separators() == [(0, 25), (1, 27), (2, 18), (3, 15)]
+        assert find_separators(app.editor.text) == [
+            (0, 25),
+            (1, 27),
+            (2, 18),
+            (3, 15),
+        ]
 
         # the whole buffer
         app.editor.selection = Selection((0, 0), (4, 0))
@@ -396,3 +405,28 @@ async def test_selected_queries(
         await pilot.pause()
         app.editor.selection = Selection((0, 0), (0, 0))
         assert app.editor.selected_queries() == ["select 'a;b'"]
+
+
+@pytest.mark.asyncio
+async def test_selected_queries_split_on_character_columns(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """The editor and `harlequin.statements` split at the same place.
+
+    tree-sitter reports columns in bytes, and the editor used to feed one
+    straight to `get_text_range()`, which wants characters. Any non-ASCII
+    before a semicolon shifted the cut, and both halves came out as syntax
+    errors -- this split into "select '日本語';select" and "2".
+    """
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+
+        while app.editor is None:
+            await pilot.pause()
+
+        app.editor.text = "select '日本語';select 2"
+        await pilot.pause()
+        app.editor.selection = Selection((0, 0), (0, 22))
+        assert app.editor.selected_queries() == ["select '日本語';", "select 2"]
+        assert app.editor.selected_queries() == [s.sql for s in split(app.editor.text)]

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -4,12 +4,9 @@ import sys
 from typing import Awaitable, Callable, List
 
 import pytest
-from textual.message import Message
-from textual.notifications import Notify
 from textual.widgets.text_area import Selection
 
 from harlequin import Harlequin
-from harlequin.app import QuerySubmitted
 from harlequin.statements import find_separators, split
 
 
@@ -242,59 +239,6 @@ async def test_member_autocomplete(
         snap_results.append(await app_snapshot(app, "submitted"))
 
         assert all(snap_results)
-
-
-@pytest.mark.asyncio
-async def test_splitting_survives_a_text_area_without_syntax_awareness(
-    app: Harlequin,
-    monkeypatch: pytest.MonkeyPatch,
-    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
-) -> None:
-    """Splitting no longer depends on the editor widget's syntax tree.
-
-    It used to: with Textual's tree-sitter unavailable the editor fell back to
-    a regex over semicolons and warned the user that query splitting might
-    misbehave. `harlequin.statements` drives the grammar itself, so a text area
-    that cannot highlight still splits exactly, and there is nothing to warn
-    about -- which is the degraded mode the tree-sitter troubleshooting page
-    described.
-    """
-    import textual.document._syntax_aware_document
-    import textual.widgets._text_area
-
-    monkeypatch.setattr(textual.document._syntax_aware_document, "TREE_SITTER", False)
-    monkeypatch.setattr(textual.widgets._text_area, "TREE_SITTER", False)
-
-    messages: list[Message] = []
-    async with app.run_test(message_hook=messages.append) as pilot:
-        await wait_for_workers(app)
-
-        while app.editor is None:
-            await pilot.pause()
-
-        assert app.editor is not None
-        assert app.editor.text_input is not None
-        # a semicolon in a string literal, which the old regex fallback split on
-        app.editor.text = "select 'a;b'; select 2"
-
-        assert not app.editor.text_input.is_syntax_aware
-
-        await pilot.press("ctrl+a")
-        await pilot.press("ctrl+j")
-        await pilot.pause()
-        await wait_for_workers(app)
-
-        submitted_msg = next(
-            iter(filter(lambda m: isinstance(m, QuerySubmitted), messages))
-        )
-        assert isinstance(submitted_msg, QuerySubmitted)
-        assert submitted_msg.queries == ["select 'a;b';", "select 2"]
-
-        assert not [
-            m
-            for m in messages
-            if isinstance(m, Notify) and "tree-sitter" in m.notification.message.lower()
-        ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -25,6 +25,8 @@ HEADLESS_IMPORTS = [
     "import harlequin.keymap",
     "import harlequin.options",
     "import harlequin.plugins",
+    "import harlequin.query",
+    "import harlequin.statements",
     "import harlequin.transaction_mode",
     "import harlequin_duckdb",
     "import harlequin_sqlite",

--- a/tests/unit_tests/test_query.py
+++ b/tests/unit_tests/test_query.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import pytest
+
+from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
+from harlequin.exception import HarlequinQueryError
+from harlequin.query import ExecutedStatement, ResultSet, RowLimit, execute, fetch
+from harlequin.statements import Statement, split
+
+
+@pytest.fixture
+def connection(duckdb_adapter: type[HarlequinAdapter]) -> HarlequinConnection:
+    return duckdb_adapter([":memory:"], no_init=True).connect()
+
+
+def statements(script: str) -> list[Statement]:
+    return split(script)
+
+
+class TestRowLimit:
+    def test_unlimited_asks_for_everything(self) -> None:
+        assert RowLimit().fetch_limit is None
+        assert RowLimit(max_rows=None, detect_overflow=True).fetch_limit is None
+
+    def test_plain_limit_asks_for_exactly_that_many(self) -> None:
+        assert RowLimit(max_rows=500).fetch_limit == 500
+
+    def test_overflow_detection_asks_for_one_more(self) -> None:
+        """Exactly n rows back from set_limit(n) is ambiguous; n+1 is not."""
+        assert RowLimit(max_rows=500, detect_overflow=True).fetch_limit == 501
+
+
+class TestExecute:
+    def test_yields_one_result_per_statement(
+        self, connection: HarlequinConnection
+    ) -> None:
+        executed = list(execute(connection, statements("select 1; select 2; select 3")))
+        assert [e.statement.index for e in executed] == [0, 1, 2]
+        assert all(e.has_result_set for e in executed)
+        assert all(e.error is None for e in executed)
+
+    def test_ddl_yields_no_cursor(self, connection: HarlequinConnection) -> None:
+        executed = list(
+            execute(connection, statements("create table foo (a int); select 1"))
+        )
+        assert not executed[0].has_result_set
+        assert executed[0].error is None
+        assert executed[1].has_result_set
+
+    def test_is_lazy(self, connection: HarlequinConnection) -> None:
+        """A caller that stops consuming stops the script."""
+        script = statements("create table foo (a int); create table bar (a int)")
+        next(iter(execute(connection, script)))
+        cur = connection.execute("select count(*) from duckdb_tables()")
+        assert cur is not None
+        assert cur.fetchall().to_pylist() == [{"count_star()": 1}]  # type: ignore[union-attr]
+
+    def test_stops_at_the_first_error_by_default(
+        self, connection: HarlequinConnection
+    ) -> None:
+        executed = list(execute(connection, statements("select 1; sel; select 3")))
+        assert len(executed) == 2
+        assert executed[0].error is None
+        assert isinstance(executed[1].error, HarlequinQueryError)
+        assert executed[1].statement.sql == "sel;"
+        assert not executed[1].has_result_set
+
+    def test_continues_past_an_error_when_asked(
+        self, connection: HarlequinConnection
+    ) -> None:
+        executed = list(
+            execute(
+                connection, statements("select 1; sel; select 3"), on_error="continue"
+            )
+        )
+        assert len(executed) == 3
+        assert [e.error is None for e in executed] == [True, False, True]
+
+    def test_applies_the_fetch_limit(self, connection: HarlequinConnection) -> None:
+        (executed,) = execute(
+            connection,
+            statements("select * from range(100)"),
+            limit=RowLimit(max_rows=5),
+        )
+        assert fetch(executed).row_count == 5
+
+    def test_overflow_detection_fetches_one_extra_row(
+        self, connection: HarlequinConnection
+    ) -> None:
+        (executed,) = execute(
+            connection,
+            statements("select * from range(100)"),
+            limit=RowLimit(max_rows=5, detect_overflow=True),
+        )
+        # the cursor holds 6; the result set keeps 5 and knows there were more.
+        assert fetch(executed).row_count == 6
+
+
+class TestFetch:
+    def test_returns_columns_and_rows(self, connection: HarlequinConnection) -> None:
+        (executed,) = execute(connection, statements("select 1 as a, 'x' as b"))
+        result = fetch(executed)
+        assert [name for name, _ in result.columns] == ["a", "b"]
+        assert result.row_count == 1
+        assert list(result.rows()) == [[1, "x"]]
+        assert result.statement.sql == "select 1 as a, 'x' as b"
+        assert result.elapsed >= 0
+
+    def test_a_query_that_matches_nothing_returns_zero_rows(
+        self, connection: HarlequinConnection
+    ) -> None:
+        """Zero rows is not an error, and must not read like one."""
+        (executed,) = execute(connection, statements("select 1 where false"))
+        result = fetch(executed)
+        assert result.columns == [("1", "#")]
+        assert result.row_count == 0
+        assert list(result.rows()) == []
+        assert result.truncated is False
+
+    def test_a_cursor_that_returns_none_has_no_backend(self) -> None:
+        """The adapter interface lets a cursor return None instead of an empty
+        result. None is not a shape create_backend() can normalize -- and there
+        is nothing to normalize."""
+
+        class EmptyCursor(HarlequinCursor):
+            def __init__(self) -> None:
+                pass
+
+            def columns(self) -> list[tuple[str, str]]:
+                return [("a", "int")]
+
+            def set_limit(self, limit: int) -> HarlequinCursor:
+                return self
+
+            def fetchall(self) -> Any:
+                return None
+
+        result = fetch(
+            ExecutedStatement(statement=Statement("select 1", 0), cursor=EmptyCursor())
+        )
+        assert result.backend is None
+        assert result.row_count == 0
+        assert list(result.rows()) == []
+        assert result.truncated is False
+
+    def test_rejects_a_statement_with_no_cursor(
+        self, connection: HarlequinConnection
+    ) -> None:
+        (executed,) = execute(connection, statements("create table foo (a int)"))
+        with pytest.raises(ValueError):
+            fetch(executed)
+
+    def test_the_row_cap_is_not_the_fetch_limit(
+        self, connection: HarlequinConnection
+    ) -> None:
+        """The app fetches everything and caps what it displays, so the backend
+        knows the exact total -- which is what lets it say '5 of 100'."""
+        (executed,) = execute(connection, statements("select * from range(100)"))
+        result = fetch(executed, limit=RowLimit(max_rows=5))
+        assert result.row_count == 5
+        assert result.backend is not None
+        assert result.backend.source_row_count == 100
+
+
+class TestTruncation:
+    @pytest.mark.parametrize(
+        ("rows", "expected_truncated", "expected_count"),
+        [(4, False, 4), (5, False, 5), (6, True, 5)],
+        ids=["under limit", "exactly at limit", "one over limit"],
+    )
+    def test_truncation_is_detected_from_one_extra_row(
+        self,
+        all_adapters: type[HarlequinAdapter],
+        rows: int,
+        expected_truncated: bool,
+        expected_count: int,
+    ) -> None:
+        """duckdb and sqlite implement set_limit differently enough to matter."""
+        connection = all_adapters([":memory:"], no_init=True).connect()
+        limit = RowLimit(max_rows=5, detect_overflow=True)
+        script = " union all ".join(f"select {i} as a" for i in range(rows))
+        (executed,) = execute(connection, statements(script), limit=limit)
+        result = fetch(executed, limit=limit)
+        assert result.row_count == expected_count
+        assert result.truncated is expected_truncated
+
+    def test_an_unlimited_fetch_is_never_truncated(
+        self, connection: HarlequinConnection
+    ) -> None:
+        limit = RowLimit(max_rows=None, detect_overflow=True)
+        (executed,) = execute(
+            connection, statements("select * from range(100)"), limit=limit
+        )
+        result = fetch(executed, limit=limit)
+        assert result.row_count == 100
+        assert result.truncated is False
+
+
+class TestExecuteWithoutAnAdapter:
+    """`execute()` is defined against the adapter interface, not against
+    duckdb, so a driver that misbehaves is worth exercising directly."""
+
+    def test_a_raw_driver_exception_does_not_escape(self) -> None:
+        class Exploding(HarlequinConnection):
+            def __init__(self) -> None:
+                pass
+
+            def execute(self, query: str) -> HarlequinCursor | None:
+                raise RuntimeError("the driver did not read the docs")
+
+            def get_catalog(self) -> Any:
+                raise NotImplementedError
+
+        (executed,) = execute(Exploding(), statements("select 1"))
+        assert isinstance(executed.error, RuntimeError)
+
+    def test_keyboard_interrupt_propagates(self) -> None:
+        """Ctrl-C is not a query error: it must not be reported as one, and it
+        must not be swallowed by on_error='continue'."""
+
+        class Interrupting(HarlequinConnection):
+            def __init__(self) -> None:
+                pass
+
+            def execute(self, query: str) -> HarlequinCursor | None:
+                raise KeyboardInterrupt
+
+            def get_catalog(self) -> Any:
+                raise NotImplementedError
+
+        with pytest.raises(KeyboardInterrupt):
+            list(execute(Interrupting(), statements("select 1"), on_error="continue"))
+
+
+def test_result_set_rows_are_lazy() -> None:
+    """`rows()` is an iterator because that is the natural shape, not because
+    anything streams -- fetchall() has already materialized the result."""
+
+    class FakeCursor(HarlequinCursor):
+        def __init__(self) -> None:
+            pass
+
+        def columns(self) -> list[tuple[str, str]]:
+            return [("a", "int")]
+
+        def set_limit(self, limit: int) -> HarlequinCursor:
+            return self
+
+        def fetchall(self) -> Any:
+            return {"a": [1, 2, 3]}
+
+    result = fetch(
+        ExecutedStatement(statement=Statement("select 1", 0), cursor=FakeCursor())
+    )
+    assert isinstance(result, ResultSet)
+    rows: Sequence[Any] = list(result.rows())
+    assert [r[0] for r in rows] == [1, 2, 3]

--- a/tests/unit_tests/test_query.py
+++ b/tests/unit_tests/test_query.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
+import pyarrow as pa
 import pytest
 
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
@@ -104,7 +105,8 @@ class TestFetch:
         result = fetch(executed)
         assert [name for name, _ in result.columns] == ["a", "b"]
         assert result.row_count == 1
-        assert list(result.rows()) == [[1, "x"]]
+        assert result.backend is not None
+        assert result.backend.source_data.to_pylist() == [{"a": 1, "b": "x"}]
         assert result.statement.sql == "select 1 as a, 'x' as b"
         assert result.elapsed >= 0
 
@@ -116,7 +118,8 @@ class TestFetch:
         result = fetch(executed)
         assert result.columns == [("1", "#")]
         assert result.row_count == 0
-        assert list(result.rows()) == []
+        assert result.backend is not None
+        assert result.backend.source_data.to_pylist() == []
         assert result.truncated is False
 
     def test_a_cursor_that_returns_none_has_no_backend(self) -> None:
@@ -142,7 +145,6 @@ class TestFetch:
         )
         assert result.backend is None
         assert result.row_count == 0
-        assert list(result.rows()) == []
         assert result.truncated is False
 
     def test_rejects_a_statement_with_no_cursor(
@@ -234,9 +236,20 @@ class TestExecuteWithoutAnAdapter:
             list(execute(Interrupting(), statements("select 1"), on_error="continue"))
 
 
-def test_result_set_rows_are_lazy() -> None:
-    """`rows()` is an iterator because that is the natural shape, not because
-    anything streams -- fetchall() has already materialized the result."""
+@pytest.mark.parametrize(
+    "returned",
+    [
+        {"a": [1, 2, 3]},
+        [(1,), (2,), (3,)],
+        pa.table({"a": [1, 2, 3]}),
+        pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], names=["a"]),
+    ],
+    ids=["mapping", "records", "table", "record batch"],
+)
+def test_every_shape_a_cursor_may_return_is_normalized(returned: Any) -> None:
+    """`fetchall()` is typed `AutoBackendType`, which is `Any`. Routing each
+    shape through the one `create_backend()` the app already uses is what keeps
+    two front ends from disagreeing about what a row is."""
 
     class FakeCursor(HarlequinCursor):
         def __init__(self) -> None:
@@ -249,11 +262,14 @@ def test_result_set_rows_are_lazy() -> None:
             return self
 
         def fetchall(self) -> Any:
-            return {"a": [1, 2, 3]}
+            return returned
 
     result = fetch(
         ExecutedStatement(statement=Statement("select 1", 0), cursor=FakeCursor())
     )
     assert isinstance(result, ResultSet)
-    rows: Sequence[Any] = list(result.rows())
-    assert [r[0] for r in rows] == [1, 2, 3]
+    assert result.row_count == 3
+    assert result.backend is not None
+    assert [
+        next(iter(row.values())) for row in result.backend.source_data.to_pylist()
+    ] == [1, 2, 3]

--- a/tests/unit_tests/test_statements.py
+++ b/tests/unit_tests/test_statements.py
@@ -1,0 +1,175 @@
+"""The tricky-SQL corpus.
+
+`tests/functional_tests/test_query_editor.py` runs the same fixtures through
+the Query Editor, so a divergence between the two front ends fails here or
+there rather than in a user's buffer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harlequin.statements import Statement, find_separators, split
+
+# (name, script, expected statements). The name is the pytest id.
+CORPUS: list[tuple[str, str, list[str]]] = [
+    ("empty", "", []),
+    ("whitespace only", "   \n\t\n  ", []),
+    ("no separator", "select 1", ["select 1"]),
+    ("trailing separator", "select 1;", ["select 1;"]),
+    ("two statements", "select 1; select 2", ["select 1;", "select 2"]),
+    (
+        "two statements, both terminated",
+        "select 1;\nselect 2;\n",
+        ["select 1;", "select 2;"],
+    ),
+    ("bare separator", ";", [";"]),
+    (
+        "consecutive separators",
+        "select 1;;select 2",
+        ["select 1;", ";", "select 2"],
+    ),
+    (
+        "blank lines between statements",
+        "select 1;\n\n\n   \n\nselect 2;",
+        ["select 1;", "select 2;"],
+    ),
+    # a semicolon inside any of these is part of a single node, so the grammar
+    # never offers it as a separator.
+    ("single-quoted literal", "select 'a;b'", ["select 'a;b'"]),
+    (
+        "single-quoted literal, then a real separator",
+        "select 'a;b'; select 2",
+        ["select 'a;b';", "select 2"],
+    ),
+    ("double-quoted identifier", 'select "a;b" from t', ['select "a;b" from t']),
+    ("line comment", "select 1 -- a; comment\n", ["select 1 -- a; comment"]),
+    (
+        "line comment after a separator",
+        "select 1; -- a; comment\nselect 2",
+        ["select 1;", "-- a; comment\nselect 2"],
+    ),
+    (
+        "block comment",
+        "select 1 /* a; comment */ from t",
+        ["select 1 /* a; comment */ from t"],
+    ),
+    (
+        "escaped quote inside a literal",
+        "select 'it''s; fine'; select 2",
+        ["select 'it''s; fine';", "select 2"],
+    ),
+    # the reason find_separators() returns character columns. A byte offset
+    # would land 6 positions late here, one per byte of overhead in 日本語.
+    (
+        "non-ascii before a separator",
+        "select '日本語';select 2",
+        ["select '日本語';", "select 2"],
+    ),
+    (
+        "non-ascii on an earlier line",
+        "select 'né';\nselect 2;",
+        ["select 'né';", "select 2;"],
+    ),
+    (
+        "astral plane before a separator",
+        "select '🦜';select 2",
+        ["select '🦜';", "select 2"],
+    ),
+    (
+        "non-ascii identifier",
+        'select "日本" from t; select 2',
+        ['select "日本" from t;', "select 2"],
+    ),
+    (
+        "windows line endings",
+        "select 1;\r\nselect 2;\r\n",
+        ["select 1;", "select 2;"],
+    ),
+    (
+        "many statements on one line",
+        "select 1;select 2;select 3",
+        ["select 1;", "select 2;", "select 3"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [(script, expected) for _, script, expected in CORPUS],
+    ids=[name for name, _, _ in CORPUS],
+)
+def test_split(script: str, expected: list[str]) -> None:
+    assert split(script) == [
+        Statement(sql=sql, index=i) for i, sql in enumerate(expected)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [(script, expected) for _, script, expected in CORPUS],
+    ids=[name for name, _, _ in CORPUS],
+)
+def test_find_separators_agrees_with_split(script: str, expected: list[str]) -> None:
+    """Slicing a buffer at the separators must reproduce split()'s statements.
+
+    This is the property the Query Editor relies on: it slices with the points,
+    while `-f` slices with the offsets, and the two must not disagree.
+    """
+    lines = script.splitlines(keepends=True)
+    line_starts = [0]
+    for line in lines:
+        line_starts.append(line_starts[-1] + len(line))
+
+    offsets = [line_starts[row] + col for row, col in find_separators(script)]
+    sliced = []
+    start = 0
+    for end in [*offsets, len(script)]:
+        if sql := script[start:end].strip():
+            sliced.append(sql)
+        start = end
+
+    assert sliced == expected
+
+
+def test_find_separators_returns_character_columns() -> None:
+    """Regression test for the byte-vs-character bug this module fixes.
+
+    tree-sitter reports `Point.column` in bytes; `日本語` is 9 bytes and 3
+    characters, so the raw node put the separator at column 19 instead of 13.
+    """
+    assert find_separators("select '日本語';select 2") == [(0, 13)]
+
+
+def test_find_separators_on_multiple_lines() -> None:
+    script = "select 1;\nselect 'né';\nselect 3;"
+    assert find_separators(script) == [(0, 9), (1, 12), (2, 9)]
+
+
+def test_find_separators_are_sorted() -> None:
+    """tree-sitter captures nodes in pattern-match order, not buffer order."""
+    script = "".join(f"select {i};\n" for i in range(50))
+    points = find_separators(script)
+    assert points == sorted(points)
+    assert len(points) == 50
+
+
+def test_statements_are_indexed_in_order() -> None:
+    statements = split("select 1; select 2; select 3")
+    assert [s.index for s in statements] == [0, 1, 2]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "https://github.com/tconbeer/harlequin/issues/1019 -- the grammar "
+        "splits inside a dollar-quoted body. The Query Editor has the same bug, "
+        "for the same reason: it is the grammar's, not ours."
+    ),
+    strict=True,
+)
+def test_dollar_quoted_body_is_not_split() -> None:
+    script = "create function f() as $$ select 1; $$; select 2"
+    assert split(script) == [
+        Statement(sql="create function f() as $$ select 1; $$;", index=0),
+        Statement(sql="select 2", index=1),
+    ]

--- a/tests/unit_tests/test_statements.py
+++ b/tests/unit_tests/test_statements.py
@@ -60,9 +60,15 @@ CORPUS: list[tuple[str, str, list[str]]] = [
         ["select 'it''s; fine';", "select 2"],
     ),
     # the reason find_separators() returns character columns. A byte offset
-    # would land 6 positions late here, one per byte of overhead in 日本語.
+    # lands one position late per byte of overhead: one for é, six for 日本語.
+    # The first is the reproduction from #1015.
     (
         "non-ascii before a separator",
+        "select 'café';select 2",
+        ["select 'café';", "select 2"],
+    ),
+    (
+        "multibyte before a separator",
         "select '日本語';select 2",
         ["select '日本語';", "select 2"],
     ),
@@ -133,11 +139,13 @@ def test_find_separators_agrees_with_split(script: str, expected: list[str]) -> 
 
 
 def test_find_separators_returns_character_columns() -> None:
-    """Regression test for the byte-vs-character bug this module fixes.
+    """Regression test for #1015, the byte-vs-character bug this module fixes.
 
-    tree-sitter reports `Point.column` in bytes; `日本語` is 9 bytes and 3
-    characters, so the raw node put the separator at column 19 instead of 13.
+    tree-sitter reports `Point.column` in bytes; `café` is 5 bytes and 4
+    characters, so the raw node put the separator at column 15 instead of 14,
+    and `日本語` (9 bytes, 3 characters) at 19 instead of 13.
     """
+    assert find_separators("select 'café';select 2") == [(0, 14)]
     assert find_separators("select '日本語';select 2") == [(0, 13)]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1325,6 +1325,8 @@ dependencies = [
     { name = "textual-fastdatatable" },
     { name = "textual-textarea" },
     { name = "tomlkit" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-sql" },
 ]
 
 [package.optional-dependencies]
@@ -1409,6 +1411,8 @@ requires-dist = [
     { name = "textual-fastdatatable", specifier = "==0.16.1" },
     { name = "textual-textarea", specifier = "==0.18.1" },
     { name = "tomlkit", specifier = ">=0.12.5,<0.14.0" },
+    { name = "tree-sitter", specifier = ">=0.25,<0.27" },
+    { name = "tree-sitter-sql", specifier = ">=0.3.11,<0.4" },
 ]
 provides-extras = ["s3", "postgres", "mysql", "odbc", "bigquery", "trino", "databricks", "adbc", "cassandra", "nebulagraph"]
 


### PR DESCRIPTION
Toward #524. Closes #1015.

This is **PR 2 of the M1 `hsql` plan** — "`harlequin.statements` and `harlequin.query`" (`docs/plans/m1-hsql-technical-plan.md` §4). Rebased onto `main` now that #1017 has landed; this is the whole diff.

§1.1 of the plan puts the problem plainly: query execution lives entirely inside the Textual app, as two threaded workers that communicate by posting messages. There is no importable function, so `hsql` cannot call any of it, and a copy is exactly the "two products" failure the product plan warns about. Same for splitting: the live splitter is a method on a Textual widget.

**What** are the key elements of this solution?

1. **`harlequin.statements` — one splitter, for both front ends.** `split(text)` returns `Statement`s; `find_separators(text)` returns the `Point`s the editor slices at. Both drive `tree-sitter-sql` directly, through the same `(";" @semicolon)` query `CodeEditor` has always used — so `-f script.sql` and the editor cannot disagree about where a statement ends. `tree-sitter` and `tree-sitter-sql` become direct dependencies (§3.2, Ted's call); both are installed for everyone already, transitively via `textual[syntax]`.

2. **`CodeEditor` is refactored onto it, and its fallback branch is deleted.** With one splitter there is no second implementation to keep in sync, so `SEMICOLON_QUERY`, `_semicolon_query`, `_query_separators`, `has_shown_tree_sitter_error` and the whole `is_syntax_aware` regex branch are gone — along with the warning pointing at `harlequin.sh/docs/troubleshooting/tree-sitter`, which described a degraded mode that no longer exists. (PR 7 retires the page itself.)

3. **That fixes #1015.** Tree-sitter's `Point.column` is a **byte** offset — Textual's own docstring says so — but `get_text_range()` takes *character* columns, and `code_editor.py` passed one straight into the other. `select 'café';select 2` split into `select 'café';s` and `elect 2`, both syntax errors. Owning the conversion once, in the shared library, is what stops `hsql` from inheriting it.

4. **`harlequin.query` — the execution core.** `execute()` runs statements and `fetch()` drains one cursor into a `ResultSet`. It keeps the app's two-phase *execute all, then fetch all* shape rather than flattening it: that split is what lets the TUI show "query executed" before results materialize.

5. **`_execute_query` and `_fetch_data` become thin wrappers**, still posting the same messages. `QueriesExecuted.cursors` now maps to `ExecutedStatement` (which carries its own statement) instead of a `tuple[HarlequinCursor, str]`, and `ResultsFetched.data` becomes `.results: dict[str, ResultSet]`. The dead `Harlequin._split_query_text` — a naive `text.split(";")` nothing called — is deleted.

6. **`ResultsTable` gets the backend `fetch()` built**, rather than raw data plus a `max_rows` it applies itself. Same object either way; the row cap just moves one call earlier.

Plus the guards PR 1 established: a third import-linter contract for the two new modules, and both added to `test_import_hygiene.py` and `scripts/cold_start.py`.

| import | ms | modules | textual |
| --- | --- | --- | --- |
| `harlequin.statements` | 35 | 106 | no |
| `harlequin.query` | 177 | 292 | no |

`harlequin.query`'s cost is `textual_fastdatatable.backend` (177ms, mostly pyarrow), which it shares — the core itself adds ~19 modules on top.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**`ResultSet` wraps a `DataTableBackend` rather than reimplementing one.** `HarlequinCursor.fetchall()` returns `AutoBackendType`, which is `Any`; `create_backend()` already normalizes every shape it can be, it is the normalization the TUI uses, and per PR 1 it needs no Textual. A second normalizer would put the most drift-prone question in the codebase — what counts as a row, what counts as null, how a nested struct comes out — in two places, and the disagreement would surface as `hsql` and the TUI showing different data for the same query.

**`RowLimit` is a value object, not an `int`, because Harlequin has two different limits.** The app's `--limit` is a *soft display cap over a full fetch*, which is why it can report `100,000 of 3,412,887`. `hsql -l` will be the *hard* one — fetching a million rows to print five hundred defeats the point — and a hard limit makes truncation unknowable: `set_limit(n)` then `fetchall()` returns at most n rows and says nothing about whether an n+1th existed. So `detect_overflow` asks for `limit + 1` and the backend's existing `source_row_count > row_count` does the rest. Principle 5 of the product plan ("truncation must always be announced") is unimplementable without it, and it costs exactly one row. The app passes `detect_overflow=False` and is unaffected.

**Two deviations from the plan's signatures, both to keep the TUI's behavior:**

- **`ExecutedStatement` gained an `error` field.** The plan has `execute()` return an iterator and doesn't say how a failure is reported. Raising would lose the association between the error and the statement it belongs to, which is exactly what the app needs to post `QueryError(query_text=…)`. Carrying it keeps `execute()` a pure iterator and gives `on_error="continue"` somewhere to put failures. `KeyboardInterrupt` deliberately propagates instead — Ctrl-C is not a query error, and `"continue"` must not swallow it.
- **`ResultSet.backend` is `DataTableBackend | None`.** A cursor is allowed to return `None` for an empty result, which is not a shape `create_backend()` can normalize — and there is nothing to normalize. This matches what `ResultsTable` already did with `data=None`.

**`ResultSet.text_columns()` is not here.** The plan puts it in PR 3, with the layouts that need it.

**One deliberate behavior change, in an unreachable-in-practice path.** `create_backend()` now runs in the worker rather than in `ResultsTable.__init__`, so an adapter returning a type it cannot normalize surfaces through `_fetch_data`'s existing `except BaseException` as a query error naming the query, instead of as `DataTable.DataLoadError`. Both open a "Query Error" modal with the same header logic; the new one attributes the failure to a statement. `handle_data_load_error` is kept — `DataTable` is third-party and may post it from other paths.

**The trade the plan names, restated:** sharing the grammar means `hsql` inherits the editor's behavior *including its bugs*. The dollar-quoting bug (`$$ … ; … $$` splits inside the body) is the editor's today, identically, because it is the grammar's. Recorded as a strict `xfail` against #1019 rather than fixed, so the day it's fixed upstream the test fails and tells us. The other cost is textual-textarea's incremental tree: the shared library reparses. Measured, that's 0.02ms for a realistic buffer and 10ms for a pathological 2000-statement one, and `selected_queries()` runs on submit, not on keystroke.

Note for review
- **`tree-sitter` is pinned `>=0.25,<0.27`** to match Textual's own floor for the `QueryCursor` API, and `tree-sitter-sql >=0.3.11,<0.4` to match `textual[syntax]`. The accepted cost the plan names: Harlequin stops installing on a platform with no tree-sitter wheel.
- `test_no_tree_sitter` is rewritten rather than deleted. It asserted the degraded mode; it now asserts the invariant that replaced it — with Textual's tree-sitter monkeypatched off, `select 'a;b'; select 2` still splits correctly (the old regex fallback split it wrong), and nothing warns.
- I filed #1018 for the split bug before finding #1015, which was already open with the same diagnosis and a fuller writeup. #1018 is closed as a duplicate; everything here references #1015.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: `docs/troubleshooting/tree-sitter` describes a degraded mode that no longer exists and should be retired. PR 7 of the plan owns that, along with the "Headless & Agents" topic.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

- **`tests/unit_tests/test_statements.py`** — the tricky-SQL corpus: 23 scripts through `split()`, and the same 23 through `find_separators()` asserting the two agree on every one. String literals, quoted identifiers, line and block comments, escaped quotes, consecutive and bare separators, CRLF, and five flavors of non-ASCII — including #1015's exact `select 'café';select 2` and an astral-plane character. Plus the strict `xfail` for #1019.
- **`tests/functional_tests/test_query_editor.py`** — `test_selected_queries_split_on_character_columns` is the #1015 regression through the real editor, asserting it agrees with `split()`; `test_selected_queries` now goes through `find_separators`.
- **`tests/unit_tests/test_query.py`** — 25 tests: laziness, DDL, error stop/continue, `KeyboardInterrupt` propagating, a raw driver exception not escaping, zero rows vs. a `None` cursor, the row cap being distinct from the fetch limit, and truncation at under/exactly/one-over the limit **on both duckdb and sqlite**, which implement `set_limit` differently enough to matter.

Verified on the rebased branch: 283 passed, 6 skipped, 1 xfailed, 140 snapshots passed on 3.10; 3 passed on the `py12` selection. `ruff`, `mypy` and `lint-imports` all clean, and `uv.lock` is consistent with `main`'s released `textual-fastdatatable==0.16.1`. The snapshots are the safety net for the TUI refactor and none of them moved.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.