### PR TITLE
Add `hsql --config validate` mode to check config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Adds `hsql --config show` and `hsql --config list-profiles`, which report on your config files instead of running SQL ([#524](https://github.com/tconbeer/harlequin/issues/524)).
+- Adds `hsql --config show`, `--config list-profiles` and `--config validate`, which report on your config files instead of running SQL ([#524](https://github.com/tconbeer/harlequin/issues/524)).
   - `list-profiles` lists every profile you can pass to `-P`, its adapter, and which one is the default. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
   - `show` prints the merged config with the file each value came from, and the files it overrode — so you can see which file is winning. `--json` for JSON.
+  - `validate` reports every problem in every discovered config file — the file, the key, what is wrong, and the line where the TOML parser knew one — instead of stopping at the first, as a run does. It checks each profile against the options its adapter declares, so a misspelled `reed_only` is reported rather than dropped in silence, and it checks your keymaps too. It exits `2` when it found anything, so `hsql --config validate --format none` is the whole check for a script. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 
 ### Breaking Changes
 

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -15,6 +15,8 @@ Who reads what:
 | the IDE's debug screen | `load_config()`              | all                  |
 | `hsql --config show`   | `load_config()`, with a      | all                  |
 |                        | `Provenance` to fill in      |                      |
+| `hsql --config`        | `validate_config_files()`    | all, and none of     |
+| `validate`             |                              | them fatally         |
 | `harlequin --config`   | `ConfigFile`, at the path    | one, and unvalidated |
 |                        | `get_highest_priority_...()` | (it is about to be   |
 |                        | returns                      | written back)        |
@@ -28,6 +30,10 @@ Config files are validated twice, and the halves know different things.
 other, so the error can name the file. `parse_profile_options()` runs once the
 adapter is known and checks the profile's remaining keys -- each of which is
 some adapter's option -- against the options that adapter declares.
+
+Both passes raise at the first problem, because every caller but one is on its
+way to a database. Hand them a `Problems` and they record it and carry on
+instead, which is the whole of `--config validate`.
 """
 
 from __future__ import annotations
@@ -40,6 +46,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Collection,
     Container,
     Dict,
@@ -136,6 +143,57 @@ class Provenance:
     keymaps: dict[str, list[Path]] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ConfigProblem:
+    """One thing wrong with one config file, as a row of a report.
+
+    `key` is the dotted path the problem is written under
+    (`profiles.prod.reed_only`), and None for a problem with the file rather
+    than with something in it. `line` is only ever a line the TOML parser
+    named: nothing reports a position for a key we merely dislike, and a
+    made-up number is worse than no number.
+    """
+
+    path: Path
+    key: str | None
+    message: str
+    line: int | None = None
+
+
+@dataclass
+class Problems:
+    """Where a reader puts a problem instead of raising it.
+
+    Passed the way `Provenance` is, and for the same reason: a reader given one
+    records what it finds and reads on, a reader given none raises at the first
+    thing it cannot use, and neither has a second copy of what it checks.
+    `--config validate` is the only caller that wants the first behavior.
+
+    `at()` binds the file and the key an entry belongs under, so that the
+    functions that find a problem do not have to know where they are.
+    """
+
+    items: list[ConfigProblem] = field(default_factory=list)
+    path: Path | None = None
+    key: str = ""
+
+    def at(self, path: Path, key: str = "") -> Problems:
+        """The same collector, for the problems in one file, under one key."""
+        return Problems(items=self.items, path=path, key=key)
+
+    def add(self, message: str, *, key: str = "", line: int | None = None) -> None:
+        """Record one problem, folded onto one line, because it will be a row."""
+        assert self.path is not None, "bind a collector to a file with at()"
+        self.items.append(
+            ConfigProblem(
+                path=self.path,
+                key=".".join(part for part in (self.key, key) if part) or None,
+                message=" ".join(message.split()),
+                line=line,
+            )
+        )
+
+
 class Config(msgspec.Struct, forbid_unknown_fields=True):
     """A config file's contents, and also several of them merged.
 
@@ -173,27 +231,37 @@ class ConfigFile:
     the file through it, and nothing imports tomlkit until something writes.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, problems: Problems | None = None) -> None:
         """
         Opens and reads the TOML file at path. Can be used to create
         a new file if one does not already exist.
 
-        Raises: HarlequinConfigError if we can't read the TOML file.
+        Raises: HarlequinConfigError if we can't read the TOML file, unless a
+        `Problems` is there to record it instead, in which case the file reads
+        as the empty config it is to every caller downstream.
         """
         self.path = path
         self.is_pyproject = path.stem == "pyproject"
         self._doc: TOMLDocument | None = None
+        self._data: dict[str, Any] = {}
         try:
             with open(path, "rb") as f:
-                self._data: dict[str, Any] = tomllib.load(f)
+                self._data = tomllib.load(f)
         except OSError:
-            self._data = {}
+            pass
         except tomllib.TOMLDecodeError as e:
-            raise HarlequinConfigError(
-                f"Attempted to load the config file at {path}, but encountered an "
-                f"error:\n\n{e}",
-                title="Harlequin could not load the config file.",
-            ) from e
+            if problems is None:
+                raise HarlequinConfigError(
+                    f"Attempted to load the config file at {path}, but encountered an "
+                    f"error:\n\n{e}",
+                    title="Harlequin could not load the config file.",
+                ) from e
+            # the parser is the only thing in the stack that knows a line
+            # number, and depending on its version it is either an attribute or
+            # only ever in the message
+            problems.at(path).add(
+                str(e), line=getattr(e, "lineno", None) or _line_in(str(e))
+            )
 
     @property
     def relevant_config(self) -> dict[str, Any]:
@@ -306,12 +374,69 @@ def load_profile_and_keymaps(
     return _select_profile(config, requested=profile_name), keymaps
 
 
+def validate_config_files(
+    config_path: Path | None,
+    *,
+    adapter_options: Callable[[str], Sequence[AbstractOption] | None],
+    command_options: Collection[str],
+    provenance: Provenance | None = None,
+) -> list[ConfigProblem]:
+    """Every discovered config file, and everything wrong with any of them.
+
+    The same two passes every start-up runs, with a `Problems` where a command
+    would have had an exception: `_read_config_files()` checks each file's
+    shape before the merge, and `parse_profile_options()` checks each of its
+    profiles against the options that profile's adapter declares. Neither stops
+    at the first problem, and both are the same code that raises for everyone
+    else -- a second copy of either would sooner or later disagree with it.
+
+    Per file rather than over the merge, which is what validating before
+    merging buys: a profile a nearer file displaced is not what any invocation
+    runs, and is still a table its author will edit.
+
+    `adapter_options` is the second pass's price: one adapter import per
+    adapter a profile names. It may raise `HarlequinConfigError` for a name
+    nothing installed provides, which is recorded against the profile that
+    named it.
+
+    Raises: HarlequinConfigError if `config_path` names a file that is not
+    there -- the one problem that is not in a config file.
+    """
+    problems = Problems()
+    provenance = provenance if provenance is not None else Provenance()
+    merged = Config()
+    for path, from_file in _read_config_files(config_path, problems=problems):
+        for name, profile in from_file.profiles.items():
+            _validate_profile(
+                profile,
+                adapter_options=adapter_options,
+                command_options=command_options,
+                problems=problems.at(path, f"profiles.{name}"),
+            )
+        for name, bindings in from_file.keymaps.items():
+            _validate_keymap(
+                name, bindings, problems=problems.at(path, f"keymaps.{name}")
+            )
+        _merge(from_file, into=merged, source=path, provenance=provenance)
+
+    if merged.default_profile is not None:
+        # the one problem no single file has, so the only one asked after the
+        # merge -- and the file that is wrong about it is the one that set it
+        _select_profile(
+            merged,
+            requested=None,
+            problems=problems.at(provenance.default_profile[0]),
+        )
+    return problems.items
+
+
 def parse_profile_options(
     profile: Profile,
     *,
     adapter: str,
     adapter_options: Sequence[AbstractOption] | None,
     command_options: Collection[str],
+    problems: Problems | None = None,
 ) -> Profile:
     """The profile, with its adapter's options parsed as that adapter declares them.
 
@@ -320,7 +445,9 @@ def parse_profile_options(
     tell, since an adapter's constructor takes supersets of what it declares
     and drops the rest in silence.
 
-    Raises: HarlequinConfigError, naming the option and the adapter.
+    Raises: HarlequinConfigError, naming the option and the adapter -- unless a
+    `Problems` is there to record every one of them instead, in which case the
+    profile comes back the way it went in.
     """
     declared = {sluggify_option_name(o.name): o for o in adapter_options or []}
     given = {
@@ -336,9 +463,16 @@ def parse_profile_options(
             given, _adapter_options_model(adapter, declared), strict=False
         )
     except msgspec.ValidationError as e:
-        raise _refuse_option(
+        found = _option_problems(
             e, adapter=adapter, declared=declared, given=given, allowed=command_options
-        ) from e
+        )
+        if problems is None:
+            # the first of them: this caller is on its way to a connection, and
+            # will not get to the second
+            raise HarlequinConfigError(found[0][1], title=CONFIG_ERROR_TITLE) from e
+        for key, message in found:
+            problems.add(message, key=key)
+        return profile
 
     return {**profile, **{key: getattr(parsed, key) for key in given}}
 
@@ -454,7 +588,62 @@ def _search_directories() -> Iterator[tuple[Path, tuple[str, ...]]]:
     yield Path.home(), ("harlequin.toml", ".harlequin.toml", "pyproject.toml")
 
 
-def _read_config_files(config_path: Path | None) -> Iterator[tuple[Path, Config]]:
+def _validate_profile(
+    profile: Profile,
+    *,
+    adapter_options: Callable[[str], Sequence[AbstractOption] | None],
+    command_options: Collection[str],
+    problems: Problems,
+) -> None:
+    """One profile through the second pass, under the adapter it would run.
+
+    Which is the one it names, or the default -- the pairing `hsql -P name`
+    runs, so a key reported here is a key that invocation would refuse.
+    """
+    adapter = profile.get("adapter") or DEFAULT_ADAPTER
+    if not isinstance(adapter, str):
+        problems.add(
+            f"Profile names an adapter that is not a name: {adapter!r}.", key="adapter"
+        )
+        return
+    try:
+        declared = adapter_options(adapter)
+    except HarlequinConfigError as e:
+        problems.add(e.msg, key="adapter")
+        return
+    parse_profile_options(
+        profile,
+        adapter=adapter,
+        adapter_options=declared,
+        command_options=command_options,
+        problems=problems,
+    )
+
+
+def _validate_keymap(
+    name: str, bindings: list[dict[str, Any]], *, problems: Problems
+) -> None:
+    """One keymap through the check the IDE runs when it next starts."""
+    try:
+        HarlequinKeyMap.from_config(
+            name=name, bindings=cast("list[RawKeyBinding]", bindings)
+        )
+    except HarlequinConfigError as e:
+        problems.add(e.msg)
+
+
+_TOML_LINE = re.compile(r"\(at line (\d+)")
+
+
+def _line_in(message: str) -> int | None:
+    """The line a TOML parse error points at, where its message points at one."""
+    match = _TOML_LINE.search(message)
+    return int(match.group(1)) if match else None
+
+
+def _read_config_files(
+    config_path: Path | None, *, problems: Problems | None = None
+) -> Iterator[tuple[Path, Config]]:
     """Each discovered config file, nearest first, validated as it is read.
 
     Paired with the path it was read from, because that is what every message
@@ -462,28 +651,44 @@ def _read_config_files(config_path: Path | None) -> Iterator[tuple[Path, Config]
 
     A generator, so a caller that has what it needs stops here: a file it never
     reaches is never opened, parsed or validated. A file with no section of ours
-    in it is not yielded at all: it was read, but it defines nothing.
+    in it is not yielded at all: it was read, but it defines nothing. With a
+    `Problems`, neither is a file that could not be read -- it is an entry in
+    there, and the walk goes on to the next file.
     """
     for path in _discover_config_files(config_path):
-        raw = ConfigFile(path).relevant_config
-        if raw:
-            yield path, _parse_config(raw, path=path)
+        raw = ConfigFile(path, problems=problems).relevant_config
+        if not raw:
+            continue
+        config = _parse_config(raw, path=path, problems=problems)
+        if config is not None:
+            yield path, config
 
 
-def _parse_config(raw: Mapping[str, Any], *, path: Path) -> Config:
-    """One file's config, or a HarlequinConfigError naming that file."""
+def _parse_config(
+    raw: Mapping[str, Any], *, path: Path, problems: Problems | None = None
+) -> Config | None:
+    """One file's config, or a HarlequinConfigError naming that file.
+
+    None, and an entry in `problems`, where there is one to record it in.
+    """
+
+    def refuse(message: str, *, key: str = "") -> None:
+        if problems is None:
+            raise _refuse(path, f"{message}, at {key}." if key else f"{message}.")
+        problems.at(path).add(message, key=key)
+
     try:
         config = msgspec.convert(raw, Config)
     except msgspec.ValidationError as e:
         message, key = _in_toml_words(e)
-        raise _refuse(path, f"{message}, at {key}." if key else f"{message}.") from e
+        refuse(message, key=key)
+        return None
 
     if "None" in config.profiles:
         # the name a caller passes to mean "none of them", so a profile cannot
         # have it: `harlequin -P None` would be ambiguous
-        raise _refuse(
-            path, "Config file defines a profile named 'None', which is not allowed."
-        )
+        refuse("Config file defines a profile named 'None', which is not allowed")
+        return None
     return config
 
 
@@ -517,11 +722,15 @@ def _merge(
         into.keymaps.setdefault(keymap_name, bindings)
 
 
-def _select_profile(config: Config, *, requested: str | None) -> Profile:
+def _select_profile(
+    config: Config, *, requested: str | None, problems: Problems | None = None
+) -> Profile:
     """The profile a name resolves to, once every file has had its say.
 
     A `default_profile` that names nothing is only an error for an invocation
-    that was going to use it: `-P other` has overridden the key.
+    that was going to use it: `-P other` has overridden the key. It is the one
+    problem no single file has, so it is also the one a `Problems` collects
+    here rather than in the pass over a file.
     """
     name = requested or config.default_profile
     if name is None or name == "None":
@@ -529,16 +738,21 @@ def _select_profile(config: Config, *, requested: str | None) -> Profile:
     if (profile := config.profiles.get(name, None)) is not None:
         return profile
     if requested is not None:
+        # a name typed at the command line rather than written in a file, so
+        # there is nowhere to record it and nobody to read it there
         raise HarlequinConfigError(
             f"Could not load the profile named {name} because it does not exist in "
             "any discovered config files.",
             title="Harlequin couldn't load your profile.",
         )
-    raise HarlequinConfigError(
+    message = (
         f"Config files set the default_profile to {name}, but no config file defines "
-        "a profile with that name.",
-        title=CONFIG_ERROR_TITLE,
+        "a profile with that name."
     )
+    if problems is None:
+        raise HarlequinConfigError(message, title=CONFIG_ERROR_TITLE)
+    problems.add(message, key="default_profile")
+    return {}
 
 
 def _adapter_options_model(
@@ -604,32 +818,48 @@ def _refuse(path: Path, message: str) -> HarlequinConfigError:
     )
 
 
-def _refuse_option(
+def _option_problems(
     error: msgspec.ValidationError,
     *,
     adapter: str,
     declared: Mapping[str, AbstractOption],
     given: Mapping[str, Any],
     allowed: Collection[str],
-) -> HarlequinConfigError:
-    """An option this adapter does not declare, or a value it cannot take."""
+) -> list[tuple[str, str]]:
+    """`(key, message)` per option this adapter does not take.
+
+    Every unknown key rather than the one msgspec stopped at: they are all in
+    hand here, and a profile with three typos in it is a profile whose author
+    would rather learn about three typos than about one, twice.
+    """
     if unknown := sorted(set(given) - set(declared)):
-        # from either set: `read-only` is a near miss for an adapter's option,
-        # and `keymap_names` for one of the command's own
-        suggestion = get_close_matches(unknown[0], [*declared, *allowed], n=1)
-        return HarlequinConfigError(
-            f"Profile defines an option {unknown[0]!r}, which is not an option of the "
-            f"{adapter} adapter."
-            + (f" Did you mean {suggestion[0]!r}?" if suggestion else ""),
-            title=CONFIG_ERROR_TITLE,
-        )
+        # suggestions come from either set: `read-only` is a near miss for an
+        # adapter's option, and `keymap_names` for one of the command's own
+        near = [*declared, *allowed]
+        return [
+            (
+                key,
+                f"Profile defines an option {key!r}, which is not an option of the "
+                f"{adapter} adapter." + _suggestion(key, near),
+            )
+            for key in unknown
+        ]
     message, key = _in_toml_words(error)
     choices = _declared_choices(declared[key]) if key in declared else None
-    return HarlequinConfigError(
-        f"Profile sets {key} to a value the {adapter} adapter cannot take: {message}."
-        + (f"\nAllowed values are {tuple(choices)}." if choices else ""),
-        title=CONFIG_ERROR_TITLE,
-    )
+    return [
+        (
+            key,
+            f"Profile sets {key} to a value the {adapter} adapter cannot take: "
+            f"{message}."
+            + (f"\nAllowed values are {tuple(choices)}." if choices else ""),
+        )
+    ]
+
+
+def _suggestion(key: str, among: Sequence[str]) -> str:
+    """The nearest spelling to `key`, as a sentence, or nothing like it."""
+    match = get_close_matches(key, among, n=1)
+    return f" Did you mean {match[0]!r}?" if match else ""
 
 
 _TOML_WORDS = {

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -317,27 +317,28 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         sources: list[tuple[str, tuple[str, ...]]] = ctx.meta.get(SOURCES, [])
 
         if config_mode is not None:
-            _report_config(
-                ctx,
-                config_mode,
-                config_path=config_path,
-                sources=sources,
-                destination=destination,
-                format_name=format_name,
-                # a shorthand flag and a profile's `format` key are choices
-                # too, and the note exists to explain a format that had no
-                # effect however it was asked for
-                format_chosen=format_name != DEFAULT_FORMAT
-                or "format" in explicitly_set,
-                display_rows=raw_display_rows,
-                tuples_only=tuples_only,
-                no_align=no_align,
-                no_header=no_header,
-                no_footer=no_footer,
-                null_string=null_string,
-                color=_use_color(color_when, destination),
+            ctx.exit(
+                _report_config(
+                    ctx,
+                    config_mode,
+                    config_path=config_path,
+                    sources=sources,
+                    destination=destination,
+                    format_name=format_name,
+                    # a shorthand flag and a profile's `format` key are choices
+                    # too, and the note exists to explain a format that had no
+                    # effect however it was asked for
+                    format_chosen=format_name != DEFAULT_FORMAT
+                    or "format" in explicitly_set,
+                    display_rows=raw_display_rows,
+                    tuples_only=tuples_only,
+                    no_align=no_align,
+                    no_header=no_header,
+                    no_footer=no_footer,
+                    null_string=null_string,
+                    color=_use_color(color_when, destination),
+                )
             )
-            ctx.exit(ExitCode.OK)
 
         if not sources:
             diagnostics.error(
@@ -475,13 +476,16 @@ def _report_config(
     format_chosen: bool,
     display_rows: Any,
     **output_options: Any,
-) -> None:
-    """Answer a `--config MODE` and return, or exit having said why not.
+) -> ExitCode:
+    """Answer a `--config MODE` and return its code, or exit having said why not.
 
     A mode does not run SQL, so `-c` or `-f` beside one is two invocations
     spelled as one, and refusing is the safer half of the choice: answering the
     config question and dropping the query would leave a script believing it had
     run one.
+
+    The code is the mode's own: `--config validate` exits 2 for a config it
+    found something wrong with, and the modes that only report exit 0.
     """
     if sources:
         diagnostics.error(
@@ -500,7 +504,7 @@ def _report_config(
             format_name=format_name, display_limit=display_limit, **output_options
         )
         with _sink(destination) as out:
-            config_mode.report(
+            code = config_mode.report(
                 mode,
                 out,
                 config_path=config_path,
@@ -515,6 +519,7 @@ def _report_config(
         # Both are the caller's to fix, and both are usage errors.
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
+    return code
 
 
 def bare_command() -> click.Command:

--- a/src/harlequin/hsql/modes/__init__.py
+++ b/src/harlequin/hsql/modes/__init__.py
@@ -13,9 +13,9 @@ import.
 
 from __future__ import annotations
 
-CONFIG_MODES = ("show", "list-profiles")
+CONFIG_MODES = ("show", "list-profiles", "validate")
 """Every `--config MODE`, in the order `--help` lists them.
 
-`validate`, `schema` and `init` join this list as they land; a mode that is not
-here is one click refuses by name, with the ones that do work in the message.
+`schema` and `init` join this list as they land; a mode that is not here is one
+click refuses by name, with the ones that do work in the message.
 """

--- a/src/harlequin/hsql/modes/config.py
+++ b/src/harlequin/hsql/modes/config.py
@@ -1,16 +1,20 @@
-"""`--config MODE`: what the config files say, and which file said it.
+"""`--config MODE`: what the config files say, which file said it, and what is wrong.
 
-Two questions, and they are the two a caller actually has. `list-profiles`
+Three questions, and they are the three a caller actually has. `list-profiles`
 answers *what can I pass to `-P`* -- a short list of names, so a profile that a
 nearer file quietly displaced is visible as a name that is missing. `show`
 answers *which file is winning* -- the merged document, with the file each
 value came from written beside it, and the files it overrode written after
-that.
+that. `validate` answers *what is wrong with any of it* -- every problem in
+every file, one to a row, where a run would have stopped at the first.
 
-Neither connects, and neither imports an adapter: a mode that reports on config
-files must work when the database does not. `show` does not import the
-execution core either -- it writes a document, not rows -- which is why the two
-imports `list-profiles` needs are deferred into it.
+None of them connects. `show` and `list-profiles` import no adapter either: a
+mode that reports on config files must work when the database does not.
+`validate` is the exception, and it is the trade its job asks for -- checking a
+profile's options against the ones its adapter declares takes importing that
+adapter, one per adapter a profile names, and still no connection. `show` does
+not import the execution core either -- it writes a document, not rows -- which
+is why the two imports the row-shaped modes need are deferred into them.
 
 The renderings are the merge, told two ways: TOML for a person, because that is
 the language they will edit the answer in, and JSON for a caller, under the same
@@ -20,10 +24,11 @@ the language they will edit the answer in, and JSON for a caller, under the same
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, BinaryIO, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Mapping, Sequence
 
 from harlequin.config import Provenance, load_config
 from harlequin.hsql import diagnostics
+from harlequin.hsql.diagnostics import ExitCode
 from harlequin.hsql.modes import CONFIG_MODES
 
 if TYPE_CHECKING:
@@ -33,8 +38,9 @@ if TYPE_CHECKING:
 
     from harlequin.config import Config
     from harlequin.layout import LayoutOptions
+    from harlequin.options import AbstractOption
 
-SHOW, LIST_PROFILES = CONFIG_MODES
+SHOW, LIST_PROFILES, VALIDATE = CONFIG_MODES
 
 JSON = "json"
 """The one `--format` a document mode answers to. `none` writes nothing."""
@@ -51,13 +57,28 @@ def report(
     format_chosen: bool,
     layout_options: LayoutOptions,
     file_options: Mapping[str, Any],
-) -> None:
-    """Write one `--config` mode's answer to an open binary stream.
+) -> ExitCode:
+    """Write one `--config` mode's answer, and return the code it exits with.
+
+    A code rather than nothing, because one of these modes is a check: a script
+    that runs `hsql --config validate` wants the answer without reading it, and
+    an exit code is how it gets one. The other two exit 0 whatever they found --
+    reporting a config is not judging it.
 
     Raises: HarlequinConfigError if a discovered config file cannot be read.
-    Every mode here reads every file, so a broken one is reported rather than
-    skipped -- `--config validate` is the mode that reports all of them at once.
+    `show` and `list-profiles` read every file, so a broken one is fatal to
+    them; `validate` is the mode that reports it as one problem among however
+    many the rest of the files hold.
     """
+    if mode == VALIDATE:
+        return _write_problems(
+            config_path,
+            out,
+            format_name=format_name,
+            layout_options=layout_options,
+            file_options=file_options,
+        )
+
     provenance = Provenance()
     config = load_config(config_path, provenance=provenance)
 
@@ -78,6 +99,7 @@ def report(
             layout_options=layout_options,
             file_options=file_options,
         )
+    return ExitCode.OK
 
 
 def _write_document(
@@ -145,6 +167,101 @@ def _write_profiles(
         out,
         layout_options=layout_options,
         file_options=file_options,
+    )
+
+
+def _write_problems(
+    config_path: Path | None,
+    out: BinaryIO,
+    *,
+    format_name: str,
+    layout_options: LayoutOptions,
+    file_options: Mapping[str, Any],
+) -> ExitCode:
+    """Every problem in every config file, as rows, and a code that says so.
+
+    Rows because a problem is four facts -- the file, the key it is written
+    under, what is wrong, and the line where the parser knew one -- and four
+    facts in a shape is what `-tA` and `--json` are already for. Ordered by
+    file, nearest first, because a report about files is one a reader walks
+    through alongside them.
+
+    Exit 2 when there is anything to report, which is the code a config problem
+    already has. That is what makes this mode usable without reading it:
+    `hsql --config validate --format none` is the whole check.
+    """
+    # deferred, each for its own reason: the row machinery is pyarrow, which
+    # `--config show` must not pay for, and `validate_config_files` reaches for
+    # an adapter per profile, which nothing else in this module does.
+    from harlequin.config import validate_config_files
+    from harlequin.hsql import output
+    from harlequin.query import rows_to_result
+
+    provenance = Provenance()
+    problems = validate_config_files(
+        config_path,
+        adapter_options=_adapter_options(),
+        command_options=_command_options(),
+        provenance=provenance,
+    )
+    if not problems and not provenance.files:
+        # a clean report and no config files read the same on stdout, and they
+        # are not the same answer. The one that found nothing to check says so.
+        diagnostics.note("No config file defines anything hsql reads.")
+
+    rows = [
+        (
+            str(problem.path),
+            problem.key,
+            problem.message,
+            None if problem.line is None else str(problem.line),
+        )
+        for problem in problems
+    ]
+    output.write(
+        rows_to_result(["file", "key", "problem", "line"], rows),
+        format_name,
+        out,
+        layout_options=layout_options,
+        file_options=file_options,
+    )
+    return ExitCode.USAGE if problems else ExitCode.OK
+
+
+def _adapter_options() -> Callable[[str], Sequence[AbstractOption] | None]:
+    """A way to ask what one adapter declares, importing each of them once.
+
+    The cache is per invocation rather than per process: four profiles naming
+    duckdb is one import, and a second call in the same interpreter -- which is
+    every test, and no `hsql` -- gets to see whatever is installed then.
+    """
+    from harlequin.plugins import load_adapter
+
+    declared: dict[str, Sequence[AbstractOption] | None] = {}
+
+    def options(name: str) -> Sequence[AbstractOption] | None:
+        if name not in declared:
+            # raises for a name nothing installed provides, which the validator
+            # records against the profile that named it
+            declared[name] = load_adapter(name).ADAPTER_OPTIONS
+        return declared[name]
+
+    return options
+
+
+def _command_options() -> set[str]:
+    """Every profile key a command reads for itself, so neither is an adapter's.
+
+    hsql's own, from the command it builds when it is asked for nothing, plus
+    the IDE's -- one profile serves both, and a profile written for the IDE has
+    to validate here or `--config validate` would report the other command's
+    config as broken.
+    """
+    from harlequin.config import TUI_ONLY_KEYS
+    from harlequin.hsql.cli import bare_command
+
+    return {param.name for param in bare_command().params if param.name} | set(
+        TUI_ONLY_KEYS
     )
 
 

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable, Sequence
 
 import pytest
 
@@ -8,6 +9,7 @@ from harlequin.config import (
     TUI_ONLY_KEYS,
     Config,
     ConfigFile,
+    ConfigProblem,
     Profile,
     Provenance,
     _discover_config_files,
@@ -19,10 +21,17 @@ from harlequin.config import (
     merge_profile_with_cli,
     parse_profile_options,
     parse_row_count,
+    validate_config_files,
 )
 from harlequin.exception import HarlequinConfigError
 from harlequin.keymap import HarlequinKeyBinding, HarlequinKeyMap
-from harlequin.options import FlagOption, ListOption, SelectOption, TextOption
+from harlequin.options import (
+    AbstractOption,
+    FlagOption,
+    ListOption,
+    SelectOption,
+    TextOption,
+)
 
 
 @pytest.mark.parametrize("filename", ["good_config.toml", "pyproject.toml"])
@@ -794,3 +803,154 @@ class TestProvenance:
         assert load_config(config_path=None) == load_config(
             config_path=None, provenance=Provenance()
         )
+
+
+class TestValidatingEveryConfigFile:
+    """`validate_config_files()`: the reader a problem does not stop.
+
+    Every other reader here raises at the first thing it cannot use, because it
+    is on its way to a database. This one is not going anywhere, so it opens
+    every file and reports what each of them says.
+    """
+
+    OPTIONS: list[AbstractOption] = [
+        FlagOption(name="read_only", description="x"),
+        TextOption(name="port", description="x"),
+    ]
+    COMMAND_OPTIONS = {"adapter", "conn_str", "limit", *TUI_ONLY_KEYS}
+
+    def validate(
+        self,
+        adapter_options: Callable[[str], Sequence[AbstractOption] | None] | None = None,
+    ) -> list[ConfigProblem]:
+        return validate_config_files(
+            None,
+            adapter_options=adapter_options or (lambda _: self.OPTIONS),
+            command_options=self.COMMAND_OPTIONS,
+        )
+
+    def test_a_config_with_nothing_wrong_has_nothing_to_report(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        cwd, home = config_dirs
+        (home / ".harlequin.toml").write_text(
+            'default_profile = "prod"\n[profiles.prod]\nread_only = true\nlimit = 10\n'
+        )
+        (cwd / ".harlequin.toml").write_text("[profiles.dev]\nport = 5432\n")
+
+        assert self.validate() == []
+
+    def test_a_file_it_cannot_parse_does_not_end_the_run(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """The difference from every other reader, in one assertion.
+
+        `load_config()` raises at the first file here and never opens the second
+        one; this reports the file it could not parse *and* what is wrong with
+        the one behind it.
+        """
+        cwd, home = config_dirs
+        (cwd / ".harlequin.toml").write_text("this is not toml\n")
+        (home / ".harlequin.toml").write_text("[profiles.prod]\nreed_only = true\n")
+
+        with pytest.raises(HarlequinConfigError):
+            load_config(config_path=None)
+
+        assert [problem.path for problem in self.validate()] == [
+            cwd / ".harlequin.toml",
+            home / ".harlequin.toml",
+        ]
+
+    def test_the_parser_is_the_only_thing_that_knows_a_line(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """A line where tomllib gave one, and none where nothing did.
+
+        A number that was not read out of a parser is a number a reader goes to
+        and finds nothing at.
+        """
+        cwd, home = config_dirs
+        (cwd / ".harlequin.toml").write_text('[profiles.prod]\nport = "5432"\noops\n')
+        (home / ".harlequin.toml").write_text("[profiles.dev]\nreed_only = true\n")
+
+        unparseable, unknown_option = self.validate()
+        assert unparseable.line == 3
+        assert unparseable.key is None
+        assert unknown_option.line is None
+
+    def test_a_profile_is_checked_in_every_file_that_defines_it(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """What validating before merging buys, and why it is per file.
+
+        The nearer file supplies `shared` whole, so the home file's copy of it
+        is not what any invocation runs -- and it is still a table its author
+        will edit, so it is still worth being told about.
+        """
+        cwd, home = config_dirs
+        (home / ".harlequin.toml").write_text("[profiles.shared]\nreed_only = true\n")
+        (cwd / ".harlequin.toml").write_text("[profiles.shared]\nread_only = true\n")
+
+        (problem,) = self.validate()
+        assert problem.path == home / ".harlequin.toml"
+        assert problem.key == "profiles.shared.reed_only"
+
+    def test_every_unknown_option_in_a_profile_is_reported(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """A profile with three typos has three problems, not one, twice."""
+        cwd, _ = config_dirs
+        (cwd / ".harlequin.toml").write_text(
+            "[profiles.prod]\nreed_only = true\nprt = 5432\nhost = 'localhost'\n"
+        )
+
+        assert [problem.key for problem in self.validate()] == [
+            "profiles.prod.host",
+            "profiles.prod.prt",
+            "profiles.prod.reed_only",
+        ]
+
+    def test_an_adapter_that_will_not_load_belongs_to_the_profile(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """A name nothing installed provides ends the profile, not the report."""
+        cwd, _ = config_dirs
+        (cwd / ".harlequin.toml").write_text(
+            '[profiles.gone]\nadapter = "no-such-adapter"\n'
+            "[profiles.fine]\nread_only = true\n"
+        )
+
+        def options(name: str) -> Sequence[AbstractOption] | None:
+            if name == "no-such-adapter":
+                raise HarlequinConfigError("No installed plug-in provides one.")
+            return self.OPTIONS
+
+        (problem,) = self.validate(adapter_options=options)
+        assert problem.key == "profiles.gone.adapter"
+
+    def test_a_default_that_names_no_profile_belongs_to_the_merge(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """Reported against the file that set the key, which the merge knows.
+
+        No single file is wrong here -- naming a profile another file defines is
+        exactly what `default_profile` is for -- so it is the one check that
+        waits until every file has been read.
+        """
+        cwd, home = config_dirs
+        (home / ".harlequin.toml").write_text('default_profile = "gone"\n')
+        (cwd / ".harlequin.toml").write_text("[profiles.here]\nread_only = true\n")
+
+        (problem,) = self.validate()
+        assert problem.path == home / ".harlequin.toml"
+        assert problem.key == "default_profile"
+        assert "gone" in problem.message
+
+    def test_a_default_a_farther_file_defines_is_not_a_problem(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        cwd, home = config_dirs
+        (cwd / ".harlequin.toml").write_text('default_profile = "prod"\n')
+        (home / ".harlequin.toml").write_text("[profiles.prod]\nread_only = true\n")
+
+        assert self.validate() == []

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -1142,10 +1142,10 @@ def test_config_show_reads_a_profile_it_was_not_asked_about(
 def test_config_reports_a_file_it_cannot_read(
     hsql: Hsql, config_dirs: tuple[Path, Path]
 ) -> None:
-    """Every mode here reads every file, so a broken one is fatal to all of it.
+    """`show` reads every file, so a broken one is fatal to it.
 
-    `--config validate` is the mode that will report every problem at once;
-    this one stops at the first, and names the file either way.
+    `--config validate` is the mode that reports every problem at once; this
+    one stops at the first, and names the file either way.
     """
     cwd, _ = config_dirs
     (cwd / ".harlequin.toml").write_text("this is not toml\n")
@@ -1171,10 +1171,11 @@ def test_config_refuses_to_also_run_sql(
 
 
 def test_an_unknown_config_mode_lists_the_ones_that_work(hsql: Hsql) -> None:
-    res = hsql("--config", "validate")
+    res = hsql("--config", "schema")
     assert res.exit_code == ExitCode.USAGE
     assert "show" in res.stderr
     assert "list-profiles" in res.stderr
+    assert "validate" in res.stderr
 
 
 def test_config_modes_are_what_the_help_offers(hsql: Hsql) -> None:
@@ -1215,3 +1216,261 @@ def test_config_show_writes_a_keymap_as_the_array_it_is(
         'keys = "ctrl+k"\n'
         'action = "cursor_up"\n'
     )
+
+
+# --- `--config validate`, the mode that reports every problem ----------------
+
+
+def test_config_validate_finds_nothing_wrong_with_a_good_config(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    """Zero problems is zero rows, and the code a script actually reads."""
+    res = hsql("--config", "validate")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == (
+        " file | key | problem | line\n------+-----+---------+------\n(0 rows)\n"
+    )
+
+
+def test_config_validate_exits_two_for_a_config_it_found_a_problem_in(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """The whole mode, for a caller that never reads the rows.
+
+    `--format none` is the spelling that says so out loud: no stdout at all,
+    and the answer in the exit code.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "duckdb"\nreed_only = true\n'
+    )
+    res = hsql("--config", "validate", "--format", "none")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+
+
+def test_config_validate_names_the_file_the_key_and_the_option(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """Pass 2, which is the surface nothing else in the stack validates.
+
+    `reed_only = true` reaches the adapter's constructor and is dropped there
+    in silence, leaving a caller who believes they are connected read-only.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "duckdb"\nreed_only = true\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    file, key, problem, line = res.stdout.strip().split("|")
+    assert file == str(cwd / ".harlequin.toml")
+    assert key == "profiles.prod.reed_only"
+    assert "duckdb" in problem
+    assert "read_only" in problem  # the spelling it was probably meant to be
+    assert line == "NULL"
+
+
+def test_config_validate_reports_every_file_and_keeps_reading(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """The mode's whole reason to exist, in the shape it is worst at.
+
+    A file it cannot parse stops `show` dead. Here it is one row, and the file
+    behind it is read, validated and reported on anyway -- which is what the
+    per-file validation in front of the merge buys.
+    """
+    cwd, home = config_dirs
+    (cwd / ".harlequin.toml").write_text("this is not toml\n")
+    (home / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "sqlite"\nreed_only = true\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    first, second = res.stdout.splitlines()
+    assert first.startswith(str(cwd / ".harlequin.toml"))
+    assert second.startswith(str(home / ".harlequin.toml"))
+
+
+def test_config_validate_names_the_line_when_the_parser_named_one(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """Where the parser gives a position, and nowhere else.
+
+    A key we merely dislike has no position anywhere, and a number that was not
+    read out of a parser would send a reader to a line with nothing on it.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text('[profiles.prod]\nadapter = "duckdb"\noops\n')
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    file, key, _, line = res.stdout.strip().split("|")
+    assert file == str(cwd / ".harlequin.toml")
+    assert key == "NULL"  # the problem is the file, not something in it
+    assert line == "3"
+
+
+def test_config_validate_reports_a_profile_the_merge_hides(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """One entry per file per problem, which is what validating first buys.
+
+    The nearer file supplies `shared` whole, so no invocation runs the home
+    file's copy of it -- and its author will still open that file to fix it.
+    """
+    cwd, home = config_dirs
+    (home / ".harlequin.toml").write_text("[profiles.shared]\nreed_only = true\n")
+    (cwd / ".harlequin.toml").write_text("[profiles.shared]\nread_only = true\n")
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout.startswith(
+        f"{home / '.harlequin.toml'}|profiles.shared.reed_only"
+    )
+
+
+def test_config_validate_reports_a_default_that_names_nothing(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """Where `list-profiles` notes it, this one fails on it.
+
+    Nothing about the key is more wrong here -- it is the same broken default.
+    The difference is what each mode was asked: one for a list of names, and
+    this one for whether the config is any good.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        'default_profile = "gone"\n[profiles.here]\nadapter = "sqlite"\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    file, key, problem, _ = res.stdout.strip().split("|")
+    assert file == str(cwd / ".harlequin.toml")
+    assert key == "default_profile"
+    assert "gone" in problem
+
+
+def test_config_validate_accepts_a_profile_written_for_the_ide(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """Valid is a union of three sets, and getting it wrong breaks working configs.
+
+    One profile serves both commands, so the IDE's keys are as legal here as
+    hsql's own and the adapter's -- and a value may arrive uncast, because the
+    adapter contract says it may: `port = 5432` and `port = "5432"` are the
+    same option written two ways a TOML file invites.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        "[profiles.ide]\n"
+        'adapter = "sqlite"\n'  # the adapter's own
+        "read_only = true\n"
+        "limit = 100\n"  # a key both commands read
+        'theme = "nord"\n'  # a key only the IDE reads
+        'keymap_name = ["vscode"]\n'
+        "[profiles.uncast]\n"
+        'adapter = "postgres"\n'
+        "port = 5432\n"
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+
+
+def test_config_validate_reports_an_adapter_nothing_installs(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """A profile whose adapter cannot be loaded is one profile's problem.
+
+    It cannot be checked any further -- there are no declared options to check
+    it against -- and the file's other profiles still can be.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.gone]\nadapter = "no-such-adapter"\n'
+        '[profiles.fine]\nadapter = "sqlite"\nread_only = true\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    (row,) = res.stdout.splitlines()
+    assert row.split("|")[1] == "profiles.gone.adapter"
+    assert "no-such-adapter" in row
+
+
+def test_config_validate_reports_a_keymap_the_ide_would_refuse(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """A keymap is checked here rather than when the IDE next starts."""
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[[keymaps.mine]]\nkeys = "ctrl+j"\naction = "cursor_down"\noops = 1\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout.split("|")[1] == "keymaps.mine"
+
+
+def test_config_validate_writes_one_line_per_problem(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """A problem is a row, and a row is a line.
+
+    Some of these messages are written over two lines when they are raised at a
+    caller; folded into a cell they would arrive as two rows in every format
+    that does not quote its cells.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "sqlite"\nmode = "reed-only"\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    (row,) = res.stdout.splitlines()
+    assert "Allowed values" in row
+
+
+def test_config_validate_is_json_for_a_caller(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """Four facts per problem, under the same --json as everywhere else."""
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "duckdb"\nreed_only = true\n'
+    )
+    res = hsql("--config", "validate", "--json")
+    assert res.exit_code == ExitCode.USAGE
+    (problem,) = json.loads(res.stdout)
+    assert problem["file"] == str(cwd / ".harlequin.toml")
+    assert problem["key"] == "profiles.prod.reed_only"
+    assert problem["line"] is None
+    assert "duckdb" in problem["problem"]
+
+
+def test_config_validate_says_when_there_was_nothing_to_check(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """A clean config and no config at all read the same on stdout.
+
+    They are not the same answer, and the one that found nothing to check is
+    the one a caller would otherwise mistake for a passing check.
+    """
+    res = hsql("--config", "validate")
+    assert res.exit_code == ExitCode.OK
+    assert "No config file defines anything" in res.stderr
+
+
+def test_config_validate_does_not_connect(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """It reads a declaration, not a database.
+
+    A profile pointing at a file that is not there is exactly the config a
+    caller runs this mode on, and needing the database to check the config
+    would make the mode useless where it is most wanted.
+    """
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        '[profiles.prod]\nadapter = "sqlite"\nconn_str = ["/no/such/dir/db.sqlite"]\n'
+    )
+    res = hsql("--config", "validate", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -9,6 +9,7 @@ which is the only way to prove a deferral actually defers.
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from typing import Callable
 
 import pytest
@@ -188,6 +189,42 @@ def test_the_config_modes_import_no_database(
     )
     leaked = [m for m in proc.stderr.strip().replace("\n", ",").split(",") if m]
     assert not leaked, f"`hsql --config {mode}` imported {leaked}"
+
+
+def test_config_validate_imports_only_the_adapters_its_profiles_name(
+    tmp_path: Path, run_python: Callable[[str], subprocess.CompletedProcess[str]]
+) -> None:
+    """The one mode here that pays for adapters, paying for as few as it can.
+
+    Checking a profile's options against the ones its adapter declares takes
+    importing that adapter -- and only that one. A mode that imported every
+    installed adapter to check a config naming one would cost a caller with
+    four of them four times what the answer is worth. It is rows rather than a
+    document, so it pays for pyarrow and not for tomlkit, like `list-profiles`.
+
+    `tmp_path` is the subprocess's cwd and its home, so this file is the whole
+    of the config it discovers.
+    """
+    (tmp_path / ".harlequin.toml").write_text(
+        '[profiles.lite]\nadapter = "sqlite"\nread_only = true\n'
+    )
+    proc = run_python(
+        "import sys\n"
+        "sys.argv = ['hsql', '--config', 'validate']\n"
+        "from harlequin.hsql import main\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print(','.join(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith('harlequin_')})), file=sys.stderr)\n"
+        "print(','.join(m for m in ('duckdb', 'tomlkit') if m in sys.modules), "
+        "file=sys.stderr)\n"
+    )
+    # two lines, and the second is empty when nothing forbidden was imported
+    adapters, forbidden = proc.stderr.split("\n")[:2]
+    assert adapters == "harlequin_sqlite"
+    assert not forbidden
 
 
 def test_public_names_still_resolve() -> None:


### PR DESCRIPTION
Implements PR3 of M2 of the hsql plan.

**What** are the key elements of this solution?

This PR adds a new `--config validate` mode that checks all discovered config files for problems without connecting to a database or running SQL. The implementation includes:

1. **New data structures** (`ConfigProblem`, `Problems`) to collect validation errors instead of raising exceptions
2. **Enhanced config reading** to accept an optional `Problems` collector, allowing files to be read and validated even when errors occur
3. **New validation function** (`validate_config_files()`) that performs two passes over config files:
   - Pass 1: Validates file structure and shape before merging
   - Pass 2: Validates each profile's options against its adapter's declared options
4. **New CLI mode** that reports all problems as rows (compatible with `-tA`, `--json`, etc.)
5. **Adapter loading** only for adapters actually named in profiles, minimizing import overhead

**Why** did you design your solution this way?

The solution reuses existing validation logic rather than duplicating it. Every other config reader raises at the first problem because it's heading to a database connection. This mode is different—it collects all problems and reports them together, which is more useful for users fixing config files.

Key design decisions:

- **Per-file validation before merge**: Validates each file independently before merging, so users see problems in the files they'll edit, even if a nearer file displaces that profile
- **Adapter-on-demand loading**: Only imports adapters that profiles actually name, avoiding the cost of loading all installed adapters
- **Reused validation code**: Both passes use the same code paths as the normal startup flow, ensuring consistency
- **Optional Problems parameter**: Existing callers pass `None` and get exceptions; the validate mode passes a `Problems` object and gets a list to report

**Does this PR require a change to Harlequin's docs?**
- [ ] No.
- [x] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

**Did you add or update tests for this change?**
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Added comprehensive test coverage including:
- Unit tests in `test_config.py` for `validate_config_files()` covering all validation scenarios
- Integration tests in `test_hsql.py` for the CLI mode with various output formats
- Import hygiene test ensuring only necessary adapters are loaded
- Tests verify the mode reports all problems, handles unparseable files, validates keymaps, and doesn't require database connectivity

**Checklist:**
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

https://claude.ai/code/session_019LRWmHbY27tukZ9jomDK6p