### PR TITLE
feat: view a result cell's full value in a modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   - `list-profiles` lists every profile you can pass to `-P`, its adapter, and which one is the default. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
   - `show` prints the merged config with the file each value came from, and the files it overrode — so you can see which file is winning. `--json` for JSON.
   - `validate` reports every problem in every discovered config file — the file, the key, what is wrong, and the line where the TOML parser knew one — instead of stopping at the first, as a run does. It checks each profile against the options its adapter declares, so a misspelled `reed_only` is reported rather than dropped in silence, and it checks your keymaps too. It exits `2` when it found anything, so `hsql --config validate --format none` is the whole check for a script. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+- The Results Viewer can open the value under the cursor in a scrollable modal, so a long string or a blob of JSON that gets clipped in the grid can be read in full (press `space`, or copy it out with `c`) ([#1011](https://github.com/tconbeer/harlequin/issues/1011)).
 
 ### Breaking Changes
 

--- a/src/harlequin/actions.py
+++ b/src/harlequin/actions.py
@@ -247,6 +247,9 @@ HARLEQUIN_ACTIONS = {
     "results_viewer.copy_selection": Action(
         target=ResultsTable, action="copy_selection"
     ),
+    "results_viewer.view_cell": Action(
+        target=ResultsTable, action="view_cell", description="View Cell"
+    ),
     "results_viewer.select_cursor": Action(target=ResultsTable, action="select_cursor"),
     # Moving the cursor
     "results_viewer.cursor_up": Action(target=ResultsTable, action="cursor_up"),

--- a/src/harlequin/app.tcss
+++ b/src/harlequin/app.tcss
@@ -422,31 +422,11 @@ CellViewModal {
     padding: 0;
 }
 
-#cell_view_outer {
-    border: round $secondary;
-    background: $background;
-    margin: 4 8;
-    padding: 1 2;
-    max-width: 100;
+/* reuses the shared #modal_outer / #modal_inner / #modal_footer styling so the
+   primary outer border and faded inner border match the help and error modals */
+CellViewModal #modal_inner {
     max-height: 80%;
-}
-
-#cell_view_scroll {
-    height: auto;
-    max-height: 100%;
-    border: round $border-color-nofocus;
     padding: 1 1 1 2;
-}
-
-#cell_view_scroll:focus {
-    border: round $primary;
-}
-
-#cell_view_footer {
-    dock: bottom;
-    color: $text-muted;
-    margin: 1 0 0 0;
-    padding: 0 1;
 }
 
 /* HELP SCREEN */

--- a/src/harlequin/app.tcss
+++ b/src/harlequin/app.tcss
@@ -416,6 +416,39 @@ ClickableStatic:hover {
     padding: 0 1;
 }
 
