### PR TITLE
feat: add hsql, the headless CLI (#524)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ uv run --python 3.12 --group test pytest -m 'py12 and not online' --snapshot-upd
 
 ## Import hygiene
 
-The headless CLI (`hsql`, planned in `docs/plans/`) has to reach a database without paying for the TUI, so **the adapter-facing modules must stay free of Textual, questionary, prompt_toolkit and sqlfmt at import time.** Concretely:
+The headless CLI (`hsql`) has to reach a database without paying for the TUI, so **the adapter-facing modules must stay free of Textual, questionary, prompt_toolkit and sqlfmt at import time.** Concretely:
 
 - `harlequin/__init__.py` resolves its public names through a PEP 562 `__getattr__`. Never add a module-scope import there — importing *any* `harlequin.*` submodule executes it, so one eager import puts the whole app behind every consumer.
 - Type-only imports of Textual (e.g. `AutoBackendType`) go under `if TYPE_CHECKING:`; every module involved already has `from __future__ import annotations`.
@@ -118,6 +118,16 @@ Both front ends run queries through here, and neither may grow its own copy.
 
 Two invariants the tests pin: **the bytes are the contract** — writers go through a temp file and are copied out in binary, so `\n` survives on Windows and `-o PATH` and `> PATH` agree — and **`-F table` and `-F csv` agree cell for cell**, which is what the output snapshots in `tests/unit_tests/__snapshots__/test_golden_formats/` exist to catch. They are syrupy single-file snapshots, one per format, written in binary — regenerate them with `--snapshot-update` on 3.10 like every other snapshot here, and read the diff; a change there is a change to Harlequin's output contract.
 
+### The headless CLI (`hsql/`)
+
+`hsql` is a second console script over the same execution core, not a mode of `harlequin`. It owns no query logic: `cli.py` parses, `harlequin.query` runs, `harlequin.layout` and `harlequin.export` write. New query behavior belongs in the core so both front ends get it.
+
+- `cli.py` parses in **two phases**. The first reads `-a`, `-P` and `--config-path` with a throwaway resilient parser to name the one adapter the invocation will use — `adapter_names()`, no `ep.load()` — and the second builds the real command with only that adapter's options. `--help` with no adapter named imports *nothing* and lists adapter names instead; that's what keeps the first thing an agent reads small and true for every adapter. `harlequin.query` and `harlequin.statements` are deferred into the callback for the same reason.
+- **hsql's own flags are the frozen part.** An adapter option whose spelling collides with one loses that spelling (`_adapter_params`), rather than shadowing a documented flag.
+- `diagnostics.py` owns **everything on stderr and the exit-code mapping**. Nothing else in `hsql/` writes to stderr, and nothing writes to stdout except `output.py`.
+- `output.py` picks between the two families of format and writes through **one binary stream**, `-o PATH` included, so a file and a redirect cannot disagree about a byte.
+- Two things it must never do: call `set_locale()` (output that varies with `LC_ALL` is output a caller cannot predict) or reach `harlequin.cli` (that module builds the IDE's command). Both are covered by the `hsql does not reach the TUI` import-linter contract and `tests/unit_tests/test_hsql.py`.
+
 ### The adapter contract (`adapter.py`, `catalog.py`, `driver.py`)
 
 `HarlequinAdapter` (built from CLI/config options) → `connect()` → `HarlequinConnection` (execute, get_catalog, optional copy/cancel/transaction-mode/completions) → `HarlequinCursor` (columns, set_limit, fetchall). Adapters must tolerate receiving both subsets and supersets of their declared options, and must not rely on option defaults.
@@ -156,7 +166,7 @@ That last sentence is `config.merge_profile_with_cli()`, and it belongs to every
 
 - `stubs/` holds type stubs for untyped dependencies (`mypy_path = "stubs,src"`).
 - Styles are Textual CSS: `global.tcss`, `app.tcss`, `keys_app.tcss`.
-- `packaging/hsql/` is a metapackage reserving the `hsql` name on PyPI; `docs/plans/` holds design docs for the planned headless CLI.
+- `packaging/hsql/` is a metapackage reserving the `hsql` name on PyPI; `docs/plans/` holds the design docs behind the headless CLI.
 - `scripts/` has the screenshot exporter used for marketing SVGs and pyinstrument profiling entrypoints (`make profiles`).
 
 ## Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Adds `hsql`, Harlequin's headless CLI, as a second console script ([#524](https://github.com/tconbeer/harlequin/issues/524)). `hsql -P prod -c "select count(*) from orders"` runs SQL and exits, against any installed adapter, with the same config files, profiles and precedence the IDE uses — so an agent or a CI job never handles a credential. The `harlequin` command is unchanged: no new flags, no new behavior.
+  - **SQL comes from `-c/--command`, `-f/--file`, or `-f -` for stdin.** Both are repeatable and run in the order given.
+  - **Formats** are `table` (the default), `markdown`/`md` and `vertical` for text, `csv`, `tsv`, `json`, `jsonl`/`ndjson`, `parquet`, `orc` and `arrow` for files, and `none` to report status without rows. Pick one with `-F/--format` or the `--csv`/`--json`/`--jsonl`/`--markdown`/`--vertical` shorthands, and write it to a file with `-o/--output`.
+  - **psql's flags, where psql has one**: `-t/--tuples-only`, `-A/--no-align`, `--no-header` and `--null-string`, so `hsql -tAc "select count(*)"` returns a bare number.
+  - **stdout is data; stderr is narration.** Row counts, timings, truncation notices and errors all go to stderr, so `hsql -c ... --csv > out.csv` produces a clean file. Errors are one plain line — `hsql: error: ...` — rather than a panel.
+  - **Exit codes are an API**: 0 success, 1 query error, 2 usage or config error, 3 connection error, 130 interrupted.
+  - **`--limit` defaults to 500 and truncation is never silent.** It is a *hard* limit — `cursor.set_limit()`, so fewer rows leave the database — where the IDE's `--limit` is a soft cap over a full fetch. A truncated result says `(500 of 500+ rows)` and reports it on stderr, `-t` included; `-l 0` fetches everything and counts exactly. A profile shared with the IDE shares its `limit` too, so pass `-l` when the IDE's cap is not the one you want.
+  - **`--stats`** writes one line of JSON to stderr — statement count, rows, truncation, elapsed time and the result's columns — whatever stdout is carrying.
+  - **`--result all|last|N`** picks which result set a multi-statement script emits, and `--on-error stop|continue` decides whether one failure ends the script. A format that cannot hold two result sets says so and exits 2, rather than writing a second header into the same csv.
+  - **Output is deterministic.** Identical bytes whether stdout is a pipe, a file or a terminal, `\n` on every platform, and unaffected by `LC_ALL`. Color is the exception and is off unless `--color` asks for it.
+  - **`hsql --help` costs no adapter import**: it lists the adapter-agnostic options, the formats, the exit codes and the *names* of installed adapters, and points at `hsql --help -a <adapter>` for one adapter's connection options.
+
+### Performance
+
+- `harlequin.exception` no longer imports `rich` ([#524](https://github.com/tconbeer/harlequin/issues/524)). It is on every headless path — `harlequin.config` imports it — so `hsql --help` was paying 20ms for a panel it never draws.
+
 ## [2.8.1] - 2026-08-09
 
 ### Refactoring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ Changelog = "https://github.com/tconbeer/harlequin/blob/main/CHANGELOG.md"
 [project.scripts]
 
 harlequin = "harlequin.cli:harlequin"
+hsql = "harlequin.hsql:main"
 
 
 [project.entry-points."harlequin.adapter"]
@@ -300,6 +301,42 @@ forbidden_modules = [
 # deferred into pretty_print_warning(), which nothing here calls; the run-time
 # test in tests/unit_tests/test_import_hygiene.py is what proves it defers.
 ignore_imports = ["harlequin.exception -> harlequin.colors"]
+unmatched_ignore_imports_alerting = "error"
+
+
+[[tool.importlinter.contracts]]
+
+# The whole point of shipping hsql as a second console script rather than a flag
+# on `harlequin` is that this becomes a rule CI can check, instead of a
+# discipline every contributor has to remember.
+name = "hsql does not reach the TUI"
+type = "forbidden"
+source_modules = ["harlequin.hsql"]
+forbidden_modules = [
+    "questionary",
+    "sqlfmt",
+    "textual",
+    "textual_textarea",
+    "harlequin.app",
+    "harlequin.cli",
+    "harlequin.colors",
+    "harlequin.components",
+    "harlequin.config_wizard",
+    "harlequin.copy_widgets",
+    "harlequin.keys_app",
+    "harlequin.messages",
+]
+# deferred into pretty_print_warning(), which nothing here calls; the run-time
+# test in tests/unit_tests/test_import_hygiene.py is what proves it defers.
+# the same deliberate deferrals the adapter-API contract lists, each with a
+# comment at its import site. tests/unit_tests/test_import_hygiene.py is what
+# proves they defer; a *new* route to Textual fails this contract instead.
+ignore_imports = [
+    "harlequin.exception -> harlequin.colors",       # pretty_print_warning()
+    "harlequin.options -> harlequin.copy_widgets",   # to_widgets()
+    "harlequin.options -> harlequin.colors",         # to_questionary()
+    "harlequin.options -> questionary",              # to_questionary()
+]
 unmatched_ignore_imports_alerting = "error"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,10 @@ unmatched_ignore_imports_alerting = "error"
 name = "hsql does not reach the TUI"
 type = "forbidden"
 source_modules = ["harlequin.hsql"]
+# `locale_manager` is not a TUI module, but it is the one trap on this path:
+# the IDE calls set_locale() so a human sees grouped digits, and output that
+# varied with LC_ALL is output a caller cannot predict. hsql casts through
+# duckdb instead, and must never reach the other thing.
 forbidden_modules = [
     "questionary",
     "sqlfmt",
@@ -324,6 +328,7 @@ forbidden_modules = [
     "harlequin.config_wizard",
     "harlequin.copy_widgets",
     "harlequin.keys_app",
+    "harlequin.locale_manager",
     "harlequin.messages",
 ]
 # deferred into pretty_print_warning(), which nothing here calls; the run-time

--- a/scripts/cold_start.py
+++ b/scripts/cold_start.py
@@ -40,6 +40,7 @@ STEPS: list[tuple[str, str]] = [
     ("harlequin.query", "import harlequin.query"),
     ("harlequin.layout", "import harlequin.layout"),
     ("harlequin.export", "import harlequin.export"),
+    ("harlequin.hsql.cli", "import harlequin.hsql.cli"),
     ("harlequin_sqlite", "import harlequin_sqlite"),
     ("harlequin_duckdb", "import harlequin_duckdb"),
     ("harlequin.cli", "import harlequin.cli"),

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -12,7 +12,11 @@ from harlequin import Harlequin
 from harlequin.adapter import HarlequinAdapter
 from harlequin.catalog_cache import get_connection_hash
 from harlequin.colors import GREEN, PINK, PURPLE, VALID_THEMES, YELLOW
-from harlequin.config import get_config_for_profile, merge_profile_with_cli
+from harlequin.config import (
+    DEFAULT_ADAPTER,
+    get_config_for_profile,
+    merge_profile_with_cli,
+)
 from harlequin.config_wizard import wizard
 from harlequin.exception import (
     HarlequinConfigError,
@@ -27,7 +31,6 @@ from harlequin.plugins import load_adapter_plugins
 from harlequin.windows_timezone import check_and_install_tzdata
 
 # configure defaults
-DEFAULT_ADAPTER = "duckdb"
 DEFAULT_LIMIT = 100_000
 DEFAULT_THEME = "harlequin"
 ALL_THEMES = ", ".join(VALID_THEMES.keys())

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -11,6 +11,26 @@ from tomlkit.toml_file import TOMLFile
 from harlequin.exception import HarlequinConfigError
 from harlequin.keymap import HarlequinKeyMap, RawKeyBinding
 
+DEFAULT_ADAPTER = "duckdb"
+"""The adapter both commands connect with when nothing names one."""
+
+TUI_ONLY_KEYS = (
+    "theme",
+    "keymap_name",
+    "show_files",
+    "show_s3",
+    "locale",
+    "no_download_tzdata",
+)
+"""Profile keys the IDE reads and a headless caller must drop.
+
+One profile serves both commands, so a profile written for the IDE has to work
+headless -- these are dropped rather than handed to an adapter as options it
+never declared. `locale` in particular is one a headless caller must ignore:
+the IDE sets it to group digits for a human, and output that varied with
+`LC_ALL` would be output a caller could not predict.
+"""
+
 
 class Profile(TypedDict, total=False):
     conn_str: Sequence[str] | str

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -1,4 +1,13 @@
-from rich.panel import Panel
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.panel import Panel
+
+# Every headless path imports this module -- `harlequin.config` does, so a
+# console script pays for it before it has parsed a flag -- and rich is 20ms
+# that only the two functions at the bottom actually need.
 
 
 class HarlequinExit(Exception):
@@ -56,7 +65,9 @@ def pretty_print_error(error: HarlequinError) -> None:
     Console(stderr=True).print(pretty_error_message(error))
 
 
-def pretty_error_message(error: HarlequinError) -> Panel:
+def pretty_error_message(error: HarlequinError) -> "Panel":
+    from rich.panel import Panel
+
     return Panel.fit(
         str(error),
         title=error.title if error.title else ("Harlequin encountered an error."),
@@ -67,6 +78,7 @@ def pretty_error_message(error: HarlequinError) -> Panel:
 
 def pretty_print_warning(title: str, message: str) -> None:
     from rich.console import Console
+    from rich.panel import Panel
 
     from harlequin.colors import GREEN
 

--- a/src/harlequin/hsql/__init__.py
+++ b/src/harlequin/hsql/__init__.py
@@ -1,0 +1,33 @@
+"""hsql -- Harlequin, headless.
+
+The same adapters, config files, profiles and execution core as the IDE, with
+no Textual anywhere in the import graph. It is a second console script rather
+than a flag on `harlequin`, so that the IDE stays free to evolve while this
+side's output format and exit codes are an API.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from harlequin.hsql.diagnostics import ExitCode
+
+__all__ = ["main"]
+
+
+def main() -> None:
+    """The `hsql` console script."""
+    import click
+
+    from harlequin.hsql.cli import PROGRAM, build_cli
+
+    try:
+        code = build_cli().main(prog_name=PROGRAM, standalone_mode=False)
+    except click.ClickException as e:
+        # parse-level failures -- an unknown option, a bad choice. click already
+        # exits 2 for those, which is the code hsql documents for usage errors.
+        e.show()
+        sys.exit(e.exit_code)
+    except (click.Abort, KeyboardInterrupt):
+        sys.exit(ExitCode.INTERRUPT)
+    sys.exit(code if isinstance(code, int) else ExitCode.OK)

--- a/src/harlequin/hsql/__init__.py
+++ b/src/harlequin/hsql/__init__.py
@@ -21,8 +21,11 @@ def main() -> None:
 
     from harlequin.hsql.cli import PROGRAM, build_cli
 
+    argv = sys.argv[1:]
     try:
-        code = build_cli().main(prog_name=PROGRAM, standalone_mode=False)
+        # the same arguments to both: which adapter's options the command
+        # carries is decided from them, and then click parses them.
+        code = build_cli(argv).main(args=argv, prog_name=PROGRAM, standalone_mode=False)
     except click.ClickException as e:
         # parse-level failures -- an unknown option, a bad choice. click already
         # exits 2 for those, which is the code hsql documents for usage errors.

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -1,0 +1,741 @@
+"""The `hsql` command: run SQL against any Harlequin adapter, and exit.
+
+Two-phase parsing is what keeps start-up cheap. The first pass reads `-a`, `-P`
+and `--config-path` well enough to name the one adapter an invocation will use,
+without importing any of them; the second builds the real command with that
+adapter's connection options on it. An invocation only ever uses one adapter,
+so for execution this is not a compromise.
+
+`--help` is the exception, and works the other way round: with no adapter named
+it renders the adapter-agnostic surface plus the *names* of what is installed,
+importing nothing at all. `hsql --help -a postgres` imports postgres alone.
+That keeps the first thing a caller reads small and stable, and keeps it true
+for every adapter rather than for whichever one is the default.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, BinaryIO, Iterator, Mapping, Sequence
+
+import click
+
+from harlequin.config import get_config_for_profile, merge_profile_with_cli
+from harlequin.exception import (
+    HarlequinConfigError,
+    HarlequinConnectionError,
+    HarlequinError,
+)
+from harlequin.hsql import diagnostics, output
+from harlequin.hsql.diagnostics import ExitCode
+from harlequin.plugins import adapter_names, load_adapter
+
+if TYPE_CHECKING:
+    from harlequin.adapter import HarlequinAdapter, HarlequinConnection
+    from harlequin.layout import LayoutOptions
+    from harlequin.query import ExecutedStatement, OnError, RowLimit
+    from harlequin.statements import Statement
+
+PROGRAM = "hsql"
+
+# Repeated from harlequin.cli rather than imported: that module builds the IDE's
+# command and reaches the app, the config wizard and the keymap editor with it.
+DEFAULT_ADAPTER = "duckdb"
+
+DEFAULT_FORMAT = "table"
+
+DEFAULT_LIMIT = 500
+"""Small on purpose. The IDE's 100,000 is right for a viewport and wrong here.
+
+`hsql -l` is also the *hard* limit -- `cursor.set_limit()`, so fewer rows leave
+the database -- where the IDE's is a soft cap over a full fetch. Same spelling,
+different promise, and the docs say so.
+"""
+
+SHORTHANDS = {
+    "csv": "csv",
+    "json": "json",
+    "jsonl": "jsonl",
+    "markdown": "markdown",
+    "vertical": "vertical",
+}
+"""`--csv` and friends, as flags, spelling the `-F` they stand for."""
+
+TUI_ONLY_KEYS = (
+    "theme",
+    "keymap_name",
+    "show_files",
+    "show_s3",
+    "locale",
+    "no_download_tzdata",
+)
+"""Profile keys that belong to the IDE.
+
+A profile is shared between the two commands, so a profile written for the IDE
+has to work here -- these are dropped rather than handed to the adapter as
+options it never declared. `locale` in particular is one hsql must ignore: the
+IDE sets it to group digits for a human, and output that varied with `LC_ALL`
+would be output a caller could not predict.
+"""
+
+SOURCES = f"{__name__}.sources"
+"""Context key under which `-c` and `-f` record themselves, in order."""
+
+
+def build_cli(args: Sequence[str] | None = None) -> click.Command:
+    """Build the hsql command, importing at most one adapter to do it."""
+    argv = list(args) if args is not None else sys.argv[1:]
+    adapter_name, wants_help = _preflight(argv)
+    installed = adapter_names()
+
+    adapter_cls: type[HarlequinAdapter] | None = None
+    adapter_error: HarlequinConfigError | None = None
+    if adapter_name is not None:
+        try:
+            adapter_cls = load_adapter(adapter_name)
+        except HarlequinConfigError as e:
+            adapter_error = e
+
+    @click.command(
+        name=PROGRAM,
+        no_args_is_help=True,
+        epilog=_epilog(installed, adapter_name),
+    )
+    @click.version_option(package_name="harlequin", prog_name=PROGRAM)
+    @click.argument("conn_str", nargs=-1)
+    @click.option(
+        "-c",
+        "--command",
+        multiple=True,
+        callback=_record_source,
+        help="Execute SQL. Repeatable.",
+    )
+    @click.option(
+        "-f",
+        "--file",
+        multiple=True,
+        callback=_record_source,
+        metavar="PATH",
+        help="Execute SQL from a file, or from stdin for `-`. Repeatable.",
+    )
+    @click.option(
+        "-o",
+        "--output",
+        type=click.Path(dir_okay=False, path_type=Path),
+        metavar="PATH",
+        help="Write results to PATH instead of stdout.",
+    )
+    @click.option(
+        "-F",
+        "--format",
+        default=DEFAULT_FORMAT,
+        show_default=True,
+        metavar="NAME",
+        type=click.Choice(output.format_names(), case_sensitive=False),
+        help="Output format. See below for the list.",
+    )
+    @click.option("--csv", is_flag=True, help="Shorthand for -F csv.")
+    @click.option("--json", is_flag=True, help="Shorthand for -F json.")
+    @click.option("--jsonl", is_flag=True, help="Shorthand for -F jsonl.")
+    @click.option("--markdown", is_flag=True, help="Shorthand for -F markdown.")
+    @click.option("--vertical", is_flag=True, help="Shorthand for -F vertical.")
+    @click.option(
+        "-t",
+        "--tuples-only",
+        is_flag=True,
+        help="Rows only: no header, no footer. As in psql.",
+    )
+    @click.option(
+        "-A", "--no-align", is_flag=True, help="Unaligned output. As in psql."
+    )
+    @click.option(
+        "--no-header", is_flag=True, help="Omit the header row, keeping other chrome."
+    )
+    @click.option(
+        "--null-string",
+        metavar="TEXT",
+        help="Render NULL as TEXT. Defaults to NULL for text formats, empty for csv.",
+    )
+    @click.option(
+        "-P",
+        "--profile",
+        help=(
+            "Load a profile from an available config file. Options passed here take "
+            "precedence over the profile's. Use the profile named None for "
+            "Harlequin's defaults instead of the config file's default profile."
+        ),
+    )
+    @click.option(
+        "-a",
+        "--adapter",
+        default=DEFAULT_ADAPTER,
+        show_default=True,
+        metavar="NAME",
+        type=click.Choice(installed, case_sensitive=False),
+        help="The installed adapter plug-in to connect with.",
+    )
+    @click.option(
+        "--config-path",
+        type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=Path),
+        envvar="HARLEQUIN_CONFIG_PATH",
+        show_envvar=True,
+        metavar="PATH",
+        help="Read this config file instead of the ones hsql discovers.",
+    )
+    @click.option(
+        "-l",
+        "--limit",
+        default=DEFAULT_LIMIT,
+        show_default=True,
+        metavar="N",
+        type=click.IntRange(min=0),
+        help="Maximum rows per result set. 0 for no limit.",
+    )
+    @click.option(
+        "--result",
+        default="all",
+        show_default=True,
+        metavar="all|last|N",
+        help="Which result set(s) to emit.",
+    )
+    @click.option(
+        "--on-error",
+        default="stop",
+        show_default=True,
+        type=click.Choice(["stop", "continue"]),
+        help="What to do when a statement fails.",
+    )
+    @click.option(
+        "--stats", is_flag=True, help="Write a one-line JSON summary to stderr."
+    )
+    @click.option(
+        "--color",
+        default="never",
+        show_default=True,
+        type=click.Choice(["auto", "always", "never"]),
+        help="Color text output. `auto` follows the terminal and NO_COLOR.",
+    )
+    @click.pass_context
+    def inner_cli(
+        ctx: click.Context,
+        profile: str | None,
+        config_path: Path | None,
+        **kwargs: Any,
+    ) -> None:
+        """Execute SQL and exit.
+
+        CONN_STR: one or more connection strings, or paths to local db files.
+        """
+        if adapter_error is not None:
+            diagnostics.report_error(adapter_error)
+            ctx.exit(ExitCode.USAGE)
+
+        try:
+            config, _ = get_config_for_profile(
+                config_path=config_path, profile_name=profile
+            )
+        except HarlequinConfigError as e:
+            diagnostics.report_error(e)
+            ctx.exit(ExitCode.USAGE)
+
+        explicitly_set = {
+            k
+            for k in kwargs
+            if ctx.get_parameter_source(k) != click.core.ParameterSource.DEFAULT
+        }
+        values: dict[str, Any] = dict(
+            merge_profile_with_cli(
+                profile=config, cli_values=kwargs, explicitly_set=explicitly_set
+            )
+        )
+        for key in TUI_ONLY_KEYS:
+            values.pop(key, None)
+
+        # every key hsql owns comes off here; whatever is left is the adapter's
+        conn_str: Sequence[str] | str = values.pop("conn_str", tuple())
+        if isinstance(conn_str, str):
+            conn_str = (conn_str,)
+        adapter: str = values.pop("adapter", DEFAULT_ADAPTER)
+        destination: Path | None = values.pop("output", None)
+        result_spec: str = str(values.pop("result", "all"))
+        raw_on_error = str(values.pop("on_error", "stop"))
+        if raw_on_error not in ("stop", "continue"):
+            # click's Choice already vetted the flag; a profile can say anything
+            diagnostics.error(f"on_error takes stop or continue, not {raw_on_error}.")
+            ctx.exit(ExitCode.USAGE)
+        on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
+        stats: bool = bool(values.pop("stats", False))
+        tuples_only: bool = bool(values.pop("tuples_only", False))
+        no_align: bool = bool(values.pop("no_align", False))
+        no_header: bool = bool(values.pop("no_header", False))
+        null_string: str | None = values.pop("null_string", None)
+        color_when: str = str(values.pop("color", "never"))
+        try:
+            limit = int(values.pop("limit", DEFAULT_LIMIT))
+        except (TypeError, ValueError):
+            diagnostics.error("--limit must be a whole number of rows, or 0.")
+            ctx.exit(ExitCode.USAGE)
+
+        format_name = _resolve_format(values, explicitly_set)
+        if format_name is None:
+            ctx.exit(ExitCode.USAGE)
+
+        sources: list[tuple[str, tuple[str, ...]]] = ctx.meta.get(SOURCES, [])
+        if not sources:
+            diagnostics.error(
+                "no SQL to run. Pass -c/--command or -f/--file, "
+                f"or see '{PROGRAM} --help'."
+            )
+            ctx.exit(ExitCode.USAGE)
+
+        try:
+            statements = _read_statements(sources)
+        except OSError as e:
+            diagnostics.error(f"could not read {e.filename}: {e.strerror}")
+            ctx.exit(ExitCode.USAGE)
+
+        from harlequin.query import RowLimit
+
+        row_limit = RowLimit(
+            max_rows=limit or None,
+            # one row more than we intend to keep is the only way to know a
+            # result was cut short: set_limit(n) then fetchall() returns at most
+            # n rows and says nothing about an n+1th.
+            detect_overflow=bool(limit),
+        )
+
+        try:
+            adapter_instance = load_adapter(adapter)(conn_str=conn_str, **values)
+        except HarlequinConfigError as e:
+            diagnostics.report_error(e)
+            ctx.exit(ExitCode.USAGE)
+
+        connection: HarlequinConnection
+        try:
+            connection = adapter_instance.connect()
+        except HarlequinConnectionError as e:
+            diagnostics.report_error(e)
+            ctx.exit(ExitCode.CONNECTION)
+
+        run_started = time.monotonic()
+        run = _Run()
+        executed = _execute_all(
+            connection, statements, limit=row_limit, on_error=on_error, run=run
+        )
+
+        selected = _select_results(executed, result_spec)
+        if selected is None:
+            ctx.exit(ExitCode.USAGE)
+        if len(selected) > 1 and not output.holds_many(format_name):
+            n = len(selected)
+            diagnostics.error(
+                f"{n} result sets, but {format_name} holds one; "
+                f"use --result last or --result {n}"
+            )
+            ctx.exit(ExitCode.USAGE)
+
+        layout_options, file_options = _output_options(
+            tuples_only=tuples_only,
+            no_align=no_align,
+            no_header=no_header,
+            null_string=null_string,
+            color=_use_color(color_when, destination),
+            format_name=format_name,
+        )
+
+        try:
+            with _sink(destination) as out:
+                _emit(
+                    selected,
+                    out,
+                    limit=row_limit,
+                    format_name=format_name,
+                    layout_options=layout_options,
+                    file_options=file_options,
+                    on_error=on_error,
+                    run=run,
+                )
+        except OSError as e:
+            diagnostics.report_error(e)
+            ctx.exit(ExitCode.USAGE)
+
+        if stats:
+            diagnostics.report_stats(
+                status="error" if run.failure is not None else "ok",
+                statements=run.statements,
+                rows=run.rows,
+                truncated=run.truncated,
+                limit=row_limit.max_rows,
+                elapsed_ms=round((time.monotonic() - run_started) * 1000),
+                columns=run.columns,
+                message=_message_for(run.failure),
+            )
+
+        ctx.exit(
+            ExitCode.OK
+            if run.failure is None
+            else diagnostics.exit_code_for(run.failure)
+        )
+
+    cmd: click.Command = inner_cli
+    if adapter_cls is not None:
+        reserved = {opt for param in cmd.params for opt in param.opts}
+        taken = {param.name for param in cmd.params if param.name is not None}
+        cmd.params.extend(_adapter_params(adapter_cls, reserved, taken))
+    return cmd
+
+
+@dataclass
+class _Run:
+    """What one invocation did, accumulated as it does it."""
+
+    statements: int = 0
+    """How many statements the database was asked to run."""
+
+    rows: int = 0
+    truncated: bool = False
+    columns: list[tuple[str, str]] = field(default_factory=list)
+    """The last emitted result set's columns, for `--stats`."""
+
+    failure: BaseException | None = None
+    """The last thing that went wrong, and so the code hsql exits with."""
+
+
+def _execute_all(
+    connection: HarlequinConnection,
+    statements: Sequence[Statement],
+    *,
+    limit: RowLimit,
+    on_error: OnError,
+    run: _Run,
+) -> list[tuple[ExecutedStatement, float]]:
+    """Run every statement, keeping the ones that produced a result set.
+
+    Execute-then-fetch, in two passes, as the IDE does it: nothing is fetched
+    until the whole script has been submitted, so `--result last` can decline
+    to pay for the rest.
+    """
+    from harlequin.query import execute
+
+    executed: list[tuple[ExecutedStatement, float]] = []
+    started = time.monotonic()
+    for item in execute(connection, statements, limit=limit, on_error=on_error):
+        elapsed = time.monotonic() - started
+        run.statements += 1
+        if item.error is not None:
+            run.failure = item.error
+            diagnostics.report_error(item.error)
+        elif item.has_result_set:
+            executed.append((item, elapsed))
+        started = time.monotonic()
+    return executed
+
+
+def _emit(
+    selected: Sequence[tuple[ExecutedStatement, float]],
+    out: BinaryIO,
+    *,
+    limit: RowLimit,
+    format_name: str,
+    layout_options: LayoutOptions,
+    file_options: Mapping[str, Any],
+    on_error: OnError,
+    run: _Run,
+) -> None:
+    """Fetch each selected result set and write it out."""
+    from harlequin.query import fetch
+
+    for item, exec_elapsed in selected:
+        try:
+            result = fetch(item, limit=limit)
+        except Exception as e:  # noqa: BLE001 -- adapters are third-party code
+            run.failure = e
+            diagnostics.report_error(e)
+            if on_error == "stop":
+                break
+            continue
+        output.write(
+            result,
+            format_name,
+            out,
+            layout_options=layout_options,
+            file_options=file_options,
+        )
+        run.rows += result.row_count
+        run.truncated = run.truncated or result.truncated
+        run.columns = result.columns
+        if result.truncated and limit.max_rows is not None:
+            diagnostics.report_truncation(limit.max_rows)
+        diagnostics.report_row_count(
+            result.row_count, exec_elapsed + result.elapsed, result.truncated
+        )
+    out.flush()
+
+
+def _preflight(args: Sequence[str]) -> tuple[str | None, bool]:
+    """Name the adapter an invocation will use, importing none of them.
+
+    Best-effort by design: a config file it cannot read is not reported here,
+    because the real parse is about to read the same file and has somewhere to
+    report it. All this decides is whose connection options get attached.
+    """
+    wants_help = not args or "--help" in args
+
+    probe = click.Command(
+        PROGRAM,
+        params=[
+            click.Option(["-a", "--adapter"]),
+            click.Option(["-P", "--profile"]),
+            click.Option(
+                ["--config-path"],
+                type=click.Path(path_type=Path),
+                envvar="HARLEQUIN_CONFIG_PATH",
+            ),
+        ],
+        add_help_option=False,
+    )
+    # on the Context, not in the command's context_settings: those are applied
+    # by make_context(), which this deliberately does not go through.
+    ctx = click.Context(
+        probe,
+        resilient_parsing=True,
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+        allow_interspersed_args=True,
+    )
+    with contextlib.suppress(click.ClickException, ValueError):
+        probe.parse_args(ctx, list(args))
+
+    name: str | None = ctx.params.get("adapter")
+    if name is None:
+        with contextlib.suppress(HarlequinConfigError, OSError):
+            found, _ = get_config_for_profile(
+                config_path=ctx.params.get("config_path"),
+                profile_name=ctx.params.get("profile"),
+            )
+            name = found.get("adapter")
+
+    installed = {n.lower(): n for n in adapter_names()}
+    if name is not None:
+        # an unknown name is left for click's Choice to reject, with the list
+        return installed.get(str(name).lower()), wants_help
+    if wants_help:
+        return None, wants_help
+    return installed.get(DEFAULT_ADAPTER), wants_help
+
+
+def _adapter_params(
+    adapter_cls: type[HarlequinAdapter], reserved: set[str], taken: set[str]
+) -> list[click.Parameter]:
+    """One adapter's connection options, as click parameters.
+
+    hsql's own flags are the part of it that is an API, so a declaration that
+    collides with one loses the colliding spelling -- visibly, in
+    `hsql --help -a <adapter>` -- rather than shadowing it.
+    """
+
+    def _stub() -> None: ...
+
+    decorated: Any = _stub
+    for option in adapter_cls.ADAPTER_OPTIONS or []:
+        decorated = option.to_click()(decorated)
+
+    params: list[click.Parameter] = []
+    for param in reversed(getattr(decorated, "__click_params__", [])):
+        param.opts = [opt for opt in param.opts if opt not in reserved]
+        param.secondary_opts = [
+            opt for opt in param.secondary_opts if opt not in reserved
+        ]
+        if param.opts and param.name not in taken:
+            params.append(param)
+    return params
+
+
+def _record_source(
+    ctx: click.Context, param: click.Parameter, value: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Keep `-c` and `-f` in the order they were typed.
+
+    click hands a repeatable option all of its values at once, and processes
+    the two options in the order they first appear -- which is what
+    `-f setup.sql -c 'select ...'` depends on.
+    """
+    if value:
+        ctx.meta.setdefault(SOURCES, []).append((param.name, value))
+    return value
+
+
+def _read_statements(
+    sources: Sequence[tuple[str, tuple[str, ...]]],
+) -> list[Statement]:
+    """Every statement the invocation asked for, in order.
+
+    Each source is split on its own, so two `-c` values are two statements
+    whether or not either ends in a semicolon.
+    """
+    from harlequin.statements import Statement, split
+
+    statements: list[Statement] = []
+    for kind, values in sources:
+        for value in values:
+            if kind == "command":
+                text = value
+            elif value == "-":
+                text = click.get_text_stream("stdin").read()
+            else:
+                text = Path(value).expanduser().read_text(encoding="utf-8")
+            for statement in split(text):
+                statements.append(Statement(sql=statement.sql, index=len(statements)))
+    return statements
+
+
+def _resolve_format(values: dict[str, Any], explicitly_set: set[str]) -> str | None:
+    """The one format this invocation writes, or None having said why not."""
+    chosen = [name for flag, name in SHORTHANDS.items() if values.pop(flag, False)]
+    named: str = str(values.pop("format", DEFAULT_FORMAT))
+
+    if len(chosen) > 1:
+        diagnostics.error(
+            "more than one output format: "
+            + ", ".join(f"--{flag}" for flag in sorted(chosen))
+        )
+        return None
+    if chosen and "format" in explicitly_set:
+        diagnostics.error(f"--{chosen[0]} and -F {named} are two output formats.")
+        return None
+    format_name = (chosen[0] if chosen else named).lower()
+    if format_name not in output.format_names():
+        diagnostics.error(
+            f"{format_name} is not an output format. "
+            f"Try one of: {', '.join(output.format_names())}."
+        )
+        return None
+    return format_name
+
+
+def _select_results(
+    executed: Sequence[tuple[ExecutedStatement, float]], spec: str
+) -> list[tuple[ExecutedStatement, float]] | None:
+    """The result sets `--result` asked for, or None having said why not."""
+    if spec == "all":
+        return list(executed)
+    if spec == "last":
+        return list(executed[-1:])
+    try:
+        index = int(spec)
+    except ValueError:
+        diagnostics.error(f"--result takes all, last or a number, not {spec}.")
+        return None
+    if not 1 <= index <= len(executed):
+        diagnostics.error(
+            f"--result {index}, but this run produced {len(executed)} result sets."
+        )
+        return None
+    return [executed[index - 1]]
+
+
+def _output_options(
+    *,
+    tuples_only: bool,
+    no_align: bool,
+    no_header: bool,
+    null_string: str | None,
+    color: bool,
+    format_name: str,
+) -> tuple[LayoutOptions, dict[str, Any]]:
+    """psql's flag algebra, in the vocabulary each family of format speaks.
+
+    `-t` is two independent switches rather than a mode, which is why `-tA`
+    needs no special case: it never was one.
+    """
+    from harlequin.layout import LayoutOptions
+
+    header = not (tuples_only or no_header)
+    layout_options = LayoutOptions(
+        header=header,
+        footer=not tuples_only,
+        aligned=not no_align,
+        null_string=null_string,
+        color=color,
+    )
+    file_options: dict[str, Any] = {}
+    if format_name in ("csv", "tsv"):
+        # the only writers with a header or a null of their own to set
+        file_options["header"] = header
+        if null_string is not None:
+            file_options["na_rep"] = null_string
+    return layout_options, file_options
+
+
+def _use_color(when: str, destination: Path | None) -> bool:
+    """Whether to style text output.
+
+    The default is `never`, so the bytes do not depend on what stdout happens
+    to be. `auto` opts into that dependence, and honors NO_COLOR; `always` is
+    the caller saying they meant it. A file never gets escapes either way.
+    """
+    if destination is not None or when == "never":
+        return False
+    if when == "always":
+        return True
+    return sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+
+@contextlib.contextmanager
+def _sink(destination: Path | None) -> Iterator[BinaryIO]:
+    """Where result sets go: a path, or stdout.
+
+    Binary in both cases. duckdb writes `\\n` and the layouts write `\\n`, and
+    text-mode translation would turn that into `\\r\\n` on Windows for the same
+    query that produced `\\n` everywhere else.
+    """
+    if destination is None:
+        yield click.get_binary_stream("stdout")
+    else:
+        with destination.expanduser().open("wb") as f:
+            yield f
+
+
+def _message_for(failure: BaseException | None) -> str | None:
+    if failure is None:
+        return None
+    return (
+        failure.msg if isinstance(failure, HarlequinError) else str(failure)
+    ) or type(failure).__name__
+
+
+def _epilog(installed: Sequence[str], adapter: str | None) -> str:
+    """The reference an agent reads once instead of guessing at twice.
+
+    Adapter *names* rather than their options: the list stays one line longer
+    per installed adapter instead of one option table longer, and it is true
+    for all of them rather than for whichever is the default.
+    """
+    formats = ", ".join(output.format_names())
+    names = ", ".join(installed) if installed else "(none installed)"
+    if adapter is None:
+        adapters = (
+            f"Installed adapters: {names}\n"
+            f"Run '{PROGRAM} --help -a <adapter>' for one adapter's "
+            "connection options."
+        )
+    else:
+        adapters = (
+            f"Installed adapters: {names}\nShowing {adapter}'s connection options."
+        )
+    blocks = [
+        f"Formats:\n  {formats}",
+        (
+            "Exit codes:\n"
+            "  0 success           1 query error       2 usage/config error\n"
+            "  3 connection error  4 timeout           130 interrupted"
+        ),
+        adapters,
+    ]
+    # a lone \b tells click not to rewrap the paragraph that follows it
+    return "\n\n".join(f"\b\n{block}" for block in blocks)

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -25,7 +25,13 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Iterator, Mapping, Sequence
 
 import click
 
-from harlequin.config import get_config_for_profile, merge_profile_with_cli
+from harlequin.config import (
+    DEFAULT_ADAPTER,
+    TUI_ONLY_KEYS,
+    Profile,
+    get_config_for_profile,
+    merge_profile_with_cli,
+)
 from harlequin.exception import (
     HarlequinConfigError,
     HarlequinConnectionError,
@@ -42,10 +48,6 @@ if TYPE_CHECKING:
     from harlequin.statements import Statement
 
 PROGRAM = "hsql"
-
-# Repeated from harlequin.cli rather than imported: that module builds the IDE's
-# command and reaches the app, the config wizard and the keymap editor with it.
-DEFAULT_ADAPTER = "duckdb"
 
 DEFAULT_FORMAT = "table"
 
@@ -66,45 +68,32 @@ SHORTHANDS = {
 }
 """`--csv` and friends, as flags, spelling the `-F` they stand for."""
 
-TUI_ONLY_KEYS = (
-    "theme",
-    "keymap_name",
-    "show_files",
-    "show_s3",
-    "locale",
-    "no_download_tzdata",
-)
-"""Profile keys that belong to the IDE.
-
-A profile is shared between the two commands, so a profile written for the IDE
-has to work here -- these are dropped rather than handed to the adapter as
-options it never declared. `locale` in particular is one hsql must ignore: the
-IDE sets it to group digits for a human, and output that varied with `LC_ALL`
-would be output a caller could not predict.
-"""
-
 SOURCES = f"{__name__}.sources"
 """Context key under which `-c` and `-f` record themselves, in order."""
 
 
-def build_cli(args: Sequence[str] | None = None) -> click.Command:
-    """Build the hsql command, importing at most one adapter to do it."""
-    argv = list(args) if args is not None else sys.argv[1:]
-    adapter_name, wants_help = _preflight(argv)
+def build_cli(argv: Sequence[str]) -> click.Command:
+    """Build the hsql command, importing at most one adapter to do it.
+
+    Takes the same arguments click is about to parse, because which adapter's
+    connection options belong on the command is a question only the arguments
+    can answer.
+    """
     installed = adapter_names()
+    found = _preflight(argv, installed)
 
     adapter_cls: type[HarlequinAdapter] | None = None
-    adapter_error: HarlequinConfigError | None = None
-    if adapter_name is not None:
+    setup_error: HarlequinConfigError | None = found.error
+    if found.adapter is not None and setup_error is None:
         try:
-            adapter_cls = load_adapter(adapter_name)
+            adapter_cls = load_adapter(found.adapter)
         except HarlequinConfigError as e:
-            adapter_error = e
+            setup_error = e
 
     @click.command(
         name=PROGRAM,
         no_args_is_help=True,
-        epilog=_epilog(installed, adapter_name),
+        epilog=_epilog(installed, found.adapter),
     )
     @click.version_option(package_name="harlequin", prog_name=PROGRAM)
     @click.argument("conn_str", nargs=-1)
@@ -223,25 +212,24 @@ def build_cli(args: Sequence[str] | None = None) -> click.Command:
     @click.pass_context
     def inner_cli(
         ctx: click.Context,
-        profile: str | None,
-        config_path: Path | None,
+        profile: str | None,  # noqa: ARG001 -- read in _preflight; see below
+        config_path: Path | None,  # noqa: ARG001
         **kwargs: Any,
     ) -> None:
         """Execute SQL and exit.
 
         CONN_STR: one or more connection strings, or paths to local db files.
         """
-        if adapter_error is not None:
-            diagnostics.report_error(adapter_error)
+        # `profile` and `config_path` are named rather than left in `kwargs` so
+        # that they stay out of the merge, and so out of the options handed to
+        # the adapter. `_preflight` has already read them off the same argv.
+        # the profile was already read, and the adapter already loaded, to
+        # decide which connection options this command carries. Whatever went
+        # wrong doing that is reported here, where there is an exit code.
+        if setup_error is not None:
+            diagnostics.report_error(setup_error)
             ctx.exit(ExitCode.USAGE)
-
-        try:
-            config, _ = get_config_for_profile(
-                config_path=config_path, profile_name=profile
-            )
-        except HarlequinConfigError as e:
-            diagnostics.report_error(e)
-            ctx.exit(ExitCode.USAGE)
+        config = found.profile
 
         explicitly_set = {
             k
@@ -322,7 +310,6 @@ def build_cli(args: Sequence[str] | None = None) -> click.Command:
             diagnostics.report_error(e)
             ctx.exit(ExitCode.CONNECTION)
 
-        run_started = time.monotonic()
         run = _Run()
         executed = _execute_all(
             connection, statements, limit=row_limit, on_error=on_error, run=run
@@ -366,33 +353,31 @@ def build_cli(args: Sequence[str] | None = None) -> click.Command:
 
         if stats:
             diagnostics.report_stats(
-                status="error" if run.failure is not None else "ok",
+                status=run.status,
                 statements=run.statements,
                 rows=run.rows,
                 truncated=run.truncated,
                 limit=row_limit.max_rows,
-                elapsed_ms=round((time.monotonic() - run_started) * 1000),
+                elapsed_ms=run.elapsed_ms,
                 columns=run.columns,
                 message=_message_for(run.failure),
             )
 
-        ctx.exit(
-            ExitCode.OK
-            if run.failure is None
-            else diagnostics.exit_code_for(run.failure)
-        )
+        ctx.exit(run.exit_code)
 
     cmd: click.Command = inner_cli
     if adapter_cls is not None:
-        reserved = {opt for param in cmd.params for opt in param.opts}
-        taken = {param.name for param in cmd.params if param.name is not None}
-        cmd.params.extend(_adapter_params(adapter_cls, reserved, taken))
+        _attach_adapter_options(cmd, adapter_cls)
     return cmd
 
 
 @dataclass
 class _Run:
-    """What one invocation did, accumulated as it does it."""
+    """What one invocation did, accumulated as it does it.
+
+    Starts its own clock, so that "when did this run begin" cannot drift from
+    "what has it done so far" by someone moving one of the two.
+    """
 
     statements: int = 0
     """How many statements the database was asked to run."""
@@ -404,6 +389,22 @@ class _Run:
 
     failure: BaseException | None = None
     """The last thing that went wrong, and so the code hsql exits with."""
+
+    started: float = field(default_factory=time.monotonic)
+
+    @property
+    def elapsed_ms(self) -> int:
+        return round((time.monotonic() - self.started) * 1000)
+
+    @property
+    def status(self) -> str:
+        return "error" if self.failure is not None else "ok"
+
+    @property
+    def exit_code(self) -> ExitCode:
+        if self.failure is None:
+            return ExitCode.OK
+        return diagnostics.exit_code_for(self.failure)
 
 
 def _execute_all(
@@ -477,15 +478,32 @@ def _emit(
     out.flush()
 
 
-def _preflight(args: Sequence[str]) -> tuple[str | None, bool]:
-    """Name the adapter an invocation will use, importing none of them.
+@dataclass(frozen=True)
+class _Preflight:
+    """What a first look at the arguments settled, before click parses them."""
 
-    Best-effort by design: a config file it cannot read is not reported here,
-    because the real parse is about to read the same file and has somewhere to
-    report it. All this decides is whose connection options get attached.
+    profile: Profile
+    """The profile this invocation runs under, read once and reused."""
+
+    adapter: str | None
+    """Whose connection options belong on the command; None to attach none."""
+
+    error: HarlequinConfigError | None = None
+    """Held rather than raised, so the callback can report it with an exit code."""
+
+
+def _preflight(argv: Sequence[str], installed: Sequence[str]) -> _Preflight:
+    """Read the profile and name the adapter, importing none of them.
+
+    This is the first of the two passes: it learns just enough from the raw
+    arguments -- `-a`, `-P`, `--config-path` -- to decide whose connection
+    options the real command carries, without `ep.load()`ing every installed
+    adapter to find out.
+
+    A config file it cannot read is held, not raised: at this point there is no
+    command and so no exit code, and the profile is wanted whether or not it
+    names an adapter, so the callback reports it.
     """
-    wants_help = not args or "--help" in args
-
     probe = click.Command(
         PROGRAM,
         params=[
@@ -496,6 +514,9 @@ def _preflight(args: Sequence[str]) -> tuple[str | None, bool]:
                 type=click.Path(path_type=Path),
                 envvar="HARLEQUIN_CONFIG_PATH",
             ),
+            # click's own --help is eager and would exit; this is the same
+            # spelling as a plain flag, so the probe can see it was asked for.
+            click.Option(["--help"], is_flag=True),
         ],
         add_help_option=False,
     )
@@ -509,51 +530,63 @@ def _preflight(args: Sequence[str]) -> tuple[str | None, bool]:
         allow_interspersed_args=True,
     )
     with contextlib.suppress(click.ClickException, ValueError):
-        probe.parse_args(ctx, list(args))
+        probe.parse_args(ctx, list(argv))
 
-    name: str | None = ctx.params.get("adapter")
+    profile: Profile = {}
+    error: HarlequinConfigError | None = None
+    try:
+        profile, _ = get_config_for_profile(
+            config_path=ctx.params.get("config_path"),
+            profile_name=ctx.params.get("profile"),
+        )
+    except HarlequinConfigError as e:
+        error = e
+    except OSError as e:
+        error = HarlequinConfigError(str(e), title="Harlequin could not read a config.")
+
+    name = ctx.params.get("adapter") or profile.get("adapter")
+    # bare `hsql` and `hsql --help` render the adapter-agnostic surface, which
+    # is the one help that is true for every adapter -- and imports none.
+    wants_help = not argv or bool(ctx.params.get("help"))
+    if name is None and wants_help:
+        return _Preflight(profile=profile, adapter=None, error=error)
+
+    by_name = {n.lower(): n for n in installed}
     if name is None:
-        with contextlib.suppress(HarlequinConfigError, OSError):
-            found, _ = get_config_for_profile(
-                config_path=ctx.params.get("config_path"),
-                profile_name=ctx.params.get("profile"),
-            )
-            name = found.get("adapter")
-
-    installed = {n.lower(): n for n in adapter_names()}
-    if name is not None:
-        # an unknown name is left for click's Choice to reject, with the list
-        return installed.get(str(name).lower()), wants_help
-    if wants_help:
-        return None, wants_help
-    return installed.get(DEFAULT_ADAPTER), wants_help
+        name = DEFAULT_ADAPTER
+    # an unknown name is left for click's Choice to reject, with the list
+    return _Preflight(
+        profile=profile, adapter=by_name.get(str(name).lower()), error=error
+    )
 
 
-def _adapter_params(
-    adapter_cls: type[HarlequinAdapter], reserved: set[str], taken: set[str]
-) -> list[click.Parameter]:
-    """One adapter's connection options, as click parameters.
+def _attach_adapter_options(
+    cmd: click.Command, adapter_cls: type[HarlequinAdapter]
+) -> None:
+    """Add one adapter's connection options to an already-built command.
 
-    hsql's own flags are the part of it that is an API, so a declaration that
-    collides with one loses the colliding spelling -- visibly, in
-    `hsql --help -a <adapter>` -- rather than shadowing it.
+    `AbstractOption.to_click()` appends straight to a `Command`'s params, so the
+    adapter declares its options exactly as it does for the IDE and this only
+    has to settle what happens when one of them collides. hsql's own flags are
+    the part of it that is an API, so a colliding declaration loses the
+    colliding spelling -- visibly, in `hsql --help -a <adapter>` -- rather than
+    shadowing a documented flag.
     """
+    reserved = {opt for param in cmd.params for opt in param.opts}
+    taken = {param.name for param in cmd.params}
+    first = len(cmd.params)
 
-    def _stub() -> None: ...
-
-    decorated: Any = _stub
     for option in adapter_cls.ADAPTER_OPTIONS or []:
-        decorated = option.to_click()(decorated)
+        option.to_click()(cmd)
 
-    params: list[click.Parameter] = []
-    for param in reversed(getattr(decorated, "__click_params__", [])):
+    for param in cmd.params[first:]:
         param.opts = [opt for opt in param.opts if opt not in reserved]
         param.secondary_opts = [
             opt for opt in param.secondary_opts if opt not in reserved
         ]
-        if param.opts and param.name not in taken:
-            params.append(param)
-    return params
+    cmd.params[first:] = [
+        param for param in cmd.params[first:] if param.opts and param.name not in taken
+    ]
 
 
 def _record_source(
@@ -683,7 +716,7 @@ def _use_color(when: str, destination: Path | None) -> bool:
         return False
     if when == "always":
         return True
-    return sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+    return sys.stdout.isatty() and not os.getenv("NO_COLOR")
 
 
 @contextlib.contextmanager

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -1,0 +1,126 @@
+"""Everything hsql writes to stderr, and the code it exits with.
+
+stdout is data: result sets, and nothing else. Timings, row counts, truncation
+notices and errors go here, so `hsql -c ... --csv > out.csv` produces a clean
+file while the caller still sees what happened.
+
+Exit codes are hsql's contract rather than Harlequin's, which is why the
+mapping lives here and not in `harlequin.exception`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from enum import IntEnum
+from typing import Any, Sequence
+
+from harlequin.exception import (
+    HarlequinConfigError,
+    HarlequinConnectionError,
+    HarlequinError,
+)
+
+PROGRAM = "hsql"
+
+
+class ExitCode(IntEnum):
+    OK = 0
+    QUERY = 1
+    """The database rejected the SQL."""
+
+    USAGE = 2
+    """A bad flag, a bad profile, or a config file hsql could not read."""
+
+    CONNECTION = 3
+    TIMEOUT = 4
+    """Unused until `--timeout` lands; the number is reserved for it."""
+
+    INTERRUPT = 130
+
+
+def exit_code_for(error: BaseException) -> ExitCode:
+    """The code hsql exits with, having failed with `error`."""
+    if isinstance(error, KeyboardInterrupt):
+        return ExitCode.INTERRUPT
+    if isinstance(error, HarlequinConfigError):
+        return ExitCode.USAGE
+    if isinstance(error, HarlequinConnectionError):
+        return ExitCode.CONNECTION
+    return ExitCode.QUERY
+
+
+def error(message: str) -> None:
+    """One plain line, prefixed with the program name.
+
+    No panel, no ANSI, no box drawing: those are affordances of a full-screen
+    app, and here they would be something a caller has to parse around.
+    """
+    _write(f"{PROGRAM}: error: {message}")
+
+
+def report_error(exception: BaseException) -> None:
+    message = (
+        exception.msg if isinstance(exception, HarlequinError) else str(exception)
+    ) or type(exception).__name__
+    error(message)
+
+
+def note(message: str) -> None:
+    _write(f"note: {message}")
+
+
+def report_truncation(max_rows: int) -> None:
+    """Say that a result was cut short.
+
+    Fires even under `-t`, which suppresses stdout chrome and not warnings: a
+    flag that silently defeated this would undo the promise it exists beside.
+    """
+    note(f"results truncated at {max_rows} rows (--limit)")
+
+
+def report_row_count(rows: int, elapsed: float, truncated: bool) -> None:
+    """The line psql puts under a result, on the stream that isn't the data.
+
+    A truncated count reads `500 of 500+` because the true total is unknowable
+    under a hard fetch limit -- not paying for the rest is the point of it.
+    """
+    noun = "row" if rows == 1 else "rows"
+    count = f"{rows} of {rows}+ {noun}" if truncated else f"{rows} {noun}"
+    _write(f"{count} in {elapsed:.2f}s")
+
+
+def report_stats(
+    *,
+    status: str,
+    statements: int,
+    rows: int,
+    truncated: bool,
+    limit: int | None,
+    elapsed_ms: int,
+    columns: Sequence[tuple[str, str]],
+    message: str | None = None,
+) -> None:
+    """One line of JSON, whatever stdout is carrying.
+
+    This is how a caller gets structured metadata about a run without polluting
+    the data -- and it reads the same whether stdout held a csv or a parquet.
+    """
+    payload: dict[str, Any] = {
+        "status": status,
+        "statements": statements,
+        "rows": rows,
+        "truncated": truncated,
+        "limit": limit,
+        "elapsed_ms": elapsed_ms,
+        "columns": [{"name": name, "type": type_} for name, type_ in columns],
+    }
+    if message is not None:
+        payload["error"] = message
+    _write(json.dumps(payload, separators=(",", ":")))
+
+
+def _write(line: str) -> None:
+    # sys.stderr is resolved on each call, not bound at import: a test harness
+    # that swaps the stream out has to be able to see what was written.
+    print(line, file=sys.stderr)

--- a/src/harlequin/hsql/output.py
+++ b/src/harlequin/hsql/output.py
@@ -1,0 +1,63 @@
+"""Choosing what a result set is written as, and writing it.
+
+Two families of format, and the difference between them is who serializes.
+`harlequin.export` hands an Arrow table to duckdb or pyarrow; `harlequin.layout`
+arranges the strings `ResultSet.text_columns()` already produced. Neither is
+reimplemented here, and nothing here renders a value itself -- which is what
+makes `-F table` and `-F csv` agree cell for cell.
+
+Everything leaves through one binary stream, `-o PATH` included, so a file and
+a redirect cannot disagree about a byte. Text is encoded UTF-8 explicitly: the
+bytes are the contract, and a console's code page is not part of it.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, Any, BinaryIO, Mapping
+
+from harlequin.export import file_format_names, write_stream
+from harlequin.layout import get_layout, layout_names
+
+if TYPE_CHECKING:
+    from harlequin.layout import LayoutOptions
+    from harlequin.query import ResultSet
+
+NONE = "none"
+"""Discard the rows and report status only. For DDL, DML and ETL."""
+
+_HOLD_MANY = frozenset({*layout_names(), "jsonl", "ndjson", NONE})
+
+
+def format_names() -> list[str]:
+    """Every name `-F` accepts, aliases included, in the order help lists them."""
+    return [*layout_names(), *file_format_names(), NONE]
+
+
+def holds_many(format_name: str) -> bool:
+    """Whether a format can hold more than one result set.
+
+    Two headers in one csv is silent corruption of the same family as silent
+    truncation, so a format that cannot hold a second result set says so
+    instead. Newline-delimited json can: another result set is more lines.
+    """
+    return format_name in _HOLD_MANY
+
+
+def write(
+    result: "ResultSet",
+    format_name: str,
+    out: BinaryIO,
+    *,
+    layout_options: "LayoutOptions",
+    file_options: Mapping[str, Any],
+) -> None:
+    """Write one result set to an open binary stream."""
+    if format_name == NONE:
+        return
+    if format_name in layout_names():
+        text = io.StringIO()
+        get_layout(format_name, layout_options).write(result, text)
+        out.write(text.getvalue().encode("utf-8"))
+    else:
+        write_stream(result.arrow_table(), out, format_name, file_options)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,23 @@ def set_locale_to_enUS() -> None:
 
 
 @pytest.fixture
+def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the machine running the tests out of them.
+
+    Config discovery walks the home directory, the user config dir and the cwd,
+    so without this a developer's own `.harlequin.toml` decides what a test
+    asserts.
+
+    The three search functions are the seam, rather than `load_config` or a
+    command's own `get_config_for_profile`, because they are the only one that
+    both commands share *and* that leaves `--config-path` working -- a test that
+    passes an explicit config file still gets it.
+    """
+    for search in ("_search_home", "_search_config", "_search_cwd"):
+        monkeypatch.setattr(f"harlequin.config.{search}", list)
+
+
+@pytest.fixture
 def data_dir() -> Path:
     here = Path(__file__)
     return here.parent / "data"

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -47,10 +47,8 @@ def no_use_catalog_cache(
 
 
 @pytest.fixture(autouse=True)
-def mock_config_loader(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "harlequin.cli.get_config_for_profile", lambda **_: (dict(), [])
-    )
+def mock_config_loader(no_discovered_config: None) -> None:
+    """Autouse wrapper over the shared fixture. test_keys_app overrides it."""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -47,10 +47,8 @@ def mock_harlequin(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 
 
 @pytest.fixture()
-def mock_empty_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "harlequin.cli.get_config_for_profile", lambda **_: (dict(), [])
-    )
+def mock_empty_config(no_discovered_config: None) -> None:
+    """No config file anywhere. See tests/conftest.py."""
 
 
 @pytest.fixture()

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -1,0 +1,602 @@
+"""hsql's contract: what lands on stdout, what lands on stderr, and the code.
+
+The output format and the exit codes are the part of hsql that is an API, so
+most of what is asserted here is a promise rather than an implementation: that
+stdout carries data and only data, that a truncated result says so, that the
+same query renders the same bytes wherever it is run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import pytest
+from click.testing import CliRunner, Result
+
+from harlequin.exception import (
+    HarlequinConfigError,
+    HarlequinConnectionError,
+    HarlequinCopyError,
+    HarlequinQueryError,
+)
+from harlequin.hsql.cli import build_cli
+from harlequin.hsql.diagnostics import ExitCode, exit_code_for
+
+Hsql = Callable[..., Result]
+
+TEN_ROWS = (
+    "with recursive t(n) as ("
+    "select 1 union all select n + 1 from t where n < 10"
+    ") select n from t"
+)
+"""Ten rows, in a spelling both bundled adapters accept."""
+
+LAYOUTS = ["table", "markdown", "md", "vertical"]
+TEXT_FILES = ["csv", "tsv", "json", "jsonl", "ndjson"]
+BINARY_FILES = ["parquet", "orc", "arrow"]
+FILE_FORMATS = TEXT_FILES + BINARY_FILES
+
+# the console script's entry point, for the assertions that need a real process
+HSQL_MAIN = (
+    "import sys; from harlequin.hsql import main; "
+    "sys.argv = ['hsql', *sys.argv[1:]]; main()"
+)
+
+
+@pytest.fixture(autouse=True)
+def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the machine running the tests out of them.
+
+    Config discovery walks the home directory and the cwd, so without this a
+    developer's own `.harlequin.toml` decides what these assert.
+    """
+    for search in ("_search_home", "_search_config", "_search_cwd"):
+        monkeypatch.setattr(f"harlequin.config.{search}", list)
+
+
+@pytest.fixture
+def hsql() -> Hsql:
+    """Invoke hsql the way the console script does, in process."""
+    runner = CliRunner()
+
+    def _run(*args: str, **kwargs: Any) -> Result:
+        argv = [str(arg) for arg in args]
+        return runner.invoke(build_cli(argv), argv, catch_exceptions=False, **kwargs)
+
+    return _run
+
+
+@pytest.fixture
+def duck() -> list[str]:
+    """The arguments that get a hermetic in-memory DuckDB."""
+    return ["-a", "duckdb", "--no-init", ":memory:"]
+
+
+@pytest.fixture(params=["duckdb", "sqlite"])
+def both_adapters(request: pytest.FixtureRequest) -> list[str]:
+    return ["-a", request.param, "--no-init", ":memory:"]
+
+
+def run_hsql(*args: str, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+    """Run hsql in a real process, for the assertions that are about bytes."""
+    return subprocess.run(
+        [sys.executable, "-c", HSQL_MAIN, *args], capture_output=True, **kwargs
+    )
+
+
+# --- help, and what it costs -------------------------------------------------
+
+
+def test_help_is_adapter_agnostic(hsql: Hsql) -> None:
+    res = hsql("--help")
+    assert res.exit_code == ExitCode.OK
+    assert "Formats:" in res.output
+    assert "Exit codes:" in res.output
+    assert "Installed adapters:" in res.output
+    assert "hsql --help -a <adapter>" in res.output
+    # no adapter's connection options, and none of the IDE's options either
+    assert "--read-only" not in res.output
+    assert "--theme" not in res.output
+    assert "--show-files" not in res.output
+
+
+def test_help_for_one_adapter(hsql: Hsql) -> None:
+    res = hsql("--help", "-a", "duckdb")
+    assert res.exit_code == ExitCode.OK
+    assert "--read-only" in res.output
+    assert "Showing duckdb's connection options." in res.output
+
+
+def test_plain_help_imports_no_adapter() -> None:
+    """The point of the two-phase parse, and the thing that regresses quietly."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from harlequin.hsql.cli import build_cli; "
+            "build_cli(['--help']); "
+            "print(any(m.startswith('harlequin_') for m in sys.modules))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert proc.stdout.strip() == "False"
+
+
+def test_bare_invocation_prints_help_and_leaves_stdout_empty(hsql: Hsql) -> None:
+    """An invocation with nothing to run is a usage error, not a result.
+
+    Putting the help on stdout would mean `hsql | ...` could carry help text
+    where data belongs, which is the one thing stdout is not allowed to do.
+    """
+    res = hsql()
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "Usage:" in res.stderr
+
+
+def test_no_sql_to_run(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck)
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "no SQL to run" in res.stderr
+
+
+# --- the shapes of output ----------------------------------------------------
+
+
+def test_select_1(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-c", "select 1 as a")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == " a\n---\n 1\n(1 row)\n"
+    assert re.fullmatch(r"1 row in \d+\.\d\ds\n", res.stderr)
+
+
+def test_the_tac_idiom(hsql: Hsql, duck: list[str]) -> None:
+    """`-tAc` capturing a scalar is the first thing a script will try."""
+    res = hsql(*duck, "-tAc", "select 42")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "42\n"
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], " a\n---\n 1\n(1 row)\n"),
+        (["-t"], " 1\n"),
+        (["-A"], "a\n1\n(1 row)\n"),
+        (["--no-header"], " 1\n(1 row)\n"),
+        (["-tA"], "1\n"),
+    ],
+)
+def test_psql_flag_algebra(
+    hsql: Hsql, duck: list[str], args: list[str], expected: str
+) -> None:
+    """`-t` and `-A` are independent switches, so `-tA` is not a special case."""
+    res = hsql(*duck, *args, "-c", "select 1 as a")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == expected
+
+
+@pytest.mark.parametrize("format_name", LAYOUTS + FILE_FORMATS + ["none"])
+def test_every_format_runs(hsql: Hsql, duck: list[str], format_name: str) -> None:
+    res = hsql(*duck, "-F", format_name, "-c", "select 1 as a, null as b")
+    assert res.exit_code == ExitCode.OK
+    assert bool(res.stdout_bytes) is (format_name != "none")
+
+
+@pytest.mark.parametrize(
+    "flag,format_name",
+    [
+        ("--csv", "csv"),
+        ("--json", "json"),
+        ("--jsonl", "jsonl"),
+        ("--markdown", "markdown"),
+        ("--vertical", "vertical"),
+    ],
+)
+def test_format_shorthands(
+    hsql: Hsql, duck: list[str], flag: str, format_name: str
+) -> None:
+    sql = "select 1 as a"
+    assert (
+        hsql(*duck, flag, "-c", sql).stdout_bytes
+        == hsql(*duck, "-F", format_name, "-c", sql).stdout_bytes
+    )
+
+
+@pytest.mark.parametrize(
+    "args", [["--csv", "--json"], ["--csv", "-F", "json"], ["-F", "json", "--csv"]]
+)
+def test_two_formats_is_a_usage_error(
+    hsql: Hsql, duck: list[str], args: list[str]
+) -> None:
+    res = hsql(*duck, *args, "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert res.stderr.startswith("hsql: error: ")
+
+
+def test_null_string(hsql: Hsql, duck: list[str]) -> None:
+    assert " NULL\n" in hsql(*duck, "-c", "select null as a").stdout
+    assert " ∅\n" in hsql(*duck, "--null-string", "∅", "-c", "select null as a").stdout
+    # csv renders a null as nothing at all unless told otherwise
+    assert hsql(*duck, "--csv", "-c", "select null as a").stdout == "a\n\n"
+    assert (
+        hsql(*duck, "--csv", "--null-string", "∅", "-c", "select null as a").stdout
+        == "a\n∅\n"
+    )
+
+
+def test_zero_rows_is_not_an_error(hsql: Hsql, duck: list[str]) -> None:
+    """A0 vs A3: "matched nothing" has to be distinguishable from "failed"."""
+    res = hsql(*duck, "--csv", "-c", "select 1 as a where false")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "a\n"
+    assert "0 rows" in res.stderr
+
+
+# --- stdout is data ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("format_name", LAYOUTS + FILE_FORMATS)
+def test_stats_does_not_touch_stdout(
+    hsql: Hsql, duck: list[str], format_name: str
+) -> None:
+    sql = "select 1 as a, 'x' as b"
+    plain = hsql(*duck, "-F", format_name, "-c", sql)
+    with_stats = hsql(*duck, "-F", format_name, "--stats", "-c", sql)
+    assert plain.stdout_bytes == with_stats.stdout_bytes
+    assert with_stats.stderr != plain.stderr
+
+
+def test_stats_payload(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-F", "none", "--stats", "-l", "3", "-c", TEN_ROWS)
+    payload = json.loads(res.stderr.splitlines()[-1])
+    assert payload == {
+        "status": "ok",
+        "statements": 1,
+        "rows": 3,
+        "truncated": True,
+        "limit": 3,
+        "elapsed_ms": payload["elapsed_ms"],
+        "columns": [{"name": "n", "type": payload["columns"][0]["type"]}],
+    }
+
+
+def test_stats_reports_a_failure(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "--stats", "-c", "select from nowhere")
+    payload = json.loads(res.stderr.splitlines()[-1])
+    assert payload["status"] == "error"
+    assert payload["rows"] == 0
+    assert payload["error"]
+
+
+def test_a_query_error_leaves_stdout_empty(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-c", "select * from no_such_table")
+    assert res.exit_code == ExitCode.QUERY
+    assert res.stdout == ""
+    assert res.stderr.startswith("hsql: error: ")
+    # plain: no panel, no box drawing, no ANSI
+    assert "─" not in res.stderr
+    assert "\x1b[" not in res.stderr
+
+
+# --- truncation --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "limit,rows,truncated", [(20, 10, False), (10, 10, False), (3, 3, True)]
+)
+def test_truncation(
+    hsql: Hsql, both_adapters: list[str], limit: int, rows: int, truncated: bool
+) -> None:
+    """Exactly at the limit is the ambiguous case, and the reason for limit+1."""
+    res = hsql(*both_adapters, "-l", str(limit), "-c", TEN_ROWS)
+    assert res.exit_code == ExitCode.OK
+    body = res.stdout.splitlines()[2:-1]  # between the rule and the footer
+    assert len(body) == rows
+    assert ("truncated" in res.stderr) is truncated
+    assert (f"({rows} of {rows}+ rows)" in res.stdout) is truncated
+
+
+def test_no_limit_counts_exactly(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-l", "0", "--stats", "-F", "none", "-c", TEN_ROWS)
+    payload = json.loads(res.stderr.splitlines()[-1])
+    assert payload["rows"] == 10
+    assert payload["truncated"] is False
+    assert payload["limit"] is None
+
+
+def test_the_truncation_notice_survives_tuples_only(
+    hsql: Hsql, duck: list[str]
+) -> None:
+    """`-t` suppresses stdout chrome. It does not suppress a warning."""
+    res = hsql(*duck, "-t", "-l", "3", "-c", TEN_ROWS)
+    assert "of 3+" not in res.stdout
+    assert "results truncated at 3 rows (--limit)" in res.stderr
+
+
+# --- several statements ------------------------------------------------------
+
+
+def test_result_all_by_default(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-tA", "-c", "select 1; select 2")
+    assert res.stdout == "1\n2\n"
+
+
+@pytest.mark.parametrize("spec,expected", [("last", "2\n"), ("1", "1\n"), ("2", "2\n")])
+def test_result_selection(
+    hsql: Hsql, duck: list[str], spec: str, expected: str
+) -> None:
+    res = hsql(*duck, "-tA", "--result", spec, "-c", "select 1; select 2")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == expected
+
+
+@pytest.mark.parametrize("spec", ["3", "0", "penultimate"])
+def test_bad_result_selection(hsql: Hsql, duck: list[str], spec: str) -> None:
+    res = hsql(*duck, "--result", spec, "-c", "select 1; select 2")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+
+
+def test_two_result_sets_will_not_fit_in_a_csv(hsql: Hsql, duck: list[str]) -> None:
+    """Two headers in one file is silent corruption; an error costs one retry."""
+    res = hsql(*duck, "--csv", "-c", "select 1; select 2")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "2 result sets, but csv holds one" in res.stderr
+    assert "--result last" in res.stderr
+
+
+def test_two_result_sets_do_fit_in_jsonl(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "--jsonl", "-c", "select 1 as a; select 2 as a")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == '{"a":1}\n{"a":2}\n'
+
+
+def test_on_error_stop(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-tA", "-c", "select 1; select bad; select 3")
+    assert res.exit_code == ExitCode.QUERY
+    assert res.stdout == "1\n"
+
+
+def test_on_error_continue(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(
+        *duck, "-tA", "--on-error", "continue", "-c", "select 1; select bad; select 3"
+    )
+    assert res.exit_code == ExitCode.QUERY, "a run with a failure in it is not ok"
+    assert res.stdout == "1\n3\n"
+
+
+def test_ddl_produces_no_result_set(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-c", "create table t (a int)", "-c", "insert into t values (1)")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+
+
+# --- where the SQL comes from ------------------------------------------------
+
+
+def test_file_source(hsql: Hsql, duck: list[str], tmp_path: Path) -> None:
+    script = tmp_path / "q.sql"
+    script.write_text("select 42 as answer;\n")
+    res = hsql(*duck, "-tA", "-f", str(script))
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "42\n"
+
+
+def test_stdin_source(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-tA", "-f", "-", input="select 42\n")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "42\n"
+
+
+def test_sources_run_in_the_order_they_were_given(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    script = tmp_path / "setup.sql"
+    script.write_text("create table t (a int); insert into t values (7);")
+    res = hsql(*duck, "-tA", "-f", str(script), "-c", "select a from t")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "7\n"
+
+
+def test_a_missing_file_is_a_usage_error(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-f", "no-such-file.sql")
+    assert res.exit_code == ExitCode.USAGE
+    assert "could not read" in res.stderr
+
+
+# --- writing to a file -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "format_name,sql",
+    [
+        *(
+            (name, "select 1 as a, null as b, 'ü' as c")
+            for name in LAYOUTS + TEXT_FILES
+        ),
+        # A null's value bytes are whatever was in the buffer, and Arrow does
+        # not zero them -- so two processes writing the same null column write
+        # different padding. That is the data, not the write path, so the
+        # columnar formats are checked without one.
+        *((name, "select 1 as a, 'ü' as c") for name in BINARY_FILES),
+    ],
+)
+def test_output_file_and_redirect_agree(
+    hsql: Hsql, duck: list[str], tmp_path: Path, format_name: str, sql: str
+) -> None:
+    """The one thing a second write path could plausibly get wrong."""
+    destination = tmp_path / f"out.{format_name}"
+    written = hsql(*duck, "-F", format_name, "-o", str(destination), "-c", sql)
+    piped = hsql(*duck, "-F", format_name, "-c", sql)
+    assert written.exit_code == ExitCode.OK
+    assert written.stdout_bytes == b""
+    assert destination.read_bytes() == piped.stdout_bytes
+
+
+def test_a_file_never_gets_color(hsql: Hsql, duck: list[str], tmp_path: Path) -> None:
+    destination = tmp_path / "out.txt"
+    hsql(*duck, "--color", "always", "-o", str(destination), "-c", "select 1 as a")
+    assert b"\x1b[" not in destination.read_bytes()
+
+
+def test_an_unwritable_destination_is_a_usage_error(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    res = hsql(*duck, "-o", str(tmp_path / "nope" / "out.csv"), "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stderr.startswith("hsql: error: ")
+
+
+# --- color -------------------------------------------------------------------
+
+
+def test_color_is_off_by_default(hsql: Hsql, duck: list[str]) -> None:
+    """Principle 4: the bytes may not depend on what stdout happens to be."""
+    assert "\x1b[" not in hsql(*duck, "-c", "select 1 as a").stdout
+
+
+def test_color_always(hsql: Hsql, duck: list[str]) -> None:
+    assert "\x1b[" in hsql(*duck, "--color", "always", "-c", "select null as a").stdout
+
+
+# --- config, profiles and adapters -------------------------------------------
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    path = tmp_path / ".harlequin.toml"
+    path.write_text(
+        "default_profile = 'duck'\n"
+        "\n[profiles.duck]\n"
+        "adapter = 'duckdb'\n"
+        "conn_str = [ ':memory:' ]\n"
+        "no_init = true\n"
+        "theme = 'fruity'\n"
+        "locale = 'de_DE.UTF-8'\n"
+        "limit = 3\n"
+        "\n[profiles.lite]\n"
+        "adapter = 'sqlite'\n"
+        "conn_str = [ ':memory:' ]\n"
+    )
+    return path
+
+
+def test_the_default_profile_applies(hsql: Hsql, config_file: Path) -> None:
+    """And the IDE's own keys are dropped rather than handed to the adapter."""
+    res = hsql("--config-path", str(config_file), "-tA", "-c", TEN_ROWS)
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "".join(f"{n}\n" for n in range(1, 4)), "profile limit of 3"
+
+
+def test_a_cli_option_beats_the_profile(hsql: Hsql, config_file: Path) -> None:
+    res = hsql("--config-path", str(config_file), "-tA", "-l", "2", "-c", TEN_ROWS)
+    assert res.stdout == "1\n2\n"
+
+
+def test_a_profile_names_its_adapter(hsql: Hsql, config_file: Path) -> None:
+    res = hsql(
+        "--config-path", str(config_file), "-P", "lite", "-tA", "-c", "select 42"
+    )
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "42\n"
+
+
+def test_help_for_the_profiles_adapter(hsql: Hsql, config_file: Path) -> None:
+    res = hsql("--config-path", str(config_file), "-P", "lite", "--help")
+    assert "Showing sqlite's connection options." in res.output
+
+
+def test_an_unknown_profile_is_a_usage_error(hsql: Hsql, config_file: Path) -> None:
+    res = hsql("--config-path", str(config_file), "-P", "nope", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "profile" in res.stderr
+
+
+def test_an_unknown_adapter_is_a_usage_error(hsql: Hsql) -> None:
+    res = hsql("-a", "nosuchadapter", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+
+
+def test_a_connection_failure_exits_three(hsql: Hsql, tmp_path: Path) -> None:
+    res = hsql(
+        "-a",
+        "duckdb",
+        "--no-init",
+        str(tmp_path / "nope" / "db.duckdb"),
+        "-c",
+        "select 1",
+    )
+    assert res.exit_code == ExitCode.CONNECTION
+    assert res.stdout == ""
+
+
+# --- the exit-code mapping ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error,code",
+    [
+        (HarlequinQueryError("boom"), ExitCode.QUERY),
+        (HarlequinConfigError("boom"), ExitCode.USAGE),
+        (HarlequinConnectionError("boom"), ExitCode.CONNECTION),
+        (HarlequinCopyError("boom"), ExitCode.QUERY),
+        (KeyboardInterrupt(), ExitCode.INTERRUPT),
+        (RuntimeError("boom"), ExitCode.QUERY),
+    ],
+)
+def test_exit_code_for(error: BaseException, code: ExitCode) -> None:
+    assert exit_code_for(error) == code
+
+
+# --- the bytes are the contract ----------------------------------------------
+
+
+@pytest.mark.parametrize("args", [[], ["--csv"], ["--json"], ["--markdown"]])
+def test_output_is_lf_on_every_platform(args: Sequence[str]) -> None:
+    proc = run_hsql(
+        "-a", "duckdb", "--no-init", ":memory:", *args, "-c", "select 1 as a"
+    )
+    assert proc.returncode == ExitCode.OK
+    assert b"\r\n" not in proc.stdout
+
+
+def test_output_does_not_vary_with_the_locale() -> None:
+    """The IDE groups digits for a human. hsql must not, on anyone's machine."""
+    args = ("-a", "duckdb", "--no-init", ":memory:", "-c", "select 1234567 as n")
+    plain = run_hsql(*args)
+    localized = run_hsql(*args, env={**_environ(), "LC_ALL": "de_DE.UTF-8"})
+    assert plain.returncode == ExitCode.OK
+    assert b"1234567" in plain.stdout
+    assert plain.stdout == localized.stdout
+
+
+def test_output_does_not_vary_with_a_pipe(tmp_path: Path) -> None:
+    args = ("-a", "duckdb", "--no-init", ":memory:", "-c", "select 1 as a, 'ü' as b")
+    piped = run_hsql(*args).stdout
+    destination = tmp_path / "out.txt"
+    with destination.open("wb") as f:
+        subprocess.run(
+            [sys.executable, "-c", HSQL_MAIN, *args],
+            stdout=f,
+            stderr=subprocess.DEVNULL,
+        )
+    assert destination.read_bytes() == piped
+
+
+def _environ() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -13,8 +13,9 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, cast
 
+import click
 import pytest
 from click.testing import CliRunner, Result
 
@@ -600,3 +601,68 @@ def _environ() -> dict[str, str]:
     import os
 
     return dict(os.environ)
+
+
+# --- how the command gets built ----------------------------------------------
+
+
+def test_the_config_is_read_once(
+    hsql: Hsql, duck: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both phases want the profile; only one of them may go to disk for it."""
+    import harlequin.config
+
+    reads: list[object] = []
+    real = harlequin.config.load_config
+
+    def counting(config_path: Any) -> Any:
+        reads.append(config_path)
+        return real(config_path)
+
+    monkeypatch.setattr("harlequin.config.load_config", counting)
+    res = hsql(*duck, "-c", "select 1")
+    assert res.exit_code == ExitCode.OK
+    assert len(reads) == 1
+
+
+def test_hsql_does_not_claim_dash_h() -> None:
+    """`-h` belongs to `--host`.
+
+    psql spells it that way, and the postgres and mysql adapters both declare
+    it. Taking it for help would silently strip it from them.
+    """
+    cmd = build_cli(["--help"])
+    with click.Context(cmd) as ctx:
+        opts = {opt for param in cmd.get_params(ctx) for opt in param.opts}
+    assert "--help" in opts
+    assert "-h" not in opts
+
+
+def test_an_adapter_option_cannot_shadow_an_hsql_flag() -> None:
+    from harlequin.adapter import HarlequinAdapter
+    from harlequin.hsql.cli import _attach_adapter_options
+    from harlequin.options import TextOption
+
+    class _Adapter:
+        ADAPTER_OPTIONS = [
+            TextOption(name="collides", description="x", short_decls=["-c"]),
+            TextOption(name="format", description="x"),
+            TextOption(name="fine", description="x", short_decls=["-Z"]),
+        ]
+
+    cmd = build_cli(["--help"])
+    _attach_adapter_options(cmd, cast("type[HarlequinAdapter]", _Adapter))
+    by_name: dict[str | None, list[click.Parameter]] = {}
+    for param in cmd.params:
+        by_name.setdefault(param.name, []).append(param)
+
+    # the colliding short goes; the option survives under its long spelling
+    (collides,) = by_name["collides"]
+    assert collides.opts == ["--collides"]
+    # an option whose only spelling hsql already owns is dropped whole, so the
+    # command is left with hsql's own --format and no duplicate
+    (fmt,) = by_name["format"]
+    assert "-F" in fmt.opts
+    # anything that doesn't collide arrives untouched
+    (fine,) = by_name["fine"]
+    assert set(fine.opts) == {"--fine", "-Z"}

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -10,10 +10,8 @@ from __future__ import annotations
 
 import json
 import re
-import subprocess
-import sys
 from pathlib import Path
-from typing import Any, Callable, Sequence, cast
+from typing import Any, Callable, cast
 
 import click
 import pytest
@@ -42,26 +40,9 @@ TEXT_FILES = ["csv", "tsv", "json", "jsonl", "ndjson"]
 BINARY_FILES = ["parquet", "orc", "arrow"]
 FILE_FORMATS = TEXT_FILES + BINARY_FILES
 
-# the console script's entry point, for the assertions that need a real process
-HSQL_MAIN = (
-    "import sys; from harlequin.hsql import main; "
-    "sys.argv = ['hsql', *sys.argv[1:]]; main()"
-)
-
-
-@pytest.fixture(autouse=True)
-def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep the machine running the tests out of them.
-
-    Config discovery walks the home directory and the cwd, so without this a
-    developer's own `.harlequin.toml` decides what these assert.
-    """
-    for search in ("_search_home", "_search_config", "_search_cwd"):
-        monkeypatch.setattr(f"harlequin.config.{search}", list)
-
 
 @pytest.fixture
-def hsql() -> Hsql:
+def hsql(no_discovered_config: None) -> Hsql:
     """Invoke hsql the way the console script does, in process."""
     runner = CliRunner()
 
@@ -81,13 +62,6 @@ def duck() -> list[str]:
 @pytest.fixture(params=["duckdb", "sqlite"])
 def both_adapters(request: pytest.FixtureRequest) -> list[str]:
     return ["-a", request.param, "--no-init", ":memory:"]
-
-
-def run_hsql(*args: str, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
-    """Run hsql in a real process, for the assertions that are about bytes."""
-    return subprocess.run(
-        [sys.executable, "-c", HSQL_MAIN, *args], capture_output=True, **kwargs
-    )
 
 
 # --- help, and what it costs -------------------------------------------------
@@ -111,23 +85,6 @@ def test_help_for_one_adapter(hsql: Hsql) -> None:
     assert res.exit_code == ExitCode.OK
     assert "--read-only" in res.output
     assert "Showing duckdb's connection options." in res.output
-
-
-def test_plain_help_imports_no_adapter() -> None:
-    """The point of the two-phase parse, and the thing that regresses quietly."""
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import sys; from harlequin.hsql.cli import build_cli; "
-            "build_cli(['--help']); "
-            "print(any(m.startswith('harlequin_') for m in sys.modules))",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    assert proc.stdout.strip() == "False"
 
 
 def test_bare_invocation_prints_help_and_leaves_stdout_empty(hsql: Hsql) -> None:
@@ -560,47 +517,6 @@ def test_a_connection_failure_exits_three(hsql: Hsql, tmp_path: Path) -> None:
 )
 def test_exit_code_for(error: BaseException, code: ExitCode) -> None:
     assert exit_code_for(error) == code
-
-
-# --- the bytes are the contract ----------------------------------------------
-
-
-@pytest.mark.parametrize("args", [[], ["--csv"], ["--json"], ["--markdown"]])
-def test_output_is_lf_on_every_platform(args: Sequence[str]) -> None:
-    proc = run_hsql(
-        "-a", "duckdb", "--no-init", ":memory:", *args, "-c", "select 1 as a"
-    )
-    assert proc.returncode == ExitCode.OK
-    assert b"\r\n" not in proc.stdout
-
-
-def test_output_does_not_vary_with_the_locale() -> None:
-    """The IDE groups digits for a human. hsql must not, on anyone's machine."""
-    args = ("-a", "duckdb", "--no-init", ":memory:", "-c", "select 1234567 as n")
-    plain = run_hsql(*args)
-    localized = run_hsql(*args, env={**_environ(), "LC_ALL": "de_DE.UTF-8"})
-    assert plain.returncode == ExitCode.OK
-    assert b"1234567" in plain.stdout
-    assert plain.stdout == localized.stdout
-
-
-def test_output_does_not_vary_with_a_pipe(tmp_path: Path) -> None:
-    args = ("-a", "duckdb", "--no-init", ":memory:", "-c", "select 1 as a, 'ü' as b")
-    piped = run_hsql(*args).stdout
-    destination = tmp_path / "out.txt"
-    with destination.open("wb") as f:
-        subprocess.run(
-            [sys.executable, "-c", HSQL_MAIN, *args],
-            stdout=f,
-            stderr=subprocess.DEVNULL,
-        )
-    assert destination.read_bytes() == piped
-
-
-def _environ() -> dict[str, str]:
-    import os
-
-    return dict(os.environ)
 
 
 # --- how the command gets built ----------------------------------------------

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -53,6 +53,24 @@ def test_headless_imports_do_not_load_the_tui(
     assert not leaked, f"{statement!r} imported {leaked}"
 
 
+def test_building_the_hsql_command_imports_no_adapter(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """The point of hsql's two-phase parse, and it regresses quietly.
+
+    `hsql --help` names no adapter, so it renders the adapter-agnostic surface
+    and must not pay `ep.load()` for every adapter installed to do it.
+    """
+    proc = run_python(
+        "import sys\n"
+        "from harlequin.hsql.cli import build_cli\n"
+        "build_cli(['--help'])\n"
+        "print(','.join(m for m in sys.modules if m.startswith('harlequin_')))\n"
+    )
+    loaded = [m for m in proc.stdout.strip().split(",") if m]
+    assert not loaded, f"building `hsql --help` imported {loaded}"
+
+
 def test_public_names_still_resolve() -> None:
     """Every name `harlequin/__init__.py` exported before it went lazy.
 

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -23,6 +23,8 @@ HEADLESS_IMPORTS = [
     "import harlequin.config",
     "import harlequin.exception",
     "import harlequin.export",
+    "import harlequin.hsql",
+    "import harlequin.hsql.cli",
     "import harlequin.keymap",
     "import harlequin.layout",
     "import harlequin.options",


### PR DESCRIPTION
Part of #524. This is **PR 5** of [the M1 technical plan](https://github.com/tconbeer/harlequin/blob/main/docs/plans/m1-hsql-technical-plan.md) — the command itself, on top of the plumbing that landed in 2.9 (PRs 1–4). It does **not** close #524; PRs 6 (discoverability hints), 7 (docs) and 8 (the eval suite) remain.

**What** are the key elements of this solution?

A new `hsql` console script, `hsql = "harlequin.hsql:main"`, in four modules:

| module | owns |
| --- | --- |
| `hsql/cli.py` | the click command, two-phase adapter resolution, the run |
| `hsql/output.py` | choosing between `harlequin.layout` and `harlequin.export`, and writing |
| `hsql/diagnostics.py` | everything on stderr, and `ExitCode` |
| `hsql/__init__.py` | `main()` |

It owns no query logic: `harlequin.query` runs the statements, `harlequin.layout` and `harlequin.export` write the results. `harlequin` itself gains nothing — no new flags, no behavior change.

The full M1 surface: `-c`/`-f`/stdin, `-o`, `-F` and the `--csv`/`--json`/`--jsonl`/`--markdown`/`--vertical` shorthands, `-t`/`-A`/`--no-header`/`--null-string`, `-P`, `-a`, `--config-path`, `-l` defaulting to 500, `--result`, `--on-error`, `--color`/`NO_COLOR`, `--stats`, exit codes, truncation notices, plain errors.

The parts that are a contract rather than an implementation:

- **stdout is data; stderr is narration.** Row counts, timings, truncation notices and errors all go to stderr, and an error is one plain line — `hsql: error: ...`, no panel.
- **Exit codes**: 0 ok, 1 query, 2 usage/config, 3 connection, 130 interrupt. (4 is reserved for `--timeout` in M2.)
- **`--limit` defaults to 500 and is the _hard_ limit**, so truncation is knowable only by fetching one row more than we keep — and it is always announced, `-t` included. `-l 0` counts exactly.
- **Deterministic output**: identical bytes whether stdout is a pipe, a file or a terminal, `\n` on every platform, unaffected by `LC_ALL`. Color is off unless asked for.
- **A format that cannot hold two result sets says so and exits 2**, rather than writing a second header into the same csv.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Mostly as §3.6 of the technical plan specifies. The decisions worth a reviewer's attention:

- **`--help` imports no adapter at all.** It lists the adapter-agnostic surface, the formats, the exit codes and the _names_ of what is installed, and points at `hsql --help -a <adapter>`. A first pass parses `-a`/`-P`/`--config-path` with a throwaway resilient parser to name the one adapter in play; a second builds the real command with only that adapter's options. Measured on the CI-ish container: `hsql --help` 147ms, `hsql -c "select 1"` against DuckDB 403ms, and `harlequin.hsql.cli` imports in 113ms with no Textual and no pyarrow (`harlequin.query` is deferred into the callback).
- **hsql's own flags win a collision** with an adapter's short alias — `_adapter_params` strips the colliding spelling rather than letting a plug-in shadow a documented flag. It stays visible in `hsql --help -a <adapter>`. Nothing installed collides today; a future adapter declaring `-c` or `-f` would.
- **A shared profile's `limit` applies.** Config discovery, profiles and precedence are identical to the IDE's, so a profile with `limit = 100000` gives `hsql` a hard 100k fetch. `-l` overrides it. The alternative — ignoring the key because the two commands mean different things by it — breaks "profiles supply defaults", so I kept it and called it out in the changelog instead.
- **IDE-only profile keys are dropped** (`theme`, `keymap_name`, `show_files`, `show_s3`, `locale`, `no_download_tzdata`) rather than handed to the adapter as options it never declared. `locale` especially: `hsql` must not call `set_locale()`, or output would vary with `LC_ALL`.
- **Bare `hsql` exits 2 with the help on stderr.** That is click 8.3's `no_args_is_help`, and I kept it deliberately: help on stdout would let `hsql | …` carry help text where data belongs.
- **`-c` and `-f` run in the order the options appear.** click hands a repeatable option all of its values at once, so ordering is by each option's first appearance — `-f setup.sql -c "select …"` works, and alternating between the two (`-c A -f X -c B`) is the one lossy case.
- **`-o PATH` goes through the same binary stream stdout does**, rather than handing duckdb the path. It costs a temp-file copy on a large export; it buys the `-o PATH` == `> PATH` property by construction, and it is what lets `jsonl` hold several result sets in one file.

One change outside PR 5's brief: **`harlequin.exception` no longer imports `rich` at module scope.** It is on every headless path via `harlequin.config`, and `hsql --help` was paying ~20ms for a panel it never draws.

Two guards, because the boundary is the point of shipping this as a second command: a new import-linter contract (`hsql does not reach the TUI`) that fails if `harlequin.hsql` ever reaches Textual, questionary, sqlfmt or `harlequin.cli`, and `test_import_hygiene.py` proving it at run time in a subprocess.

**Not in this PR**, per §7 of the plan: `--read-only`, `--timeout`, `--dry-run`, `--single-transaction`, every subcommand, and streaming. Also worth noting for release time: `packaging/hsql/README.md` still says the command isn't here yet — true until the release that ships it, at which point the metapackage wants a dependency bump and a republish.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR. The "Headless & Agents" topic is PR 7 of the M1 plan and lands separately. It needs: the flag reference, the format table, the exit-code table, a "differences from psql" note, and one sentence on `--limit` meaning a soft display cap in the IDE and a hard fetch limit here.

Did you add or update tests for this change?
- [x] Yes. `tests/unit_tests/test_hsql.py`, 109 tests: the psql flag algebra, every format, `-tAc` returning a bare number, stdout purity (identical bytes with and without `--stats`; a query error leaves stdout completely empty), truncation under/at/over the limit on both bundled adapters, `--result` and the multi-result-set error, `--on-error`, `-o PATH` vs `> PATH` byte-for-byte, profiles, the exit-code mapping, and — in real subprocesses — LF on every platform, no variation under `LC_ALL=de_DE.UTF-8`, and no variation between a pipe and a file.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdZHNXduKLEvFjNAxo3Swd)_