### PR TITLE
chore: bump the pre-commit hooks into step with pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,30 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.1
+    rev: v0.16.1
     hooks:
       - id: ruff-format
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v2.0.0
     hooks:
       - id: mypy
+        # this hook resolves its own environment, so every version here is one
+        # that can drift from pyproject.toml's. The three textual pins are the
+        # ones that matter: they are pinned exactly in pyproject.toml because
+        # their APIs move, and a stale copy here fails the hook on code that
+        # `uv run mypy` accepts. Keep all four in step with pyproject.toml.
         additional_dependencies:
           - click
           - duckdb>=1.5.1
           - shandy-sqlfmt[jinjafmt]
-          - "textual>=6.3"
-          - "textual-fastdatatable==0.13.0"
-          - "textual-textarea==0.16.0"
+          - "textual==8.2.8"
+          - "textual-fastdatatable==0.17.1"
+          - "textual-textarea==0.18.1"
           - pytest
+          # reaches this environment transitively in the project's, through
+          # pytest-textual-snapshot, so it has to be asked for by name here
+          - syrupy
           - types-pygments
           - rich-click>=1.7.1
           - questionary


### PR DESCRIPTION
The `mypy` hook resolves its own environment, so its `additional_dependencies` are a second copy of the versions `pyproject.toml` pins — and that copy had drifted. It failed on `src/harlequin/query.py:256` (`Unexpected keyword argument "column_names" for "create_backend"`), code that `uv run mypy` accepts, because it was still installing `textual-fastdatatable==0.13.0` against a project that pins `0.17.1`.

- the three textual pins now match `pyproject.toml` exactly: `textual==8.2.8`, `textual-fastdatatable==0.17.1`, `textual-textarea==0.18.1`. `textual` was the loose `>=6.3`, which is how it drifted without anyone choosing to.
- `syrupy` added by name. It reaches the project's environment transitively through `pytest-textual-snapshot`, so nothing asked for it here and `tests/unit_tests/test_golden_formats.py` was 7 errors of `import-not-found`.
- `mirrors-mypy` `v1.18.2` → `v2.0.0`, matching `mypy==2.0.0,<3`, and `ruff-pre-commit` `v0.14.1` → `v0.16.1`, matching the resolved `ruff`.

`pre-commit run --all-files` now passes all three hooks, and `ruff format --check`, `ruff check` and `uv run mypy` still pass unchanged — no source changes were needed.

Tooling only, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)