### PR TITLE
fix: escape --null-string in markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- `hsql --format markdown` no longer breaks the table when `--null-string` contains a `|` or a newline.
+
 ## [2.9.0] - 2026-08-15
 
 ### Breaking Changes

--- a/src/harlequin/layout.py
+++ b/src/harlequin/layout.py
@@ -243,6 +243,13 @@ class _MarkdownLayout(_BaseLayout):
     MIN_WIDTH = 3
     """The shortest delimiter row GFM accepts is `---`."""
 
+    def __init__(self, options: LayoutOptions) -> None:
+        super().__init__(options)
+        # `_cell()` is shared with the other layouts and prints `self.null` as
+        # it finds it, so a null string a caller chose is escaped once, here,
+        # rather than at every place that renders one.
+        self.null = _escape(self.null)
+
     def write(self, result: "ResultSet", out: TextIO) -> None:
         headers = [_escape(name) for name in self._headers(result)]
         rows: list[Row] = [
@@ -251,7 +258,7 @@ class _MarkdownLayout(_BaseLayout):
         ]
         widths = [
             max(width, self.MIN_WIDTH)
-            for width in _column_widths(headers, rows, _escape(self.null))
+            for width in _column_widths(headers, rows, self.null)
         ]
 
         if self.options.header:

--- a/tests/unit_tests/test_layout.py
+++ b/tests/unit_tests/test_layout.py
@@ -112,6 +112,20 @@ class TestMarkdownLayout:
         assert "one<br>two" in rendered
         assert len(rendered.splitlines()) == 3
 
+    def test_a_null_string_cannot_escape_its_column(
+        self, result_set: ResultSetFactory
+    ) -> None:
+        """The null string is printed like any other value, so a `|` or a
+        newline in it breaks the table the same way."""
+        result = result_set("select null as x, 1 as y")
+        rendered = render(
+            result,
+            "markdown",
+            LayoutOptions(footer=False, null_string="a|b\nc"),
+        )
+        assert "a\\|b<br>c" in rendered
+        assert len(rendered.splitlines()) == 3
+
     def test_columns_are_at_least_three_wide(
         self, result_set: ResultSetFactory
     ) -> None:


### PR DESCRIPTION
Closes: I could not find a matching existing open issue. Happy to add a reference if there is one I missed.

**What** are the key elements of this solution?

`--null-string` is printed into markdown output unescaped, so a `|` or a newline in it breaks the table.

```
$ hsql -a sqlite -c "select null as x" --format markdown --null-string "a|b"
| x    |
| ---- |
| a|b  |
```

One column in the header, two cells in the row. With a newline the row splits in two:

```
$ hsql -a sqlite -c "select null as x, 1 as y" --format markdown --null-string "$(printf 'a\nb')"
| x      | y   |
| ------ | --- |
| a
b    | 1   |
```

`_MarkdownLayout.write` escapes headers and values, and `_column_widths` is already called with `_escape(self.null)`. But `_BaseLayout._cell` renders `self.null` as it finds it, so the width was measured from the escaped string while the unescaped one was printed. That is also why the column misaligns.

The escape now happens once in `_MarkdownLayout.__init__`. `_column_widths` then takes the already-escaped value and the two agree by construction.

After:

```
| x    |          | x      | y   |
| ---- |          | ------ | --- |
| a\|b |          | a<br>b | 1   |
```

The other layouts are byte-identical before and after, still printing `a|b` raw:

```
 x   | y            -[ RECORD 1 ]-        x,y
-----+---           x | a|b               a|b,1
 a|b | 1            y | 1
```

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

`_cell` is shared with the table and vertical layouts, which must keep printing the null string raw, so escaping at the render site was not an option. Doing it once at construction is the only place where the width calculation and the render can be made to agree by construction rather than by coincidence.

Verification: `test_a_null_string_cannot_escape_its_column`, directly beside `test_a_cell_cannot_escape_its_column`, whose docstring already states the invariant: "A `|` or a newline in a value doesn't make a table hard to read; it makes it a different table". The sibling gives the mutation check for free, since it passes today: with the fix reverted the new test fails and the sibling still passes.

`make check` passes: 641 tests, mypy clean over 105 files, ruff clean, 4 contracts kept.

Does this PR require a change to Harlequin's docs?
- [x] No. (bug fix to markdown escaping, no documented behaviour changes)
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. (entry added under `[Unreleased]`; it references no issue because I could not find a matching open one)
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

*Disclosure: written with AI assistance (Claude Code). I reproduced the issue, ran the change and the verification myself.*