### PR TITLE
Drop pandas and pandas-stubs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,11 @@ uv run harlequin [OPTIONS] [CONN_STR]              # run the CLI from source
 - Tests run under xdist (`-n auto` is in `addopts`). Pass `-n0` when using a debugger or `-s`.
 - Markers: `online` (needs network + secrets; always deselect locally), `py12` (only runs on 3.12+), `use_cache` (opts a test back into the buffer/catalog caches that an autouse fixture otherwise disables).
 - `TEST_MARKERS` in the Makefile is a marker *expression*, not a flag — a second `-m` silently overrides the first.
+- **On a fresh Linux container, generate the `en_US.UTF-8` locale before the first test run.** A session-scoped autouse fixture (`tests/conftest.py::set_locale_to_enUS`) calls `set_locale("en_US.UTF-8")`, and an image that ships only `C`/`POSIX` (check with `locale -a`) errors every test in setup with `locale.Error: unsupported locale setting`. One command fixes it, and it is not a test failure to debug:
+
+```bash
+localedef -i en_US -f UTF-8 en_US.UTF-8   # prefix with sudo if you are not root
+```
 
 ## Testing notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Dependencies
 
 - Adds `msgspec`.
-- Drops `pandas`. It was declared on Python 3.14 only, to keep the resolver from building an old `pandas` sdist for a version it had no wheels for; it arrived transitively then, and no longer does — `textual-fastdatatable` dropped it in 0.17. No Harlequin code imports it.
+- Drops `pandas`. It was declared on Python 3.14 only, but is no longer required, since the DataTable component dropped it.
 
 ## [2.9.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Dependencies
 
 - Adds `msgspec`.
+- Drops `pandas`. It was declared on Python 3.14 only, to keep the resolver from building an old `pandas` sdist for a version it had no wheels for; it arrived transitively then, and no longer does — `textual-fastdatatable` dropped it in 0.17. No Harlequin code imports it.
 
 ## [2.9.0] - 2026-08-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
 
     # ensure we install from wheels
     "duckdb>=1.4.2; python_version >= '3.14'",
-    "pandas>=2.3; python_version >= '3.14'",
 ]
 
 
