### PR TITLE
fix: merge profiles and keymaps by name across config files (#1040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Config files now merge `profiles` and `keymaps` by name, so a project-local file no longer hides profiles defined in an earlier file ([#1040](https://github.com/tconbeer/harlequin/issues/1040)).
 - The Results Viewer no longer reports a truncated fetch as an exact total ([#1026](https://github.com/tconbeer/harlequin/issues/1026)).
 - The SQLite adapter now honors a limit of `1` or `0`.
 - A config file that sets `default_profile` and defines no profiles at all is now reported as a `HarlequinConfigError`, instead of crashing ([#1032](https://github.com/tconbeer/harlequin/pull/1032)).

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -325,11 +325,69 @@ def _search_home() -> list[Path]:
 
 
 def _merge_config_files(paths: list[Path]) -> Config:
+    """Merge discovered config files. Later paths win.
+
+    `profiles` and `keymaps` are merged by name rather than replaced, so a
+    project-local file that defines one profile does not hide every profile
+    in an earlier file. Within a profile, later files win key by key. A
+    later keymap of the same name replaces the earlier one.
+    """
     config: Config = {}
     for p in paths:
-        config_file = ConfigFile(p)
-        config.update(config_file.relevant_config)
+        _apply_config(config, ConfigFile(p).relevant_config)
     return config
+
+
+def _apply_config(base: Config, incoming: Config) -> None:
+    incoming_profiles = incoming.get("profiles")
+    incoming_keymaps = incoming.get("keymaps")
+    for key, value in incoming.items():
+        if key in ("profiles", "keymaps"):
+            continue
+        base[key] = value  # type: ignore[literal-required]
+    if incoming_profiles is not None:
+        existing = base.get("profiles")
+        if isinstance(incoming_profiles, dict) and (
+            existing is None or isinstance(existing, dict)
+        ):
+            base["profiles"] = _merge_profiles(existing, incoming_profiles)
+        else:
+            # Leave a bad value for `_raise_on_bad_schema` to report.
+            base["profiles"] = incoming_profiles
+    if incoming_keymaps is not None:
+        existing_keymaps = base.get("keymaps")
+        if isinstance(incoming_keymaps, dict) and (
+            existing_keymaps is None or isinstance(existing_keymaps, dict)
+        ):
+            merged_keymaps = dict(existing_keymaps or {})
+            merged_keymaps.update(incoming_keymaps)
+            base["keymaps"] = merged_keymaps
+        else:
+            base["keymaps"] = incoming_keymaps
+
+
+def _merge_profiles(
+    existing: dict[str, Profile] | None,
+    incoming: dict[str, Profile],
+) -> dict[str, Profile]:
+    merged: dict[str, Profile] = {}
+    for name, profile in (existing or {}).items():
+        if isinstance(profile, dict):
+            merged[name] = cast(Profile, dict(profile))
+        else:
+            merged[name] = profile
+    for name, profile in incoming.items():
+        if (
+            name in merged
+            and isinstance(merged[name], dict)
+            and isinstance(profile, dict)
+        ):
+            merged[name] = cast(Profile, {**merged[name], **profile})
+        elif isinstance(profile, dict):
+            merged[name] = cast(Profile, dict(profile))
+        else:
+            merged[name] = profile
+    return merged
 
 
 def _raise_on_bad_schema(config: Config) -> None:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -8,6 +8,7 @@ from harlequin.config import (
     ConfigFile,
     Profile,
     _find_config_files,
+    _merge_config_files,
     get_config_for_profile,
     get_highest_priority_existing_config_file,
     load_config,
@@ -164,6 +165,124 @@ def test_config_file_discovery(
     expected_paths.pop()
     assert _find_config_files(config_path=None) == expected_paths
     assert get_highest_priority_existing_config_file() == expected_paths[-1]
+
+
+class TestMergeConfigFiles:
+    """Later files win key-by-key; they must not replace whole tables."""
+
+    def test_a_later_file_keeps_earlier_profiles(self, tmp_path: Path) -> None:
+        home = tmp_path / "home.toml"
+        home.write_text(
+            'default_profile = "personal"\n'
+            "\n"
+            "[profiles.personal]\n"
+            'adapter = "duckdb"\n'
+            'theme = "nord"\n'
+            "\n"
+            "[profiles.shared]\n"
+            'adapter = "duckdb"\n'
+            'theme = "gruvbox"\n'
+        )
+        cwd = tmp_path / "cwd.toml"
+        cwd.write_text('[profiles.project]\nadapter = "sqlite"\n')
+
+        merged = _merge_config_files([home, cwd])
+        assert merged["default_profile"] == "personal"
+        assert set(merged["profiles"]) == {"personal", "shared", "project"}
+        assert merged["profiles"]["personal"] == {
+            "adapter": "duckdb",
+            "theme": "nord",
+        }
+        assert merged["profiles"]["project"] == {"adapter": "sqlite"}
+
+    def test_a_later_file_overrides_keys_inside_a_shared_profile(
+        self, tmp_path: Path
+    ) -> None:
+        earlier = tmp_path / "earlier.toml"
+        earlier.write_text(
+            '[profiles.personal]\nadapter = "duckdb"\nlimit = 200000\ntheme = "nord"\n'
+        )
+        later = tmp_path / "later.toml"
+        later.write_text("[profiles.personal]\nlimit = 50\n")
+
+        merged = _merge_config_files([earlier, later])
+        assert merged["profiles"]["personal"] == {
+            "adapter": "duckdb",
+            "limit": 50,
+            "theme": "nord",
+        }
+
+    def test_a_later_file_keeps_earlier_keymaps(self, tmp_path: Path) -> None:
+        earlier = tmp_path / "earlier.toml"
+        earlier.write_text('[[keymaps.home]]\nkeys = "ctrl+k"\naction = "quit"\n')
+        later = tmp_path / "later.toml"
+        later.write_text('[[keymaps.project]]\nkeys = "ctrl+p"\naction = "print"\n')
+
+        merged = _merge_config_files([earlier, later])
+        assert set(merged["keymaps"]) == {"home", "project"}
+        assert merged["keymaps"]["home"][0]["action"] == "quit"
+        assert merged["keymaps"]["project"][0]["action"] == "print"
+
+    def test_a_later_keymap_of_the_same_name_replaces_the_earlier_one(
+        self, tmp_path: Path
+    ) -> None:
+        earlier = tmp_path / "earlier.toml"
+        earlier.write_text('[[keymaps.shared]]\nkeys = "ctrl+k"\naction = "quit"\n')
+        later = tmp_path / "later.toml"
+        later.write_text('[[keymaps.shared]]\nkeys = "ctrl+q"\naction = "quit"\n')
+
+        merged = _merge_config_files([earlier, later])
+        assert merged["keymaps"]["shared"] == [{"keys": "ctrl+q", "action": "quit"}]
+
+    def test_a_later_default_profile_still_wins(self, tmp_path: Path) -> None:
+        earlier = tmp_path / "earlier.toml"
+        earlier.write_text(
+            'default_profile = "personal"\n[profiles.personal]\nadapter = "duckdb"\n'
+        )
+        later = tmp_path / "later.toml"
+        later.write_text(
+            'default_profile = "project"\n[profiles.project]\nadapter = "sqlite"\n'
+        )
+
+        merged = _merge_config_files([earlier, later])
+        assert merged["default_profile"] == "project"
+        assert set(merged["profiles"]) == {"personal", "project"}
+
+    def test_load_config_keeps_a_home_default_when_cwd_adds_a_profile(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The #1040 reproduction: cwd must not hide the home default profile."""
+        mock_home = tmp_path_factory.mktemp("home")
+        mock_config = tmp_path_factory.mktemp("config")
+        mock_cwd = tmp_path_factory.mktemp("cwd")
+        (mock_home / ".harlequin.toml").write_text(
+            'default_profile = "personal"\n'
+            "\n"
+            "[profiles.personal]\n"
+            'adapter = "duckdb"\n'
+            'theme = "nord"\n'
+            "\n"
+            "[profiles.shared]\n"
+            'adapter = "duckdb"\n'
+            'theme = "gruvbox"\n'
+        )
+        (mock_cwd / ".harlequin.toml").write_text(
+            '[profiles.project]\nadapter = "sqlite"\n'
+        )
+        monkeypatch.setattr(Path, "cwd", lambda: mock_cwd)
+        monkeypatch.setattr(Path, "home", lambda: mock_home)
+        monkeypatch.setattr(
+            "harlequin.config.user_config_path", lambda **_: mock_config
+        )
+
+        loaded = load_config(config_path=None)
+        assert loaded["default_profile"] == "personal"
+        assert set(loaded["profiles"]) == {"personal", "shared", "project"}
+        profile, _ = get_config_for_profile(config_path=None, profile_name=None)
+        assert profile["adapter"] == "duckdb"
+        assert profile["theme"] == "nord"
 
 
 def test_merge_profile_with_cli_prefers_values_the_user_typed() -> None:


### PR DESCRIPTION
Closes #1040

**What** are the key elements of this solution?

`_merge_config_files()` used `dict.update()`, so a later file's `profiles` (or `keymaps`) table replaced the earlier one entirely. A project-local file that defined one profile therefore hid every profile in the home file — and because `default_profile` is a different top-level key, it survived and pointed at a name that was no longer there.

The merge is now by name: later files still win, but they win *key by key* inside a profile, and they add or replace individual keymaps rather than the whole table. Other top-level keys (`default_profile`) keep later-wins.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

This is the merge #1040 asked for, pulled forward on its own rather than waiting for the M2 `hsql --config show` work. I did not deep-merge keymap *bindings* (they are a list, not a table of keys); a later keymap of the same name replaces the earlier one, which matches "later wins" without inventing a binding-identity rule.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.