### PR TITLE
fix: unbreak local tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
           - pandas-stubs
           - importlib_metadata
           - boto3-stubs
+          - msgspec
         args:
           - "--disallow-untyped-calls"
           - "--disallow-untyped-defs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def set_locale_to_enUS() -> None:
     set_locale("en_US.UTF-8")
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the machine running the tests out of them.
 
@@ -75,7 +75,9 @@ def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
     The search is the seam, rather than `load_config()` or a command's own
     `load_profile()`, because it is the one both commands share *and* that
     leaves `--config-path` working -- a test that passes an explicit config
-    file still gets it.
+    file still gets it. A test about discovery itself patches the seam back
+    (see `test_discover_config_files`) or replaces it with directories of its
+    own (see the `config_dirs` fixture).
     """
     monkeypatch.setattr("harlequin.config._search_directories", list)
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Callable
 
 import pytest
@@ -31,14 +33,28 @@ def result_set(
 
 
 @pytest.fixture
-def run_python() -> Callable[[str], subprocess.CompletedProcess[str]]:
+def run_python(tmp_path: Path) -> Callable[[str], subprocess.CompletedProcess[str]]:
     """Run a snippet in a fresh interpreter and capture its streams.
 
     In-process assertions can't see the state these tests care about: which
     modules an import pulled in, and which stream something was written to.
     Both are properties of a clean interpreter, and pytest has already imported
     half the world by the time a test runs.
+
+    A clean *machine*, too: `no_discovered_config` cannot reach into a
+    subprocess, so the child gets an empty directory as its cwd, its home and
+    its config dir. Otherwise it reads the config files of whoever is running
+    the tests.
     """
+    env = {
+        **os.environ,
+        # where config discovery looks, on every platform platformdirs knows
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
+        "APPDATA": str(tmp_path / "appdata"),
+        "LOCALAPPDATA": str(tmp_path / "localappdata"),
+    }
 
     def _run(code: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -46,6 +62,8 @@ def run_python() -> Callable[[str], subprocess.CompletedProcess[str]]:
             capture_output=True,
             text=True,
             check=True,
+            cwd=tmp_path,
+            env=env,
         )
 
     return _run

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -10,6 +10,7 @@ from harlequin.config import (
     ConfigFile,
     Profile,
     _discover_config_files,
+    _search_directories,
     get_highest_priority_existing_config_file,
     load_config,
     load_profile,
@@ -195,6 +196,10 @@ def test_config_file_discovery(
         p.parent.mkdir(parents=True, exist_ok=True)
         p.open("w").close()
 
+    # the real search, which `no_discovered_config` stubs out for every other
+    # test, is the thing under test here -- so put it back and redirect the
+    # three directories it walks instead
+    monkeypatch.setattr("harlequin.config._search_directories", _search_directories)
     monkeypatch.setattr(Path, "cwd", lambda: mock_cwd)
     monkeypatch.setattr(Path, "home", lambda: mock_home)
     monkeypatch.setattr("harlequin.config.user_config_path", lambda **_: mock_config)


### PR DESCRIPTION
fixtures weren't adequately isolating the dev CWD, so my local harlequin config was breaking some tests. This should fix that.