@@ -100,7 +99,6 @@ dev = [
 static = [
     "ruff>=0.14.1",
     "mypy==2.3.1,<3",
-    "pandas-stubs>=2,<3",
     "boto3-stubs>=1.34.23,<2",
     "import-linter>=2.5",
 ]

--- a/stubs/pyarrow/__init__.pyi
+++ b/stubs/pyarrow/__init__.pyi
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Iterator, Literal, Mapping, Sequence, Type, TypeVar
 
-import pandas as pd
-
 from .compute import CastOptions
 
 class DataType: ...
@@ -148,11 +146,9 @@ def nulls(
     memory_pool: MemoryPool | None = None,
 ) -> Array: ...
 def table(
-    data: (
-        pd.DataFrame
-        | Mapping[str, _PandasConvertible | list]
-        | list[_PandasConvertible]
-    ),
+    # pyarrow also accepts a pandas DataFrame here; Harlequin never builds one,
+    # and typing it would put pandas-stubs in the static group for one name.
+    data: Mapping[str, _PandasConvertible | list] | list[_PandasConvertible],
     names: list[str] | None = None,
     schema: Schema | None = None,
     metadata: Mapping | None = None,

--- a/uv.lock
+++ b/uv.lock
@@ -1316,7 +1316,6 @@ dependencies = [
     { name = "click" },
     { name = "duckdb" },
     { name = "msgspec" },
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
     { name = "platformdirs" },
     { name = "pyperclip" },
     { name = "questionary" },
@@ -1376,7 +1375,6 @@ static = [
     { name = "boto3-stubs" },
     { name = "import-linter" },
     { name = "mypy" },
-    { name = "pandas-stubs" },
     { name = "ruff" },
 ]
 test = [
@@ -1405,7 +1403,6 @@ requires-dist = [
     { name = "harlequin-postgres", marker = "extra == 'postgres'" },
     { name = "harlequin-trino", marker = "extra == 'trino'" },
     { name = "msgspec", specifier = ">=0.19,<1" },
-    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3" },
     { name = "platformdirs", specifier = ">=3.10,<5.0" },
     { name = "pyperclip", specifier = ">=1.9,<2" },
     { name = "questionary", specifier = "==2.1.1" },
@@ -1434,7 +1431,6 @@ static = [
     { name = "boto3-stubs", specifier = ">=1.34.23,<2" },
     { name = "import-linter", specifier = ">=2.5" },
     { name = "mypy", specifier = "==2.3.1,<3" },
-    { name = "pandas-stubs", specifier = ">=2,<3" },
     { name = "ruff", specifier = ">=0.14.1" },
 ]
 test = [
@@ -2592,20 +2588,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
-]
-
-[[package]]
-name = "pandas-stubs"
-version = "2.3.3.260113"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "types-pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
 ]
 
 [[package]]
@@ -4021,15 +4003,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2026.3.1.20260727"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/cf/eae96172a036b942e0ad0ec49512108b4ef4b97cd6c2aed5677540a597e7/types_pytz-2026.3.1.20260727.tar.gz", hash = "sha256:4364075b6867dd15b210bb8c1d29727d609917129b45600defe1d4b3eda5ecb9", size = 10914, upload-time = "2026-07-27T05:36:32.389Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/24/a654176875944981c75516857cd8750600eeb9ff7fc07a2b82573619a57c/types_pytz-2026.3.1.20260727-py3-none-any.whl", hash = "sha256:42ac44e83645bfceb46597342c8fb8ec028a1407e2feae9c5c539986eab6b57a", size = 10132, upload-time = "2026-07-27T05:36:31.52Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
No existing issue; opened directly.

**What** are the key elements of this solution?

- Removes `"pandas>=2.3; python_version >= '3.14'"` from `dependencies` and `"pandas-stubs>=2,<3"` from the `static` dependency group.
- Removes the one thing `pandas-stubs` existed for: `import pandas as pd` in the hand-written `stubs/pyarrow/__init__.pyi`, used once, for `pd.DataFrame` in the `data` union of the `pa.table()` stub. The union member goes with it, with a comment saying why.
- Relocks (`uv.lock` loses `pandas-stubs` and `types-pytz`) and adds a `CHANGELOG.md` entry under `[Unreleased]` → `Dependencies`.
- Separately, documents in `AGENTS.md` that a fresh Linux container needs `localedef -i en_US -f UTF-8 en_US.UTF-8` before the first test run — see below.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The `pandas` pin was never about Harlequin needing pandas. It was declared for Python 3.14 only, under the `# ensure we install from wheels` comment, to stop the resolver from picking an old `pandas` and building its sdist on a version with no cp314 wheels. That was a real problem while pandas arrived transitively — but `textual-fastdatatable` dropped it in 0.17, and 0.17.1 (what we pin) depends only on `pyarrow`, `textual`, `typing-extensions` and `tzdata`. With the pin gone, the only remaining `pandas` edge in the whole lock is `databricks-sql-connector → pandas`, which arrives through the `databricks` extra and not a default install. Nothing in `src/` or `tests/` imports pandas, so the pin's only effect today was installing ~12MB nobody reads. The `duckdb>=1.4.2` line under the same comment still earns it and stays.

For the stub, the alternative was keeping `pandas-stubs` for that single annotation. The only `pa.table()` call site (`harlequin/query.py:334`) passes a list of arrays, and these are minimal local stubs describing what Harlequin actually uses, so narrowing the union costs nothing and the accuracy note lives in a comment. If a future caller does build a DataFrame, mypy says so at that line and the union member comes back with the stubs.

The `AGENTS.md` addition is unrelated to the dependency change and rides along because it came out of running the suite here: `tests/conftest.py::set_locale_to_enUS` is session-scoped and autouse, so a container that ships only `C`/`POSIX` errors all 727 tests in setup with `locale.Error: unsupported locale setting` — which reads like a broken checkout and is one `localedef` away from green.

Verification, all on this branch:
- `uv run mypy` — clean, 107 source files, with `pandas-stubs` uninstalled.
- `uv run lint-imports` — 4 kept, 0 broken.
- `uv run ruff format . && uv run ruff check .` — clean.
- `uv run pytest -m 'not online'` — 727 passed, 6 skipped, 1 xfailed; 147 snapshots passed.
- Resolved and installed the project under Python 3.14: 43 packages, every one a wheel with no build step, and `pandas` not among them — the property the pin was protecting still holds without it.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary. The existing suite, mypy and import-linter are the check: this only removes a dependency nothing imports.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. (No issue to reference — there is no open issue for this.)
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtcFbjTCLgFAFun6EPyiHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtcFbjTCLgFAFun6EPyiHo)_