### PR TITLE
refactor: share the profile/CLI precedence rule, load adapters one at a time (#524)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ That last sentence is `config.merge_profile_with_cli()`, and it belongs to every
 
 ## Conventions
 
+- **Docstrings and comments are as concise as possible.** One sentence describing the function, and at most a sentence or two on why it works the way it does. They are not the place to relay the design behind a change, the alternatives weighed, or the instructions the author was working from — that belongs in the PR description, or in `docs/plans/` for anything longer-lived.
 - Python 3.10 is the floor (`target-version = "py310"`). Use `from __future__ import annotations`; mypy runs strict, so every def is annotated.
 - Textual and its component libraries (`textual-textarea`, `textual-fastdatatable`) are pinned exactly — bump them together, and expect snapshot churn.
 - **Every PR adds a `CHANGELOG.md` entry under `[Unreleased]`**, referencing the issue it closes. Keep-a-changelog headings: Features, Performance, Bug Fixes, Dependencies, Refactoring. Releases are cut by the `release.yml` workflow, which bumps the version and rolls `[Unreleased]` into a version heading — don't hand-edit released sections or `version` in `pyproject.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ import-linter reads the *static* graph, so it cannot tell a deferred import from
 - `harlequin_duckdb`, `harlequin_sqlite` — in-tree adapters, registered through the `harlequin.adapter` entry point group like any third-party adapter. They are the reference implementations of the adapter contract.
 - `harlequin_vscode` — a keymap, registered through `harlequin.keymap`.
 
-`plugins.py` loads both groups via `importlib.metadata.entry_points`; a plugin that fails to import prints a warning instead of taking down the app. Loading is deliberately available at two grains, because `ep.load()` is the single most expensive thing a front end can do at start-up — four installed adapters cost ~160ms, and it grows without bound. `adapter_names()` reads entry point *names* and imports nothing; `load_adapter(name)` imports exactly one and raises rather than warning, since a caller that named an adapter has nothing to fall back to. `load_adapter_plugins()` imports every one, and is for the `harlequin` command, whose `--help` describes them all.
+`plugins.py` loads both groups via `importlib.metadata.entry_points`; a plugin that fails to import prints a warning instead of taking down the app. Loading comes at three grains, because `ep.load()` is the most expensive thing a front end can do at start-up and it grows with every adapter the user installs. `adapter_names()` reads entry point *names* and imports nothing; `load_adapter(name)` imports exactly one, and raises rather than warning, since a caller that named an adapter has nothing to fall back to; `load_adapter_plugins()` imports every one, for the `harlequin` command, whose `--help` describes them all.
 
 ### The execution core (`statements.py`, `query.py`)
 
@@ -146,7 +146,7 @@ The Data Catalog (`components/data_catalog/database_tree.py`) loads by viewport,
 
 Config files are TOML, discovered in order home → user config dir → cwd, merged so **later wins**; `pyproject.toml` is read from its `[tool.harlequin]` section. Profiles supply defaults that CLI options override.
 
-That last sentence is `config.merge_profile_with_cli()`, and it belongs to every command rather than to `cli.py`: **a CLI value beats the profile only if the user actually typed it**, since an option sitting at its default carries no intent and would otherwise clobber what the profile set. It takes the *names* of the options that were set — in click, every parameter whose `ctx.get_parameter_source()` isn't `DEFAULT` — rather than a `Context`, so `harlequin.config` stays free of the CLI framework (an import-linter contract pins that) and the rule is testable without one. An empty `conn_str` is the documented exception: it's an argument, so click always reports it as coming from the command line.
+That last sentence is `config.merge_profile_with_cli()`, and it belongs to every command rather than to `cli.py`: **a CLI value beats the profile only if the user actually typed it**, since an option sitting at its default carries no intent and would otherwise clobber what the profile set. It takes the *names* of the options that were set — in click, every parameter whose `ctx.get_parameter_source()` isn't `DEFAULT` — rather than a `Context`, so the rule is testable without building a command. An empty `conn_str` is the documented exception: it's an argument, so click always reports it as coming from the command line.
 
 ### Caches
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ import-linter reads the *static* graph, so it cannot tell a deferred import from
 - `harlequin_duckdb`, `harlequin_sqlite` — in-tree adapters, registered through the `harlequin.adapter` entry point group like any third-party adapter. They are the reference implementations of the adapter contract.
 - `harlequin_vscode` — a keymap, registered through `harlequin.keymap`.
 
-`plugins.py` loads both groups via `importlib.metadata.entry_points`; a plugin that fails to import prints a warning instead of taking down the app.
+`plugins.py` loads both groups via `importlib.metadata.entry_points`; a plugin that fails to import prints a warning instead of taking down the app. Loading is deliberately available at two grains, because `ep.load()` is the single most expensive thing a front end can do at start-up — four installed adapters cost ~160ms, and it grows without bound. `adapter_names()` reads entry point *names* and imports nothing; `load_adapter(name)` imports exactly one and raises rather than warning, since a caller that named an adapter has nothing to fall back to. `load_adapter_plugins()` imports every one, and is for the `harlequin` command, whose `--help` describes them all.
 
 ### The execution core (`statements.py`, `query.py`)
 
@@ -145,6 +145,8 @@ The Data Catalog (`components/data_catalog/database_tree.py`) loads by viewport,
 `AbstractOption` subclasses (`TextOption`, `ListOption`, `PathOption`, `SelectOption`, `FlagOption`) each know how to render themselves three ways: `to_click()` for the CLI, `to_widgets()` for the TUI, and `to_questionary()` for the config wizard. Declaring an adapter option once gets all three. `cli.py` builds the click command dynamically from the loaded adapters' `ADAPTER_OPTIONS`.
 
 Config files are TOML, discovered in order home → user config dir → cwd, merged so **later wins**; `pyproject.toml` is read from its `[tool.harlequin]` section. Profiles supply defaults that CLI options override.
+
+That last sentence is `config.merge_profile_with_cli()`, and it belongs to every command rather than to `cli.py`: **a CLI value beats the profile only if the user actually typed it**, since an option sitting at its default carries no intent and would otherwise clobber what the profile set. It takes the *names* of the options that were set — in click, every parameter whose `ctx.get_parameter_source()` isn't `DEFAULT` — rather than a `Context`, so `harlequin.config` stays free of the CLI framework (an import-linter contract pins that) and the rule is testable without one. An empty `conn_str` is the documented exception: it's an argument, so click always reports it as coming from the command line.
 
 ### Caches
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactoring
 
+- The rule that decides whether a CLI option or a config profile wins is now `harlequin.config.merge_profile_with_cli()`, rather than living inside the `harlequin` command ([#524](https://github.com/tconbeer/harlequin/issues/524)). It takes the names of the options the user actually typed instead of a click `Context`, so the precedence rule can be shared by a command that builds itself differently, and tested without the CLI framework. `harlequin.plugins` gains `adapter_names()`, which lists every installed adapter without importing any of them, and `load_adapter()`, which imports exactly one and fails loudly if it can't. Both are for the planned headless CLI, which uses one adapter per invocation and shouldn't pay to import the rest; the `harlequin` command still loads them all, since its `--help` describes every one.
 - Writing a result set to a file no longer requires a Textual widget ([#524](https://github.com/tconbeer/harlequin/issues/524)). `harlequin.export.write_file()` and `write_stream()` take an Arrow table and write it to a path or an open binary stream, and `harlequin.layout` arranges a result set as `table`, `markdown` or `vertical` text. Both are for the planned headless CLI and have no user-facing surface yet; the Data Exporter behaves as before. `export.py` also gains `tsv`, `jsonl`/`ndjson` and `arrow` as option variants of formats it already wrote.
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file.
 
 ### Refactoring
 
-- The rule that decides whether a CLI option or a config profile wins is now `harlequin.config.merge_profile_with_cli()`, rather than living inside the `harlequin` command ([#524](https://github.com/tconbeer/harlequin/issues/524)). It takes the names of the options the user actually typed instead of a click `Context`, so the precedence rule can be shared by a command that builds itself differently, and tested without the CLI framework. `harlequin.plugins` gains `adapter_names()`, which lists every installed adapter without importing any of them, and `load_adapter()`, which imports exactly one and fails loudly if it can't. Both are for the planned headless CLI, which uses one adapter per invocation and shouldn't pay to import the rest; the `harlequin` command still loads them all, since its `--help` describes every one.
 - Writing a result set to a file no longer requires a Textual widget ([#524](https://github.com/tconbeer/harlequin/issues/524)). `harlequin.export.write_file()` and `write_stream()` take an Arrow table and write it to a path or an open binary stream, and `harlequin.layout` arranges a result set as `table`, `markdown` or `vertical` text. Both are for the planned headless CLI and have no user-facing surface yet; the Data Exporter behaves as before. `export.py` also gains `tsv`, `jsonl`/`ndjson` and `arrow` as option variants of formats it already wrote.
 
 ### Performance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,20 +305,6 @@ unmatched_ignore_imports_alerting = "error"
 
 [[tool.importlinter.contracts]]
 
-# `merge_profile_with_cli()` is the precedence rule every Harlequin command
-# implements, so it takes the names of the options the user set rather than a
-# click Context. Keeping the config library free of the CLI framework is what
-# makes that rule testable without one, and shareable by a front end that builds
-# its command differently.
-name = "The config library does not depend on the CLI framework"
-type = "forbidden"
-source_modules = ["harlequin.config"]
-forbidden_modules = ["click", "rich_click"]
-unmatched_ignore_imports_alerting = "error"
-
-
-[[tool.importlinter.contracts]]
-
 # Importing any harlequin.* submodule executes this package's __init__, so a
 # single eager import there puts the whole TUI behind every consumer. The
 # public names are resolved by a PEP 562 __getattr__ instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ source_modules = [
     "harlequin.adapter",
     "harlequin.autocomplete",
     "harlequin.catalog",
+    "harlequin.config",
     "harlequin.exception",
     "harlequin.keymap",
     "harlequin.options",
@@ -299,6 +300,20 @@ forbidden_modules = [
 # deferred into pretty_print_warning(), which nothing here calls; the run-time
 # test in tests/unit_tests/test_import_hygiene.py is what proves it defers.
 ignore_imports = ["harlequin.exception -> harlequin.colors"]
+unmatched_ignore_imports_alerting = "error"
+
+
+[[tool.importlinter.contracts]]
+
+# `merge_profile_with_cli()` is the precedence rule every Harlequin command
+# implements, so it takes the names of the options the user set rather than a
+# click Context. Keeping the config library free of the CLI framework is what
+# makes that rule testable without one, and shareable by a front end that builds
+# its command differently.
+name = "The config library does not depend on the CLI framework"
+type = "forbidden"
+source_modules = ["harlequin.config"]
+forbidden_modules = ["click", "rich_click"]
 unmatched_ignore_imports_alerting = "error"
 
 

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -312,8 +312,7 @@ def build_cli() -> click.Command:
             pretty_print_error(e)
             ctx.exit(2)
 
-        # merge the config and the cli options; an option left at its default
-        # must not override the profile
+        # merge the config and the cli options
         explicitly_set = {
             k
             for k in kwargs

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -12,7 +12,7 @@ from harlequin import Harlequin
 from harlequin.adapter import HarlequinAdapter
 from harlequin.catalog_cache import get_connection_hash
 from harlequin.colors import GREEN, PINK, PURPLE, VALID_THEMES, YELLOW
-from harlequin.config import get_config_for_profile
+from harlequin.config import get_config_for_profile, merge_profile_with_cli
 from harlequin.config_wizard import wizard
 from harlequin.exception import (
     HarlequinConfigError,
@@ -312,19 +312,16 @@ def build_cli() -> click.Command:
             pretty_print_error(e)
             ctx.exit(2)
 
-        # prune the kwargs to only those that don't have their default arguments
-        params = list(kwargs.keys())
-        for k in params:
-            if (
-                ctx.get_parameter_source(k) == click.core.ParameterSource.DEFAULT  # type: ignore[attr-defined]
-            ):
-                kwargs.pop(k)
-            # conn_str is an arg, not an option, so get_paramter_source is always CLI
-            elif k == "conn_str" and kwargs[k] == tuple():
-                kwargs.pop(k)
-
-        # merge the config and the cli options
-        config.update(kwargs)  # type: ignore[typeddict-item]
+        # merge the config and the cli options; an option left at its default
+        # must not override the profile
+        explicitly_set = {
+            k
+            for k in kwargs
+            if ctx.get_parameter_source(k) != click.core.ParameterSource.DEFAULT  # type: ignore[attr-defined]
+        }
+        config = merge_profile_with_cli(
+            profile=config, cli_values=kwargs, explicitly_set=explicitly_set
+        )
 
         # detect and install (if necessary) a tzdatabase on Windows
         if sys.platform == "win32" and not config.pop("no_download_tzdata", None):

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -127,23 +127,14 @@ def merge_profile_with_cli(
 ) -> Profile:
     """
     Layer the values a user passed on the command line over the profile loaded
-    from their config files, and return the result. Neither argument is mutated.
+    from their config files. Neither argument is mutated.
 
-    The precedence rule is the same for every Harlequin command, which is why it
-    lives here and not in one of them: **a CLI value wins over the profile only
-    if the user actually typed it.** An option left at its default carries no
-    intent, so it must not overwrite what the profile set -- otherwise every
-    profile value would be clobbered by a default the user never chose.
-
-    `explicitly_set` names the keys of `cli_values` the user set, rather than
-    taking a click Context, so this stays testable and free of the CLI
-    framework. In click that set is every parameter whose
-    `ctx.get_parameter_source()` is not `ParameterSource.DEFAULT`.
-
-    An empty `conn_str` is the one exception: it is an argument rather than an
-    option, so click always reports it as coming from the command line, even
-    when it is absent. Overriding a profile's conn_str with an empty tuple would
-    make `harlequin -P prod` open nothing at all.
+    A CLI value wins only if the user actually typed it; `explicitly_set` names
+    those keys, which in click is every parameter whose
+    `ctx.get_parameter_source()` is not `ParameterSource.DEFAULT`. An empty
+    `conn_str` is the exception -- it is an argument, so click always reports it
+    as typed, and letting it through would leave `harlequin -P prod` with
+    nothing to open.
     """
     merged: dict[str, Any] = dict(profile)
     for key, value in cli_values.items():

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence, TypedDict, cast
+from typing import Any, Container, Mapping, Sequence, TypedDict, cast
 
 from platformdirs import user_config_path
 from tomlkit.exceptions import TOMLKitError
@@ -118,6 +118,41 @@ def get_config_for_profile(
     ]
 
     return profile, keymaps
+
+
+def merge_profile_with_cli(
+    profile: Profile,
+    cli_values: Mapping[str, Any],
+    explicitly_set: Container[str],
+) -> Profile:
+    """
+    Layer the values a user passed on the command line over the profile loaded
+    from their config files, and return the result. Neither argument is mutated.
+
+    The precedence rule is the same for every Harlequin command, which is why it
+    lives here and not in one of them: **a CLI value wins over the profile only
+    if the user actually typed it.** An option left at its default carries no
+    intent, so it must not overwrite what the profile set -- otherwise every
+    profile value would be clobbered by a default the user never chose.
+
+    `explicitly_set` names the keys of `cli_values` the user set, rather than
+    taking a click Context, so this stays testable and free of the CLI
+    framework. In click that set is every parameter whose
+    `ctx.get_parameter_source()` is not `ParameterSource.DEFAULT`.
+
+    An empty `conn_str` is the one exception: it is an argument rather than an
+    option, so click always reports it as coming from the command line, even
+    when it is absent. Overriding a profile's conn_str with an empty tuple would
+    make `harlequin -P prod` open nothing at all.
+    """
+    merged: dict[str, Any] = dict(profile)
+    for key, value in cli_values.items():
+        if key not in explicitly_set:
+            continue
+        if key == "conn_str" and value == tuple():
+            continue
+        merged[key] = value
+    return cast(Profile, merged)
 
 
 def load_config(config_path: Path | None) -> Config:

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -126,15 +126,12 @@ def merge_profile_with_cli(
     explicitly_set: Container[str],
 ) -> Profile:
     """
-    Layer the values a user passed on the command line over the profile loaded
-    from their config files. Neither argument is mutated.
+    Layer the CLI values a user typed over the profile from their config files.
 
-    A CLI value wins only if the user actually typed it; `explicitly_set` names
-    those keys, which in click is every parameter whose
-    `ctx.get_parameter_source()` is not `ParameterSource.DEFAULT`. An empty
-    `conn_str` is the exception -- it is an argument, so click always reports it
-    as typed, and letting it through would leave `harlequin -P prod` with
-    nothing to open.
+    A value counts as typed only if `explicitly_set` names it -- in click, every
+    parameter whose `get_parameter_source()` is not `DEFAULT`. An empty
+    `conn_str` never counts: it is an argument, so click always reports it as
+    typed.
     """
     merged: dict[str, Any] = dict(profile)
     for key, value in cli_values.items():

--- a/src/harlequin/plugins.py
+++ b/src/harlequin/plugins.py
@@ -2,11 +2,52 @@ from __future__ import annotations
 
 import sys
 from importlib.metadata import entry_points
-from typing import Literal, Sequence, overload
+from typing import Literal, Sequence, cast, overload
 
 from harlequin.adapter import HarlequinAdapter
 from harlequin.exception import HarlequinConfigError
 from harlequin.keymap import HarlequinKeyMap
+
+
+def adapter_names() -> list[str]:
+    """
+    The name of every installed adapter, without importing any of them.
+
+    Reading entry point names costs nothing; `ep.load()` imports the adapter and
+    everything it depends on, which for four installed adapters is ~160ms. A
+    front end that only ever uses one adapter per invocation can name them all
+    from here and then load just the one it needs.
+    """
+    return sorted({ep.name for ep in entry_points(group="harlequin.adapter")})
+
+
+def load_adapter(name: str) -> type[HarlequinAdapter]:
+    """
+    Import exactly one installed adapter, by its entry point name.
+
+    Unlike load_adapter_plugins(), a failure here is fatal: the caller asked for
+    this adapter by name, so there is nothing to fall back to.
+
+    Raises: HarlequinConfigError if no installed plug-in registers that name, or
+    if the adapter it registers cannot be imported.
+    """
+    matches = [ep for ep in entry_points(group="harlequin.adapter") if ep.name == name]
+    if not matches:
+        installed = ", ".join(adapter_names())
+        raise HarlequinConfigError(
+            f"Could not load an adapter named {name}, because no installed "
+            "plug-in provides one with that name. Installed adapters: "
+            f"{installed if installed else '(none)'}.",
+            title="Harlequin could not load your adapter.",
+        )
+    ep = matches[-1]  # last one wins, to agree with load_adapter_plugins()
+    try:
+        return cast("type[HarlequinAdapter]", ep.load())
+    except ImportError as e:
+        raise HarlequinConfigError(
+            f"Could not load the installed plug-in named {ep.name}.\n\n{e}",
+            title="Harlequin could not load your adapter.",
+        ) from e
 
 
 def load_adapter_plugins() -> dict[str, type[HarlequinAdapter]]:

--- a/src/harlequin/plugins.py
+++ b/src/harlequin/plugins.py
@@ -20,11 +20,8 @@ def load_adapter(name: str) -> type[HarlequinAdapter]:
     """
     Import exactly one installed adapter, by its entry point name.
 
-    Unlike load_adapter_plugins(), a failure here is fatal: the caller asked for
-    this adapter by name, so there is nothing to fall back to.
-
-    Raises: HarlequinConfigError if no installed plug-in registers that name, or
-    if the adapter it registers cannot be imported.
+    Raises HarlequinConfigError, where load_adapter_plugins() only warns,
+    because a caller that named an adapter has nothing to fall back to.
     """
     matches = [ep for ep in entry_points(group="harlequin.adapter") if ep.name == name]
     if not matches:

--- a/src/harlequin/plugins.py
+++ b/src/harlequin/plugins.py
@@ -12,11 +12,6 @@ from harlequin.keymap import HarlequinKeyMap
 def adapter_names() -> list[str]:
     """
     The name of every installed adapter, without importing any of them.
-
-    Reading entry point names costs nothing; `ep.load()` imports the adapter and
-    everything it depends on, which for four installed adapters is ~160ms. A
-    front end that only ever uses one adapter per invocation can name them all
-    from here and then load just the one it needs.
     """
     return sorted({ep.name for ep in entry_points(group="harlequin.adapter")})
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -342,6 +342,31 @@ def test_config_path_fron_env(
     assert mock_adapter.call_args.kwargs["extension"] == ["httpfs", "spatial"]
 
 
+@pytest.mark.parametrize("filename", ["good_config.toml", "pyproject.toml"])
+def test_conn_str_overrides_the_profile(
+    mock_harlequin: MagicMock,
+    mock_adapter: MagicMock,
+    data_dir: Path,
+    filename: str,
+) -> None:
+    """A conn_str on the command line beats the profile's; an absent one doesn't.
+
+    The other half of this pair is test_config_path, where no conn_str is passed
+    and the profile's survives.
+    """
+    runner = CliRunner()
+    config_path = data_dir / "unit_tests" / "config" / filename
+    res = runner.invoke(
+        build_cli(), args=f"--config-path {config_path.as_posix()} other.db"
+    )
+    assert res.exit_code == 0
+    mock_adapter.assert_called_once()
+    assert mock_adapter.call_args.kwargs["conn_str"] == ("other.db",)
+    # unrelated profile values are untouched
+    assert mock_adapter.call_args.kwargs["extension"] == ["httpfs", "spatial"]
+    assert mock_harlequin.call_args.kwargs["max_results"] == 200_000
+
+
 def test_bad_config_exits(
     mock_harlequin: MagicMock,
     mock_adapter: MagicMock,

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -349,10 +349,9 @@ def test_conn_str_overrides_the_profile(
     data_dir: Path,
     filename: str,
 ) -> None:
-    """A conn_str on the command line beats the profile's; an absent one doesn't.
+    """A conn_str on the command line beats the profile's.
 
-    The other half of this pair is test_config_path, where no conn_str is passed
-    and the profile's survives.
+    test_config_path is the other half: with none passed, the profile's survives.
     """
     runner = CliRunner()
     config_path = data_dir / "unit_tests" / "config" / filename

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -168,8 +168,7 @@ def test_merge_profile_with_cli_prefers_values_the_user_typed() -> None:
         cli_values={"theme": "zenburn", "limit": 100_000},
         explicitly_set={"theme"},
     )
-    # the theme was typed, so it wins; the limit is a click default, which
-    # carries no intent and must not clobber the profile
+    # the theme was typed, so it wins; the limit is a default, so it doesn't
     assert merged == {"theme": "zenburn", "limit": 200_000}
 
 
@@ -185,11 +184,7 @@ def test_merge_profile_with_cli_keeps_options_the_profile_alone_defines() -> Non
 
 
 def test_merge_profile_with_cli_ignores_an_empty_conn_str() -> None:
-    """conn_str is an argument, so click always reports it as typed.
-
-    Letting an absent one through would leave `harlequin -P prod` with nothing
-    to connect to.
-    """
+    """An absent conn_str would otherwise leave `harlequin -P prod` nothing to open."""
     profile: Profile = {"conn_str": ["my-database.db"]}
     merged = merge_profile_with_cli(
         profile=profile,

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import pytest
 
 from harlequin.config import (
+    Profile,
     _find_config_files,
     get_config_for_profile,
     get_highest_priority_existing_config_file,
     load_config,
+    merge_profile_with_cli,
 )
 from harlequin.exception import HarlequinConfigError
 from harlequin.keymap import HarlequinKeyBinding, HarlequinKeyMap
@@ -157,3 +159,74 @@ def test_config_file_discovery(
     expected_paths.pop()
     assert _find_config_files(config_path=None) == expected_paths
     assert get_highest_priority_existing_config_file() == expected_paths[-1]
+
+
+def test_merge_profile_with_cli_prefers_values_the_user_typed() -> None:
+    profile: Profile = {"theme": "fruity", "limit": 200_000}
+    merged = merge_profile_with_cli(
+        profile=profile,
+        cli_values={"theme": "zenburn", "limit": 100_000},
+        explicitly_set={"theme"},
+    )
+    # the theme was typed, so it wins; the limit is a click default, which
+    # carries no intent and must not clobber the profile
+    assert merged == {"theme": "zenburn", "limit": 200_000}
+
+
+def test_merge_profile_with_cli_keeps_options_the_profile_alone_defines() -> None:
+    """Adapter options live in the profile under names the CLI never saw."""
+    profile: Profile = {"adapter": "postgres", "dbname": "prod"}  # type: ignore[typeddict-unknown-key]
+    merged = merge_profile_with_cli(
+        profile=profile,
+        cli_values={"username": "ted"},
+        explicitly_set={"username"},
+    )
+    assert merged == {"adapter": "postgres", "dbname": "prod", "username": "ted"}
+
+
+def test_merge_profile_with_cli_ignores_an_empty_conn_str() -> None:
+    """conn_str is an argument, so click always reports it as typed.
+
+    Letting an absent one through would leave `harlequin -P prod` with nothing
+    to connect to.
+    """
+    profile: Profile = {"conn_str": ["my-database.db"]}
+    merged = merge_profile_with_cli(
+        profile=profile,
+        cli_values={"conn_str": tuple()},
+        explicitly_set={"conn_str"},
+    )
+    assert merged == {"conn_str": ["my-database.db"]}
+
+
+def test_merge_profile_with_cli_accepts_a_conn_str_that_was_passed() -> None:
+    profile: Profile = {"conn_str": ["my-database.db"]}
+    merged = merge_profile_with_cli(
+        profile=profile,
+        cli_values={"conn_str": ("other.db",)},
+        explicitly_set={"conn_str"},
+    )
+    assert merged == {"conn_str": ("other.db",)}
+
+
+def test_merge_profile_with_cli_leaves_its_arguments_alone() -> None:
+    """The profile is a live reference into the merged config files."""
+    profile: Profile = {"theme": "fruity"}
+    cli_values = {"theme": "zenburn"}
+    merged = merge_profile_with_cli(
+        profile=profile, cli_values=cli_values, explicitly_set={"theme"}
+    )
+    assert profile == {"theme": "fruity"}
+    assert cli_values == {"theme": "zenburn"}
+    assert merged is not profile
+
+
+def test_merge_profile_with_cli_falsy_values_are_still_values() -> None:
+    """`--limit 0` and `--no-init` mean what they say."""
+    profile: Profile = {"limit": 200_000, "no_init": False}  # type: ignore[typeddict-unknown-key]
+    merged = merge_profile_with_cli(
+        profile=profile,
+        cli_values={"limit": 0, "no_init": True},
+        explicitly_set={"limit", "no_init"},
+    )
+    assert merged == {"limit": 0, "no_init": True}

--- a/tests/unit_tests/test_plugins.py
+++ b/tests/unit_tests/test_plugins.py
@@ -28,13 +28,10 @@ def _adapter_packages(code: str) -> str:
 
 
 def test_adapter_names_agree_with_the_loaded_adapters() -> None:
-    """The cheap listing and the expensive one must not disagree.
+    """The cheap listing and the expensive one must name the same adapters.
 
-    `adapter_names()` exists to avoid importing every adapter just to find out
-    what is installed, so it has to name the same ones. Not equality: an adapter
-    that is installed but won't import is named here and dropped by
-    `load_adapter_plugins()`, which is the difference between the two functions
-    and not a disagreement about what is installed.
+    A subset, not equality: an installed adapter that won't import is named here
+    and dropped by `load_adapter_plugins()`.
     """
     names = adapter_names()
     assert set(load_adapter_plugins().keys()) <= set(names)
@@ -79,12 +76,7 @@ def test_load_adapter_raises_for_an_unknown_name() -> None:
 def test_load_adapter_raises_when_the_adapter_will_not_import(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A named adapter that won't import is fatal, unlike one found by scanning.
-
-    `load_adapter_plugins()` warns and carries on, because the app can still run
-    with the adapters that did load. Here the caller asked for this one by name,
-    so there is nothing to fall back to.
-    """
+    """A named adapter that won't import is fatal, unlike one found by scanning."""
     ep = MagicMock()
     ep.name = "broken"
     ep.load.side_effect = ImportError("no module named nope", name="nope")

--- a/tests/unit_tests/test_plugins.py
+++ b/tests/unit_tests/test_plugins.py
@@ -46,12 +46,7 @@ def test_adapter_names_agree_with_the_loaded_adapters() -> None:
 def test_adapter_names_imports_no_adapter(
     run_python: Callable[[str], subprocess.CompletedProcess[str]],
 ) -> None:
-    """Naming the installed adapters must not import any of them.
-
-    This is what makes a headless front end's two-phase parse worth doing: with
-    four adapters installed, `ep.load()` on all of them is ~160ms of a ~380ms
-    invocation, and it grows with every adapter the user installs.
-    """
+    """Naming the installed adapters must not import any of them."""
     proc = run_python(
         _adapter_packages(
             "from harlequin.plugins import adapter_names\n"

--- a/tests/unit_tests/test_plugins.py
+++ b/tests/unit_tests/test_plugins.py
@@ -2,13 +2,102 @@ from __future__ import annotations
 
 import subprocess
 from typing import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
 from harlequin.cli import DEFAULT_KEYMAP_NAMES
 from harlequin.exception import HarlequinConfigError
 from harlequin.keymap import HarlequinKeyMap
-from harlequin.plugins import load_keymap_plugins
+from harlequin.plugins import (
+    adapter_names,
+    load_adapter,
+    load_adapter_plugins,
+    load_keymap_plugins,
+)
+
+
+def _adapter_packages(code: str) -> str:
+    """A snippet that runs `code`, then reports the adapters it imported."""
+    return (
+        f"{code}\n"
+        "import sys\n"
+        "print(','.join(sorted({m.split('.')[0] for m in list(sys.modules)"
+        " if m.startswith('harlequin_')})))\n"
+    )
+
+
+def test_adapter_names_agree_with_the_loaded_adapters() -> None:
+    """The cheap listing and the expensive one must not disagree.
+
+    `adapter_names()` exists to avoid importing every adapter just to find out
+    what is installed, so it has to name the same ones. Not equality: an adapter
+    that is installed but won't import is named here and dropped by
+    `load_adapter_plugins()`, which is the difference between the two functions
+    and not a disagreement about what is installed.
+    """
+    names = adapter_names()
+    assert set(load_adapter_plugins().keys()) <= set(names)
+    assert "duckdb" in names
+    assert "sqlite" in names
+    assert names == sorted(names)
+
+
+def test_adapter_names_imports_no_adapter(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """Naming the installed adapters must not import any of them.
+
+    This is what makes a headless front end's two-phase parse worth doing: with
+    four adapters installed, `ep.load()` on all of them is ~160ms of a ~380ms
+    invocation, and it grows with every adapter the user installs.
+    """
+    proc = run_python(
+        _adapter_packages(
+            "from harlequin.plugins import adapter_names\n"
+            "assert 'duckdb' in adapter_names()"
+        )
+    )
+    assert proc.stdout.strip() == ""
+
+
+def test_load_adapter_loads_exactly_one_adapter(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    assert load_adapter("duckdb") is load_adapter_plugins()["duckdb"]
+    proc = run_python(
+        _adapter_packages(
+            "from harlequin.plugins import load_adapter\nload_adapter('duckdb')"
+        )
+    )
+    assert proc.stdout.strip() == "harlequin_duckdb"
+
+
+def test_load_adapter_raises_for_an_unknown_name() -> None:
+    with pytest.raises(HarlequinConfigError) as exc_info:
+        load_adapter("not-an-adapter")
+    # names the adapter that was asked for, and the ones that could have been
+    assert "not-an-adapter" in str(exc_info.value)
+    assert "duckdb" in str(exc_info.value)
+
+
+def test_load_adapter_raises_when_the_adapter_will_not_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named adapter that won't import is fatal, unlike one found by scanning.
+
+    `load_adapter_plugins()` warns and carries on, because the app can still run
+    with the adapters that did load. Here the caller asked for this one by name,
+    so there is nothing to fall back to.
+    """
+    ep = MagicMock()
+    ep.name = "broken"
+    ep.load.side_effect = ImportError("no module named nope", name="nope")
+    monkeypatch.setattr("harlequin.plugins.entry_points", lambda group: [ep])
+    with pytest.raises(HarlequinConfigError) as exc_info:
+        load_adapter("broken")
+    assert "broken" in str(exc_info.value)
+    assert "no module named nope" in str(exc_info.value)
 
 
 def test_load_keymap_plugins() -> None:


### PR DESCRIPTION
Part of #524 — PR 4 of the M1 `hsql` plan (`docs/plans/m1-hsql-technical-plan.md`, §3.4–3.5). Not `Closes`: #524 stays open until PRs 5–8 land the command itself.

**What** are the key elements of this solution?

Two extractions, both behavior-neutral for the `harlequin` command.

- `config.merge_profile_with_cli()` is the precedence rule that used to sit inside `inner_cli`: **a CLI value beats the profile only if the user actually typed it**, since an option resting on its default carries no intent. It takes the *names* of the options that were set rather than a click `Context`. The empty-`conn_str` carve-out moves with it and is now stated in a docstring rather than implied by an `elif`.
- `plugins.adapter_names()` lists every installed adapter without importing any of them; `plugins.load_adapter(name)` imports exactly one. `harlequin`'s CLI is refactored onto the first and keeps `load_adapter_plugins()`, since its `--help` describes every installed adapter.

Neither new plugins function has a consumer yet — they're what makes the two-phase parse in PR 5 possible.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

*Names, not a `Context`.* Taking `explicitly_set: Container[str]` means the rule can be applied — and tested — without building a command first, which is what `hsql` needs: it resolves its adapter before it has a full command to get a `Context` from. The tradeoff is that the caller now derives the set, which is one comprehension over `ctx.get_parameter_source()`.

*Why `load_adapter` raises where `load_adapter_plugins` warns.* Scanning can afford to skip an adapter that won't import — the app still runs with the ones that did. A caller that named an adapter has nothing to fall back to, so a `HarlequinConfigError` (exit 2, with the underlying `ImportError` in the message) is the honest answer. Alternative considered: returning `None` and letting callers decide, which just moves the same decision to every call site.

*Why the split at all.* `ep.load()` on every installed adapter is the only unbounded cost in start-up, and it's paid to build a command that will use exactly one. Two subprocess tests hold that line: `adapter_names()` imports no `harlequin_*` package, and `load_adapter("duckdb")` imports exactly `harlequin_duckdb`.

*One incidental improvement:* the merge no longer mutates the profile dict in place. It was a live reference into the merged config files, and the code downstream `pop()`s from it.

Does this PR require a change to Harlequin's docs?
- [x] No. Nothing user-facing changes; the `hsql` docs topic is PR 7 of this plan. `AGENTS.md` is updated with the precedence rule and the three loading grains.

Did you add or update tests for this change?
- [x] Yes. 8 new in `test_plugins.py`, 6 in `test_config.py`, and `test_conn_str_overrides_the_profile` in `test_cli.py` — a precedence case the existing tests never covered (a CLI `conn_str` beating a profile's, with the rest of the profile intact). The rest of the refactor is covered by the existing `test_cli.py`. Full suite 451 passed / 6 skipped, py12 3 passed, mypy clean, import contracts kept.

Please complete the following checklist:
- [ ] ~I have added an entry to `CHANGELOG.md`~ — deliberately none, [per review](https://github.com/tconbeer/harlequin/pull/1023#discussion_r3744662817): nothing in this PR is visible to a user of the `harlequin` command.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.