+/* CELL VIEW MODAL */
+CellViewModal {
+    align: center middle;
+    padding: 0;
+}
+
+#cell_view_outer {
+    border: round $secondary;
+    background: $background;
+    margin: 4 8;
+    padding: 1 2;
+    max-width: 100;
+    max-height: 80%;
+}
+
+#cell_view_scroll {
+    height: auto;
+    max-height: 100%;
+    border: round $border-color-nofocus;
+    padding: 1 1 1 2;
+}
+
+#cell_view_scroll:focus {
+    border: round $primary;
+}
+
+#cell_view_footer {
+    dock: bottom;
+    color: $text-muted;
+    margin: 1 0 0 0;
+    padding: 0 1;
+}
+
 /* HELP SCREEN */
 HelpScreen {
     align: center middle;

--- a/src/harlequin/components/__init__.py
+++ b/src/harlequin/components/__init__.py
@@ -1,3 +1,4 @@
+from harlequin.components.cell_view_modal import CellViewModal
 from harlequin.components.code_editor import CodeEditor, EditorCollection
 from harlequin.components.data_catalog import DataCatalog, HarlequinTree
 from harlequin.components.debug_info import DebugInfoScreen
@@ -9,6 +10,7 @@ from harlequin.components.results_viewer import ResultsTable, ResultsViewer
 from harlequin.components.run_query_bar import RunQueryBar
 
 __all__ = [
+    "CellViewModal",
     "CodeEditor",
     "EditorCollection",
     "ErrorModal",

--- a/src/harlequin/components/cell_view_modal.py
+++ b/src/harlequin/components/cell_view_modal.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pyperclip
+from rich.markup import escape
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class CellViewModal(ModalScreen[None]):
+    """Shows a single result cell's whole value in a scrollable pane, so long
+    strings and JSON that get clipped in the grid can be read in full."""
+
+    BINDINGS = [
+        Binding("escape,enter,q", "close", "Close"),
+        Binding("c", "copy", "Copy Value"),
+    ]
+
+    def __init__(
+        self,
+        value: Any,
+        column_label: str = "",
+        name: str | None = None,
+        id: str | None = None,  # noqa: A002
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name, id, classes)
+        self.value_str = "∅ null" if value is None else str(value)
+        self.column_label = column_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="cell_view_outer"):
+            with VerticalScroll(id="cell_view_scroll"):
+                yield Static(escape(self.value_str), id="cell_view_value")
+            yield Static(
+                "Arrows / PgUp / PgDn scroll. c copies. esc closes.",
+                id="cell_view_footer",
+            )
+
+    def on_mount(self) -> None:
+        outer = self.query_one("#cell_view_outer")
+        outer.border_title = self.column_label or "Cell Contents"
+        scroll = self.query_one("#cell_view_scroll", VerticalScroll)
+        scroll.can_focus = True
+        scroll.focus()
+
+    def action_close(self) -> None:
+        self.dismiss()
+
+    def action_copy(self) -> None:
+        # OSC 52 works over ssh and where pyperclip has no backend
+        self.app.copy_to_clipboard(self.value_str)
+        try:
+            pyperclip.copy(self.value_str)
+        except pyperclip.PyperclipException:
+            pass
+        self.app.notify("Cell value copied to clipboard.")

--- a/src/harlequin/components/cell_view_modal.py
+++ b/src/harlequin/components/cell_view_modal.py
@@ -6,14 +6,17 @@ import pyperclip
 from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical, VerticalScroll
+from textual.containers import VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Static
+
+from harlequin.components.help_screen import VerticalSuppressClicks
 
 
 class CellViewModal(ModalScreen[None]):
     """Shows a single result cell's whole value in a scrollable pane, so long
-    strings and JSON that get clipped in the grid can be read in full."""
+    strings and JSON that get clipped in the grid can be read in full. Styled to
+    match the help and error modals: primary outer border, faded inner border."""
 
     BINDINGS = [
         Binding("escape,enter,q", "close", "Close"),
@@ -33,20 +36,24 @@ class CellViewModal(ModalScreen[None]):
         self.column_label = column_label
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="cell_view_outer"):
-            with VerticalScroll(id="cell_view_scroll"):
-                yield Static(escape(self.value_str), id="cell_view_value")
+        with VerticalSuppressClicks(id="modal_outer"):
+            with VerticalScroll(id="modal_inner"):
+                yield Static(escape(self.value_str), id="modal_info")
             yield Static(
                 "Arrows / PgUp / PgDn scroll. c copies. esc closes.",
-                id="cell_view_footer",
+                id="modal_footer",
             )
 
     def on_mount(self) -> None:
-        outer = self.query_one("#cell_view_outer")
+        outer = self.query_one("#modal_outer")
         outer.border_title = self.column_label or "Cell Contents"
-        scroll = self.query_one("#cell_view_scroll", VerticalScroll)
+        scroll = self.query_one("#modal_inner", VerticalScroll)
         scroll.can_focus = True
         scroll.focus()
+
+    def on_click(self) -> None:
+        # a click outside the modal closes it, matching the help and error modals
+        self.dismiss()
 
     def action_close(self) -> None:
         self.dismiss()

--- a/src/harlequin/components/error_modal.py
+++ b/src/harlequin/components/error_modal.py
@@ -51,7 +51,11 @@ class ErrorModal(ModalScreen):
         container = self.query_one("#error_outer")
         container.border_title = self.title
 
-    def on_key(self) -> None:
+    def on_key(self, event: events.Key) -> None:
+        # consume the key so dismissing the modal can't also actuate a binding
+        # on the widget underneath (e.g. a results-table shortcut).
+        event.stop()
+        event.prevent_default()
         self.app.pop_screen()
 
     def on_click(self, message: events.Click) -> None:

--- a/src/harlequin/components/results_viewer.py
+++ b/src/harlequin/components/results_viewer.py
@@ -13,6 +13,7 @@ from textual.widgets import (
 )
 from textual_fastdatatable import DataTable
 
+from harlequin.components.cell_view_modal import CellViewModal
 from harlequin.messages import WidgetMounted
 
 if TYPE_CHECKING:
@@ -96,6 +97,20 @@ class ResultsTable(DataTable, inherit_bindings=False):
             null_rep=null_rep,
             render_markup=render_markup,
         )
+
+    def action_view_cell(self) -> None:
+        """Open a modal showing the full value of the cell under the cursor."""
+        if self.backend is None or self.row_count == 0:
+            return
+        coord = self.cursor_coordinate
+        if not self.is_valid_coordinate(coord):
+            return
+        value = self.get_cell_at(coord)
+        try:
+            column_label = self.plain_column_labels[coord.column]
+        except IndexError:
+            column_label = ""
+        self.app.push_screen(CellViewModal(value=value, column_label=column_label))
 
 
 class ResultsViewer(TabbedContent, can_focus=True):

--- a/src/harlequin_vscode/__init__.py
+++ b/src/harlequin_vscode/__init__.py
@@ -86,6 +86,7 @@ VSCODE_RESULTS_VIEWER_BINDINGS = [
     HarlequinKeyBinding("k", "results_viewer.next_tab"),
     HarlequinKeyBinding("ctrl+c", "results_viewer.copy_selection"),
     HarlequinKeyBinding("enter", "results_viewer.select_cursor"),
+    HarlequinKeyBinding("space", "results_viewer.view_cell"),
     HarlequinKeyBinding("up", "results_viewer.cursor_up"),
     HarlequinKeyBinding("down", "results_viewer.cursor_down"),
     HarlequinKeyBinding("left", "results_viewer.cursor_left"),

--- a/tests/functional_tests/test_results_viewer.py
+++ b/tests/functional_tests/test_results_viewer.py
@@ -116,6 +116,14 @@ async def test_view_cell_modal(
         await pilot.pause()
         assert not isinstance(app.screen, CellViewModal)
 
+        # a click outside the modal also closes it, like the help/error modals
+        await pilot.press("space")
+        await pilot.pause()
+        assert isinstance(app.screen, CellViewModal)
+        await pilot.click()
+        await pilot.pause()
+        assert not isinstance(app.screen, CellViewModal)
+
 
 @pytest.mark.asyncio
 async def test_data_truncated_with_tooltip(

--- a/tests/functional_tests/test_results_viewer.py
+++ b/tests/functional_tests/test_results_viewer.py
@@ -10,6 +10,7 @@ from textual_fastdatatable import DataTable
 
 from harlequin import Harlequin
 from harlequin.adapter import HarlequinAdapter
+from harlequin.components.cell_view_modal import CellViewModal
 from harlequin.components.results_viewer import ResultsViewer
 
 
@@ -82,6 +83,38 @@ async def test_copy_data(
         assert app.editor.text == expected
         if not transaction_button_visible(app):
             assert await app_snapshot(app, "paste values from table")
+
+
+@pytest.mark.asyncio
+async def test_view_cell_modal(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    long_value = "the quick brown fox " * 40
+    query = f"select '{long_value}' as story"
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        app.editor.text = query
+        await pilot.press("ctrl+j")
+        await wait_for_workers(app)
+        await pilot.pause()
+        await wait_for_workers(app)
+        await pilot.pause()
+
+        assert app.results_viewer._has_focus_within
+        await pilot.press("space")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CellViewModal)
+        assert app.screen.value_str == long_value
+        assert app.screen.column_label == "story"
+
+        # esc pops the modal back off
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, CellViewModal)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1011.

Adds a modal that shows the full value of the focused Results Viewer cell, so a long string or a blob of JSON that gets clipped in the grid is actually readable. Press `space` on a cell and you get a scrollable pane with the whole value; arrows/PgUp/PgDn scroll it, `c` copies it, and esc/enter/q close.

Wired it the normal way so it stays rebindable: a `results_viewer.view_cell` entry in `HARLEQUIN_ACTIONS`, an `action_view_cell` on `ResultsTable`, and a default `space` binding in the vscode keymap.

I went with a keybinding rather than the double-click the issue floated. #987 is already using double-click for in-place edits, and a key works fine when you're driving from the keyboard. Can add double-click too if you'd prefer.

One thing this surfaced: `ErrorModal` dismisses on any key but never stopped the event, so the keypress could fall through and trigger a binding on the table underneath (dismiss an error with `space`, and you'd immediately pop this modal open). Made the error modal consume the key.

For tests I added `test_view_cell_modal`: runs a query with a long string, focuses the table, presses `space`, checks the modal is up and shows the cell value in full, then esc pops it off. Plain pilot assertions, no new snapshot. Ran the results-viewer, keymap, help-screen and app suites locally and they're green; the error-modal fix is covered by the existing `test_query_errors` cases.
