### PR TITLE
fix: escape --null-string in markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - A project-local config file that defines a profile no longer hides the profiles defined in your home config file, and no longer contradicts the `default_profile` set there — which made both commands refuse to start ([#1040](https://github.com/tconbeer/harlequin/issues/1040)).
 - Config file errors now name the file the problem is written in, and the key it is written under. A key Harlequin does not recognize is reported with the nearest one it does, so `read-only`, `reed_only` and `keymap_names` each name the option they were probably meant to be.
 - A `default_profile` that names no profile now only stops an invocation that was going to use it: `harlequin -P other` and `harlequin -P None` start, as `hsql` does, instead of refusing over a key neither of them read.
+- `hsql --format markdown` no longer breaks the table when `--null-string` contains a `|` or a newline.
 
 ### Performance
 

--- a/src/harlequin/layout.py
+++ b/src/harlequin/layout.py
@@ -243,6 +243,13 @@ class _MarkdownLayout(_BaseLayout):
     MIN_WIDTH = 3
     """The shortest delimiter row GFM accepts is `---`."""
 
+    def __init__(self, options: LayoutOptions) -> None:
+        super().__init__(options)
+        # `_cell()` is shared with the other layouts and prints `self.null` as
+        # it finds it, so a null string a caller chose is escaped once, here,
+        # rather than at every place that renders one.
+        self.null = _escape(self.null)
+
     def write(self, result: "ResultSet", out: TextIO) -> None:
         headers = [_escape(name) for name in self._headers(result)]
         rows: list[Row] = [
@@ -251,7 +258,7 @@ class _MarkdownLayout(_BaseLayout):
         ]
         widths = [
             max(width, self.MIN_WIDTH)
-            for width in _column_widths(headers, rows, _escape(self.null))
+            for width in _column_widths(headers, rows, self.null)
         ]
 
         if self.options.header:

--- a/tests/unit_tests/test_layout.py
+++ b/tests/unit_tests/test_layout.py
@@ -112,6 +112,20 @@ class TestMarkdownLayout:
         assert "one<br>two" in rendered
         assert len(rendered.splitlines()) == 3
 
+    def test_a_null_string_cannot_escape_its_column(
+        self, result_set: ResultSetFactory
+    ) -> None:
+        """The null string is printed like any other value, so a `|` or a
+        newline in it breaks the table the same way."""
+        result = result_set("select null as x, 1 as y")
+        rendered = render(
+            result,
+            "markdown",
+            LayoutOptions(footer=False, null_string="a|b\nc"),
+        )
+        assert "a\\|b<br>c" in rendered
+        assert len(rendered.splitlines()) == 3
+
     def test_columns_are_at_least_three_wide(
         self, result_set: ResultSetFactory
     ) -> None:


### PR DESCRIPTION
Supersedes #1044 (rebases on main, updates Changelog).