### PR TITLE
Add `hsql --info` (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
   - `show` prints the merged config with the file each value came from, and the files it overrode — so you can see which file is winning. `--json` for JSON.
   - `validate` reports every problem in every discovered config file — the file, the key, what is wrong, and the line where the TOML parser knew one — instead of stopping at the first, as a run does. It checks each profile against the options its adapter declares, so a misspelled `reed_only` is reported rather than dropped in silence, and it checks your keymaps too. It exits `2` when it found anything, so `hsql --config validate --format none` is the whole check for a script. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Adds `hsql --spec`, a machine-readable `--help`: hsql's options and every installed adapter's connection options, as JSON. `-a NAME` narrows it to one adapter ([#524](https://github.com/tconbeer/harlequin/issues/524)).
+- Adds `hsql --info`, a JSON report on your installation: versions, platform, the config files hsql found in the order it reads them, the profile a run would use, and what each installed adapter declares it supports. It opens no connection, so it answers when the database does not; `-a NAME` narrows it to one adapter ([#524](https://github.com/tconbeer/harlequin/issues/524)).
 - Adds `AbstractOption.to_dict()` to the adapter API, which serializes an option as plain data.
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Adds `hsql --config show`, `--config list-profiles` and `--config validate`, which report on your config files instead of running SQL ([#524](https://github.com/tconbeer/harlequin/issues/524)).
+- Adds `hsql --config show`, `--config list-profiles` and `--config validate`, which report on your config files instead of running SQL. 
   - `list-profiles` lists every profile you can pass to `-P`, its adapter, and which one is the default. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
   - `show` prints the merged config with the file each value came from, and the files it overrode — so you can see which file is winning. `--json` for JSON.
-  - `validate` reports every problem in every discovered config file — the file, the key, what is wrong, and the line where the TOML parser knew one — instead of stopping at the first, as a run does. It checks each profile against the options its adapter declares, so a misspelled `reed_only` is reported rather than dropped in silence, and it checks your keymaps too. It exits `2` when it found anything, so `hsql --config validate --format none` is the whole check for a script. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
-- Adds `hsql --spec`, a machine-readable `--help`: hsql's options and every installed adapter's connection options, as JSON. `-a NAME` narrows it to one adapter ([#524](https://github.com/tconbeer/harlequin/issues/524)).
-- Adds `hsql --info`, a JSON report on your installation: versions, platform, the config files hsql found in the order it reads them, the profile a run would use, and what each installed adapter declares it supports. It opens no connection, so it answers when the database does not; `-a NAME` narrows it to one adapter ([#524](https://github.com/tconbeer/harlequin/issues/524)).
+  - `validate` reports every problem in every discovered config file: the file, the key, what is wrong, and the line. It exits `2` on any validation errors. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+- Adds `hsql --spec`, a machine-readable `--help`: hsql's options and every installed adapter's connection options, as JSON. `-a NAME` narrows it to one adapter. 
+- Adds `hsql --info`, a JSON report on your installation: versions, platform, the config files hsql found, the profile a run would use, and what each installed adapter declares it supports. `-a NAME` narrows it to one adapter. 
 - Adds `AbstractOption.to_dict()` to the adapter API, which serializes an option as plain data.
 
 ### Breaking Changes

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -533,6 +533,17 @@ def parse_row_count(
     return rows
 
 
+def discover_config_files(config_path: Path | None) -> list[Path]:
+    """Every config file that exists, highest priority first.
+
+    Discovery alone: none of them is opened, so this says which files a command
+    would read and in what order, and nothing about what any of them holds.
+
+    Raises: HarlequinConfigError if `config_path` names a file that is not there.
+    """
+    return list(_discover_config_files(config_path))
+
+
 def get_highest_priority_existing_config_file() -> Path | None:
     """The nearest config file, skipping a pyproject.toml with no section of ours."""
     for path in _discover_config_files(config_path=None):

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -10,6 +10,8 @@ Who reads what:
 | ---------------------- | ---------------------------- | -------------------- |
 | `hsql`                 | `load_profile()`             | up to the one that   |
 |                        |                              | defines the profile  |
+| `hsql --info`          | `resolve_profile()`          | the same, plus the   |
+|                        |                              | name it resolved     |
 | `harlequin`, `--keys`  | `load_profile_and_keymaps()` | all: keymaps merge   |
 |                        |                              | across every file    |
 | the IDE's debug screen | `load_config()`              | all                  |
@@ -23,7 +25,8 @@ Who reads what:
 
 `load_profile()` is the fast path: it stops at the file that answers the
 question, so `hsql -P prod` never opens the files behind that one, and
-`hsql -P None` opens none. The others need the whole document.
+`hsql -P None` opens none. `resolve_profile()` is the same walk, returning the
+name it resolved beside the profile. The others need the whole document.
 
 Config files are validated twice, and the halves know different things.
 `_read_config_files()` checks one file's shape before it is merged with any
@@ -346,16 +349,34 @@ def load_config(
 
 def load_profile(config_path: Path | None, profile_name: str | None) -> Profile:
     """The profile an invocation runs under, reading no further than it must."""
+    return resolve_profile(config_path, profile_name)[1]
+
+
+def resolve_profile(
+    config_path: Path | None, profile_name: str | None
+) -> tuple[str | None, Profile]:
+    """The name an invocation's profile resolves to, and the profile itself.
+
+    The name is what `-P` asked for, or the `default_profile` the files settled
+    on, and None where nothing named one -- which `load_profile()` resolves and
+    then discards, and `hsql --info` reports.
+
+    Raises: HarlequinConfigError for a name no discovered file defines.
+    """
     if profile_name == "None":
-        return {}  # Harlequin's own defaults, which no config file can change
+        return "None", {}  # Harlequin's own defaults, which no config file can change
 
     config = Config()
     for path, from_file in _read_config_files(config_path):
         _merge(from_file, into=config, source=path)
         name = profile_name or config.default_profile
         if name is not None and name in config.profiles:
-            return config.profiles[name]  # the files behind this one go unread
-    return _select_profile(config, requested=profile_name)
+            # the files behind this one go unread
+            return name, config.profiles[name]
+    return (
+        profile_name or config.default_profile,
+        _select_profile(config, requested=profile_name),
+    )
 
 
 def load_profile_and_keymaps(
@@ -536,8 +557,10 @@ def parse_row_count(
 def discover_config_files(config_path: Path | None) -> list[Path]:
     """Every config file that exists, highest priority first.
 
-    Discovery alone: none of them is opened, so this says which files a command
-    would read and in what order, and nothing about what any of them holds.
+    Existence is the whole of what is checked: each path is one a command would
+    open, in the order it would open them, and none of them is read -- so a
+    `pyproject.toml` with no `[tool.harlequin]` section is here, and a file that
+    is not on disk is not.
 
     Raises: HarlequinConfigError if `config_path` names a file that is not there.
     """

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -13,12 +13,12 @@ postgres` imports postgres alone. That keeps the first thing a caller reads
 small and stable, and keeps it true for every adapter rather than for whichever
 one is the default.
 
-A **mode** is the third shape. `--config MODE` reports on the config files and
-`--spec` reports on the command itself, rather than either of them running SQL,
-so the first pass skips the profile and names no adapter, and the command
-carries no connection options at all. Modes are options rather than subcommands
-because `CONN_STR` is positional: `hsql catalog` and a DuckDB file named
-`catalog` would have needed a rule, and `--catalog` needs none. They are
+A **mode** is the third shape. `--config MODE` reports on the config files,
+`--spec` on the command itself and `--info` on the installation, rather than any
+of them running SQL, so the first pass skips the profile and names no adapter,
+and the command carries no connection options at all. Modes are options rather
+than subcommands because `CONN_STR` is positional: `hsql catalog` and a DuckDB
+file named `catalog` would have needed a rule, and `--catalog` needs none. They are
 mutually exclusive, and each lives in `harlequin.hsql.modes`, imported by the
 callback when it is chosen.
 """
@@ -218,6 +218,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         ),
     )
     @click.option(
+        "--info",
+        is_flag=True,
+        help=(
+            "Versions, config files, the active profile, and what each "
+            "installed adapter declares it supports, as JSON. Connects to "
+            "nothing. -a narrows it to one adapter."
+        ),
+    )
+    @click.option(
         "--limit",
         default=DEFAULT_LIMIT,
         show_default=True,
@@ -261,10 +270,11 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     @click.pass_context
     def inner_cli(
         ctx: click.Context,
-        profile: str | None,  # noqa: ARG001 -- read in _preflight; see below
+        profile: str | None,
         config_path: Path | None,
         config_mode: str | None,
         spec: bool,
+        info: bool,
         **kwargs: Any,
     ) -> None:
         """Execute SQL and exit.
@@ -326,7 +336,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
 
         sources: list[tuple[str, tuple[str, ...]]] = ctx.meta.get(SOURCES, [])
 
-        mode = _one_mode(ctx, config_mode=config_mode, spec=spec)
+        mode = _one_mode(ctx, config_mode=config_mode, spec=spec, info=info)
         if mode is not None and sources:
             # a mode does not run SQL, so `-c` or `-f` beside one is two
             # invocations spelled as one, and refusing is the safer half of the
@@ -337,6 +347,22 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 f"or drop {mode.split()[0]}."
             )
             ctx.exit(ExitCode.USAGE)
+
+        if info:
+            ctx.exit(
+                _report_info(
+                    ctx,
+                    # `-a` narrows the document to one adapter; its default
+                    # names duckdb, and defaulting is not asking
+                    adapter=adapter if "adapter" in explicitly_set else None,
+                    profile_name=profile,
+                    config_path=config_path,
+                    destination=destination,
+                    format_name=format_name,
+                    format_chosen=format_name != DEFAULT_FORMAT
+                    or "format" in explicitly_set,
+                )
+            )
 
         if spec:
             ctx.exit(
@@ -500,7 +526,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     return cmd
 
 
-def _one_mode(ctx: click.Context, *, config_mode: str | None, spec: bool) -> str | None:
+def _one_mode(
+    ctx: click.Context, *, config_mode: str | None, spec: bool, info: bool
+) -> str | None:
     """The one mode this invocation chose, or exit having named the two it did.
 
     Modes are options rather than subcommands, so nothing about the parse stops
@@ -510,6 +538,7 @@ def _one_mode(ctx: click.Context, *, config_mode: str | None, spec: bool) -> str
     asked = (
         (f"--config {config_mode}", config_mode is not None),
         ("--spec", spec),
+        ("--info", info),
     )
     chosen = [name for name, was_asked in asked if was_asked]
     if len(chosen) > 1:
@@ -518,6 +547,46 @@ def _one_mode(ctx: click.Context, *, config_mode: str | None, spec: bool) -> str
         )
         ctx.exit(ExitCode.USAGE)
     return chosen[0] if chosen else None
+
+
+def _report_info(
+    ctx: click.Context,
+    *,
+    adapter: str | None,
+    profile_name: str | None,
+    config_path: Path | None,
+    destination: Path | None,
+    format_name: str,
+    format_chosen: bool,
+) -> ExitCode:
+    """Answer `--info` and return its code, or exit having said why not.
+
+    Exit 0 for a document it wrote: a config file it could not parse and an
+    adapter that will not import are both facts this mode reports, rather than
+    this invocation's failure.
+    """
+    # here rather than at module scope, for the reason the mode exists in its
+    # own module: it imports every installed adapter, which no other invocation
+    # should pay for
+    from harlequin.hsql.modes import info as info_mode
+
+    try:
+        with _sink(destination) as out:
+            code = info_mode.report(
+                out,
+                adapter=adapter,
+                profile_name=profile_name,
+                config_path=config_path,
+                format_name=format_name,
+                format_chosen=format_chosen,
+            )
+            out.flush()
+    except (HarlequinConfigError, OSError) as e:
+        # a `--config-path` naming no file, or a `-o PATH` it could not write.
+        # Both are the caller's to fix, and both are usage errors.
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    return code
 
 
 def _report_spec(
@@ -765,6 +834,7 @@ def _preflight(argv: Sequence[str], installed: Sequence[str]) -> _Preflight:
             # command that is not going to connect with one
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
+            click.Option(["--info"], is_flag=True),
             # click's own --help and --version are eager and would exit; these
             # are the same spellings as plain flags, so the probe can see that
             # one was asked for.
@@ -785,14 +855,19 @@ def _preflight(argv: Sequence[str], installed: Sequence[str]) -> _Preflight:
     with contextlib.suppress(click.ClickException, ValueError):
         probe.parse_args(ctx, list(argv))
 
-    if ctx.params.get("config") is not None or ctx.params.get("spec"):
+    if (
+        ctx.params.get("config") is not None
+        or ctx.params.get("spec")
+        or ctx.params.get("info")
+    ):
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read here and no adapter
         # whose options belong on the command. `--config` reads the files itself
         # and reports what it finds wrong with them under its own exit code,
         # rather than having this pass hold an error about the first file it
-        # stumbled on; `--spec` describes the command, which a config file it
-        # could not read has no bearing on.
+        # stumbled on, and `--info` reports one as part of its answer; `--spec`
+        # describes the command, which a config file it could not read has no
+        # bearing on.
         return _Preflight(profile={}, adapter=None)
 
     profile: Profile = {}
@@ -1101,7 +1176,9 @@ def _epilog(installed: Sequence[str], adapter: str | None) -> str:
         (
             "Machine-readable:\n"
             f"  {PROGRAM} --spec   this help as JSON, with every installed "
-            "adapter's options"
+            "adapter's options\n"
+            f"  {PROGRAM} --info   versions, config files, and what each "
+            "adapter supports"
         ),
     ]
     # a lone \b tells click not to rewrap the paragraph that follows it

--- a/src/harlequin/hsql/modes/__init__.py
+++ b/src/harlequin/hsql/modes/__init__.py
@@ -1,7 +1,7 @@
 """One module per `hsql` mode, imported only when that mode is asked for.
 
-A mode is an option rather than a subcommand (`--config show`, `--spec`, and
-later `--catalog` and `--info`), so the command stays one click command with one
+A mode is an option rather than a subcommand (`--config show`, `--spec`,
+`--info`, and later `--catalog`), so the command stays one click command with one
 parse. What each mode costs is why they live in separate modules: the callback
 imports the one it was given and nothing else, so that no mode pays for what it
 did not ask for -- `--spec` imports every installed adapter, and is the clearest

--- a/src/harlequin/hsql/modes/info.py
+++ b/src/harlequin/hsql/modes/info.py
@@ -31,7 +31,7 @@ import sys
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, BinaryIO
 
-from harlequin.config import DEFAULT_ADAPTER, discover_config_files, load_config
+from harlequin.config import DEFAULT_ADAPTER, discover_config_files, resolve_profile
 from harlequin.exception import HarlequinConfigError
 from harlequin.hsql import diagnostics
 from harlequin.hsql.diagnostics import ExitCode
@@ -114,32 +114,24 @@ def _config_files(config_path: Path | None) -> dict[str, Any]:
 def _profile(profile_name: str | None, config_path: Path | None) -> dict[str, Any]:
     """The profile an invocation would run under, whole.
 
-    `name` is null when nothing names one, and `options` is null for a name no
-    config file defines -- which is the failure a `-P` typo produces, and one of
-    the things a caller is most likely running this to find.
-    """
-    if profile_name == "None":
-        # Harlequin's own defaults, which no config file can change -- so there
-        # is nothing to read and nothing a file could say about it
-        return {"name": "None", "options": {}, "error": None}
+    Resolved the way a run resolves it, stopping at the file that defines it, so
+    that this reports the profile `hsql -c ...` would use rather than one merged
+    from files that run would never open. `--config validate` is the mode that
+    reads all of them.
 
+    `name` is null when nothing names one, and `options` is null when the name
+    resolved to no profile -- a `-P` typo, or a `default_profile` naming
+    nothing, both of which a run refuses over and this reports.
+    """
     try:
-        config = load_config(config_path)
+        name, options = resolve_profile(config_path, profile_name)
     except (HarlequinConfigError, OSError) as e:
-        # a config file this mode could not read is the answer rather than a
-        # refusal: a caller whose config is broken is one of the callers most
-        # likely to be reading this
+        # a config file this mode could not read, or a name nothing defines, is
+        # the answer rather than a refusal: a caller whose config is broken is
+        # one of the callers most likely to be reading this
         message = e.msg if isinstance(e, HarlequinConfigError) else str(e)
         return {"name": profile_name, "options": None, "error": message}
-
-    name = profile_name or config.default_profile
-    options = config.profiles.get(name) if name is not None else {}
-    error = (
-        None
-        if name is None or options is not None
-        else f"No config file defines a profile named {name}."
-    )
-    return {"name": name, "options": options, "error": error}
+    return {"name": name, "options": options, "error": None}
 
 
 def _adapter_in_use(typed: str | None, options: Any) -> dict[str, Any]:

--- a/src/harlequin/hsql/modes/info.py
+++ b/src/harlequin/hsql/modes/info.py
@@ -1,0 +1,216 @@
+"""`--info`: what is installed, what it can do, and what config it is reading.
+
+The diagnostic an agent runs before it runs anything else, and the one a human
+asks for when a run did something they did not expect. It answers four
+questions in one document: which versions of what are installed, which config
+files this machine has and in what order they are read, which profile an
+invocation would run under, and what each installed adapter *declares* it can
+do.
+
+**It opens no connection**, which is the point rather than an omission: the
+diagnostic a caller reaches for when the database is unreachable must not
+itself require the database. Capabilities are class attributes for exactly that
+reason -- reading one costs an import of the adapter class and never a
+connection.
+
+**It does import**, though, and that is the cost this mode pays: every installed
+adapter, so that every capability is read from the adapter itself rather than
+guessed. `-a NAME` narrows the document to one adapter and the import to one
+with it, which is the common case of asking about the adapter you are using.
+
+An adapter that will not import is reported with its capabilities `"unknown"`
+and the import error beside them. Never `false`: guessing false about what an
+adapter implements is the direction that gets someone hurt.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import sys
+from importlib.metadata import version
+from typing import TYPE_CHECKING, Any, BinaryIO
+
+from harlequin.config import DEFAULT_ADAPTER, discover_config_files, load_config
+from harlequin.exception import HarlequinConfigError
+from harlequin.hsql import diagnostics
+from harlequin.hsql.diagnostics import ExitCode
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from harlequin.adapter import HarlequinAdapter
+
+JSON = "json"
+"""The one `--format` a document mode answers to. `none` writes nothing."""
+
+NONE = "none"
+
+UNKNOWN = "unknown"
+"""What an adapter that would not import declares, in place of a capability map."""
+
+
+def report(
+    out: BinaryIO,
+    *,
+    adapter: str | None,
+    profile_name: str | None,
+    config_path: Path | None,
+    format_name: str,
+    format_chosen: bool,
+) -> ExitCode:
+    """Write the report, and return the code it exits with.
+
+    Exit 0 whatever it found. Every problem this mode can run into -- a config
+    file it cannot read, a profile that is not defined, an adapter that will not
+    import -- is a fact about the installation and so part of the answer, rather
+    than a reason to refuse one.
+    """
+    if format_name == NONE:
+        return ExitCode.OK
+    if format_name != JSON and format_chosen:
+        diagnostics.report_document_format_ignored("--info", format_name)
+
+    profile = _profile(profile_name, config_path)
+    document = {
+        "program": "hsql",
+        "version": version("harlequin"),
+        "python": {
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "executable": sys.executable,
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "config": _config_files(config_path),
+        "profile": profile,
+        "adapter": _adapter_in_use(adapter, profile["options"]),
+        "adapters": _adapters(adapter),
+    }
+    out.write((json.dumps(document, indent=2, default=str) + "\n").encode("utf-8"))
+    return ExitCode.OK
+
+
+def _config_files(config_path: Path | None) -> dict[str, Any]:
+    """Every config file this machine has, highest priority first.
+
+    Discovery rather than the merge: a file that defines nothing hsql reads is
+    still a file a caller put there and expects to be read, and the order is
+    what answers "which one is winning". `--config show` is the mode that says
+    which value came from where.
+
+    Raises: HarlequinConfigError if `--config-path` names a file that is not
+    there, which is a usage error rather than a fact about the installation.
+    """
+    return {
+        "path": _text(config_path),
+        "files": [str(path) for path in discover_config_files(config_path)],
+    }
+
+
+def _profile(profile_name: str | None, config_path: Path | None) -> dict[str, Any]:
+    """The profile an invocation would run under, whole.
+
+    `name` is null when nothing names one, and `options` is null for a name no
+    config file defines -- which is the failure a `-P` typo produces, and one of
+    the things a caller is most likely running this to find.
+    """
+    if profile_name == "None":
+        # Harlequin's own defaults, which no config file can change -- so there
+        # is nothing to read and nothing a file could say about it
+        return {"name": "None", "options": {}, "error": None}
+
+    try:
+        config = load_config(config_path)
+    except (HarlequinConfigError, OSError) as e:
+        # a config file this mode could not read is the answer rather than a
+        # refusal: a caller whose config is broken is one of the callers most
+        # likely to be reading this
+        message = e.msg if isinstance(e, HarlequinConfigError) else str(e)
+        return {"name": profile_name, "options": None, "error": message}
+
+    name = profile_name or config.default_profile
+    options = config.profiles.get(name) if name is not None else {}
+    error = (
+        None
+        if name is None or options is not None
+        else f"No config file defines a profile named {name}."
+    )
+    return {"name": name, "options": options, "error": error}
+
+
+def _adapter_in_use(typed: str | None, options: Any) -> dict[str, Any]:
+    """Which adapter an invocation would connect with, and what decided it.
+
+    Three things can, in this order, and knowing which one did is the whole
+    answer to "why is it connecting to that": `-a`, the profile, or the default
+    nothing named.
+    """
+    if typed is not None:
+        return {"name": typed, "from": "-a"}
+    named = (options or {}).get("adapter")
+    if named:
+        return {"name": str(named), "from": "profile"}
+    return {"name": DEFAULT_ADAPTER, "from": "default"}
+
+
+def _adapters(only: str | None) -> dict[str, Any]:
+    """Every installed adapter's declarations, or one's, keyed by adapter name.
+
+    Keyed rather than a list, because the question a caller has is about a name
+    they already hold: what can `duckdb` do.
+    """
+    from harlequin.plugins import (
+        adapter_distributions,
+        adapter_names,
+        adapter_versions,
+        load_adapter,
+    )
+
+    distributions = adapter_distributions()
+    versions = adapter_versions()
+    names = [only] if only is not None else adapter_names()
+    adapters: dict[str, Any] = {}
+    for name in names:
+        capabilities: dict[str, bool] | str = UNKNOWN
+        error: str | None = None
+        try:
+            adapter_cls = load_adapter(name)
+        except HarlequinConfigError as e:
+            # both halves are worth reporting: an agent reading the document
+            # sees why the capabilities are unknown, and a human sees it on
+            # stderr
+            error = e.msg
+            diagnostics.note(f"{name} is installed, but could not be imported.")
+        else:
+            capabilities = _capabilities(adapter_cls)
+        adapters[name] = {
+            "distribution": distributions.get(name),
+            "version": versions.get(name),
+            "capabilities": capabilities,
+            "error": error,
+        }
+    return adapters
+
+
+def _capabilities(adapter_cls: type[HarlequinAdapter]) -> dict[str, bool]:
+    """What one adapter declares, read off the class and never called.
+
+    The names come from the contract rather than a list kept here, so a
+    capability added to `HarlequinAdapter` is reported by this mode as soon as
+    it exists.
+    """
+    from harlequin.adapter import HarlequinAdapter
+
+    return {
+        name.lower(): bool(getattr(adapter_cls, name, False))
+        for name in sorted(vars(HarlequinAdapter))
+        if name.startswith("IMPLEMENTS_")
+    }
+
+
+def _text(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/src/harlequin/plugins.py
+++ b/src/harlequin/plugins.py
@@ -34,6 +34,21 @@ def adapter_versions() -> dict[str, str | None]:
     return versions
 
 
+def adapter_distributions() -> dict[str, str | None]:
+    """
+    The name of the distribution behind each installed adapter, importing
+    none of them.
+
+    None where the entry point has no distribution behind it, which is what an
+    adapter installed from a source checkout can look like.
+    """
+    distributions: dict[str, str | None] = {}
+    for ep in entry_points(group="harlequin.adapter"):
+        # last one wins, to agree with load_adapter() and load_adapter_plugins()
+        distributions[ep.name] = None if ep.dist is None else ep.dist.name
+    return distributions
+
+
 def load_adapter(name: str) -> type[HarlequinAdapter]:
     """
     Import exactly one installed adapter, by its entry point name.

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -21,6 +21,7 @@ from harlequin.config import (
     merge_profile_with_cli,
     parse_profile_options,
     parse_row_count,
+    resolve_profile,
     validate_config_files,
 )
 from harlequin.exception import HarlequinConfigError
@@ -579,6 +580,52 @@ class TestReadingNoMoreThanItMust:
         (cwd / ".harlequin.toml").write_text("this is not toml at all [[[")
 
         assert load_profile(config_path=None, profile_name="None") == {}
+        assert resolve_profile(config_path=None, profile_name="None") == ("None", {})
+
+    def test_resolving_a_profile_names_the_one_it_resolved_to(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """The name `load_profile()` works out and discards, which is what
+        `hsql --info` reports as the profile a run would use."""
+        cwd, home = config_dirs
+        (home / ".harlequin.toml").write_text(
+            'default_profile = "personal"\n[profiles.personal]\nlimit = 1\n'
+        )
+        (cwd / ".harlequin.toml").write_text("[profiles.project]\nlimit = 2\n")
+
+        assert resolve_profile(config_path=None, profile_name=None) == (
+            "personal",
+            {"limit": 1},
+        )
+        assert resolve_profile(config_path=None, profile_name="project") == (
+            "project",
+            {"limit": 2},
+        )
+
+    def test_resolving_a_profile_is_the_same_walk_load_profile_takes(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """One walk and one early stop, so the two cannot disagree about which
+        file answered."""
+        cwd, home = config_dirs
+        (cwd / ".harlequin.toml").write_text(
+            'default_profile = "near"\n[profiles.near]\nlimit = 1\n'
+        )
+        (home / ".harlequin.toml").write_text("this is not toml at all [[[")
+
+        name, profile = resolve_profile(config_path=None, profile_name=None)
+        assert name == "near"
+        assert profile == load_profile(config_path=None, profile_name=None)
+
+    def test_resolving_a_name_nothing_defines_raises(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        cwd, _ = config_dirs
+        (cwd / ".harlequin.toml").write_text("[profiles.here]\nlimit = 1\n")
+
+        with pytest.raises(HarlequinConfigError) as exc_info:
+            resolve_profile(config_path=None, profile_name="gone")
+        assert "gone" in exc_info.value.msg
 
     def test_a_file_it_did_reach_is_still_validated(
         self, config_dirs: tuple[Path, Path]

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -1869,3 +1869,268 @@ def test_spec_drops_a_spelling_an_hsql_flag_already_owns(
     assert [o["name"] for o in options] == ["cautious"]
     # and `-c` is gone from the one that kept its other spellings
     assert options[0]["decls"] == ["--cautious", "-w"]
+
+
+# --- `--info`, the mode that reports on the installation ---------------------
+
+
+def info_of(res: Result) -> dict[str, Any]:
+    assert res.exit_code == ExitCode.OK
+    return cast("dict[str, Any]", json.loads(res.stdout))
+
+
+def test_info_is_json(hsql: Hsql) -> None:
+    info = info_of(hsql("--info"))
+    assert info["program"] == "hsql"
+    assert info["version"]
+    assert info["python"]["version"]
+    assert info["python"]["implementation"]
+    assert info["python"]["executable"]
+    assert info["platform"]["system"]
+    assert info["adapters"]
+
+
+def test_info_reports_the_interpreter_it_is_running_under(hsql: Hsql) -> None:
+    """The half of a bug report nobody remembers to include."""
+    import platform
+
+    info = info_of(hsql("--info"))
+    assert info["python"]["version"] == platform.python_version()
+    assert info["python"]["executable"] == sys.executable
+    assert info["platform"]["machine"] == platform.machine()
+
+
+def test_info_lists_config_files_in_precedence_order(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    """Nearest first, which is the order that decides which file wins."""
+    project, home = two_config_files
+    info = info_of(hsql("--info"))
+    assert info["config"] == {
+        "path": None,
+        "files": [str(project), str(home)],
+    }
+
+
+def test_info_lists_no_config_files_when_there_are_none(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    assert info_of(hsql("--info"))["config"]["files"] == []
+
+
+def test_info_names_the_file_config_path_pointed_at(hsql: Hsql, tmp_path: Path) -> None:
+    """An explicit file is the only one read, and it is the one to report."""
+    path = tmp_path / "explicit.toml"
+    path.write_text('[profiles.here]\nadapter = "sqlite"\n')
+    config = info_of(hsql("--info", "--config-path", str(path)))["config"]
+    assert config["path"] == str(path)
+    assert config["files"] == [str(path)]
+
+
+def test_info_names_the_active_profile_and_what_chose_the_adapter(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    """Which profile a run would use, and why it would connect where it does."""
+    info = info_of(hsql("--info"))
+    assert info["profile"] == {
+        "name": "personal",
+        "options": {"adapter": "duckdb", "limit": 200000},
+        "error": None,
+    }
+    assert info["adapter"] == {"name": "duckdb", "from": "profile"}
+
+
+def test_info_reports_the_profile_dash_p_asked_for(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    info = info_of(hsql("--info", "-P", "project"))
+    assert info["profile"]["name"] == "project"
+    assert info["adapter"] == {"name": "sqlite", "from": "profile"}
+
+
+def test_info_says_dash_a_beat_the_profile(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    """`-a` wins over the profile, and a report that did not say so would send
+    a reader to the wrong file to change it."""
+    assert info_of(hsql("--info", "-a", "sqlite"))["adapter"] == {
+        "name": "sqlite",
+        "from": "-a",
+    }
+
+
+def test_info_falls_back_to_the_default_adapter(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    from harlequin.config import DEFAULT_ADAPTER
+
+    assert info_of(hsql("--info"))["adapter"] == {
+        "name": DEFAULT_ADAPTER,
+        "from": "default",
+    }
+
+
+def test_info_reports_a_profile_no_file_defines(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    """A `-P` typo is what this mode is most often run to find, so it is an
+    answer rather than a refusal."""
+    info = info_of(hsql("--info", "-P", "prod"))
+    assert info["profile"]["name"] == "prod"
+    assert info["profile"]["options"] is None
+    assert "prod" in info["profile"]["error"]
+
+
+def test_info_reports_the_profile_named_none_as_the_defaults(
+    hsql: Hsql, two_config_files: tuple[Path, Path]
+) -> None:
+    info = info_of(hsql("--info", "-P", "None"))
+    assert info["profile"] == {"name": "None", "options": {}, "error": None}
+
+
+def test_info_answers_over_a_config_it_could_not_read(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """A caller whose config file is broken is the caller most likely to be
+    running this, so the parse error is part of the answer."""
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text("this is not toml\n")
+    info = info_of(hsql("--info"))
+    assert info["config"]["files"] == [str(cwd / ".harlequin.toml")]
+    assert info["profile"]["options"] is None
+    assert "line 1" in info["profile"]["error"]
+    assert info["adapters"]
+
+
+def test_info_reports_declared_capabilities_for_every_installed_adapter(
+    hsql: Hsql,
+) -> None:
+    from importlib.metadata import version
+
+    from harlequin.plugins import adapter_names
+
+    info = info_of(hsql("--info"))
+    assert sorted(info["adapters"]) == sorted(adapter_names())
+    for entry in info["adapters"].values():
+        assert entry["error"] is None
+        assert entry["capabilities"]["implements_cancel"] in (True, False)
+    duckdb = info["adapters"]["duckdb"]
+    assert duckdb["distribution"] == "harlequin"
+    assert duckdb["version"] == version("harlequin")
+
+
+def test_info_reads_the_capability_names_off_the_contract(hsql: Hsql) -> None:
+    """A capability added to `HarlequinAdapter` is reported without this mode
+    keeping a second list of them."""
+    from harlequin.adapter import HarlequinAdapter
+
+    declared = sorted(
+        name.lower()
+        for name in vars(HarlequinAdapter)
+        if name.startswith("IMPLEMENTS_")
+    )
+    assert declared  # the contract declares at least one
+    capabilities = info_of(hsql("--info"))["adapters"]["duckdb"]["capabilities"]
+    assert sorted(capabilities) == declared
+
+
+def test_info_narrows_to_one_adapter(hsql: Hsql) -> None:
+    assert list(info_of(hsql("--info", "-a", "sqlite"))["adapters"]) == ["sqlite"]
+
+
+def test_info_reports_an_adapter_it_could_not_import_as_unknown(
+    hsql: Hsql, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never `false`: guessing false about what an adapter implements is the
+    direction that gets someone hurt."""
+    from harlequin.plugins import load_adapter as real_load_adapter
+
+    def fake_load_adapter(name: str) -> Any:
+        if name == "duckdb":
+            raise HarlequinConfigError("No module named 'duckdb'", title="nope")
+        return real_load_adapter(name)
+
+    monkeypatch.setattr("harlequin.plugins.load_adapter", fake_load_adapter)
+    res = hsql("--info")
+    info = info_of(res)
+    assert info["adapters"]["duckdb"]["capabilities"] == "unknown"
+    assert "duckdb" in info["adapters"]["duckdb"]["error"]
+    # and the rest of the installation is still reported
+    assert info["adapters"]["sqlite"]["capabilities"]["implements_cancel"] is True
+    assert "could not be imported" in res.stderr
+
+
+def test_info_opens_no_connection(hsql: Hsql, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The design decision this mode exists on: the diagnostic a caller runs
+    when the database is unreachable must not itself require the database."""
+    from harlequin.plugins import load_adapter as real_load_adapter
+
+    def refuse(self: Any) -> Any:
+        raise AssertionError("--info opened a connection")
+
+    def fake_load_adapter(name: str) -> Any:
+        return type("Faked", (real_load_adapter(name),), {"connect": refuse})
+
+    monkeypatch.setattr("harlequin.plugins.load_adapter", fake_load_adapter)
+    assert info_of(hsql("--info"))["adapters"]["duckdb"]["capabilities"]
+
+
+def test_info_does_not_run_sql(hsql: Hsql) -> None:
+    res = hsql("--info", ":memory:", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "does not run SQL" in res.stderr
+
+
+def test_info_carries_no_adapters_options(hsql: Hsql) -> None:
+    """It reports what an adapter declares rather than taking its options."""
+    res = hsql("--info", "-a", "duckdb", "--no-init")
+    assert res.exit_code == ExitCode.USAGE
+    assert "--no-init" in res.stderr
+
+
+@pytest.mark.parametrize("other", [["--spec"], ["--config", "show"]])
+def test_info_beside_another_mode_is_a_usage_error(
+    hsql: Hsql, other: list[str]
+) -> None:
+    res = hsql("--info", *other)
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "--info" in res.stderr
+
+
+def test_info_writes_nothing_under_format_none(hsql: Hsql) -> None:
+    res = hsql("--info", "--format", "none")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+
+
+@pytest.mark.parametrize("argv", [["--csv"], ["--format", "markdown"]])
+def test_info_notes_a_format_it_cannot_reach(hsql: Hsql, argv: list[str]) -> None:
+    res = hsql("--info", *argv)
+    assert res.exit_code == ExitCode.OK
+    assert json.loads(res.stdout)["program"] == "hsql"
+    assert "had no effect" in res.stderr
+    assert "--format json" in res.stderr
+
+
+def test_info_json_is_not_a_format_it_declines(hsql: Hsql) -> None:
+    res = hsql("--info", "--json")
+    assert res.exit_code == ExitCode.OK
+    assert json.loads(res.stdout)["program"] == "hsql"
+    assert res.stderr == ""
+
+
+def test_info_goes_to_the_file_dash_o_names(hsql: Hsql, tmp_path: Path) -> None:
+    destination = tmp_path / "info.json"
+    res = hsql("--info", "-o", str(destination))
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+    assert json.loads(destination.read_text(encoding="utf-8"))["program"] == "hsql"
+
+
+def test_info_is_in_the_help(hsql: Hsql) -> None:
+    res = hsql("--help")
+    assert res.exit_code == ExitCode.OK
+    assert "--info" in res.output
+    assert f"{PROGRAM} --info" in res.output

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -1974,11 +1974,57 @@ def test_info_reports_a_profile_no_file_defines(
     hsql: Hsql, two_config_files: tuple[Path, Path]
 ) -> None:
     """A `-P` typo is what this mode is most often run to find, so it is an
-    answer rather than a refusal."""
+    answer rather than a refusal -- and the answer a run would have refused
+    with."""
     info = info_of(hsql("--info", "-P", "prod"))
     assert info["profile"]["name"] == "prod"
     assert info["profile"]["options"] is None
     assert "prod" in info["profile"]["error"]
+    # the same message a run gives, because it comes from the same resolution
+    res = hsql("-P", "prod", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert info["profile"]["error"] in res.stderr
+
+
+def test_info_reports_a_default_profile_that_names_nothing(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        'default_profile = "gone"\n[profiles.here]\nadapter = "sqlite"\n'
+    )
+    info = info_of(hsql("--info"))
+    assert info["profile"]["options"] is None
+    assert "default_profile" in info["profile"]["error"]
+    assert "gone" in info["profile"]["error"]
+
+
+def test_info_reads_no_further_than_a_run_would(
+    hsql: Hsql, config_dirs: tuple[Path, Path]
+) -> None:
+    """It reports the profile a run would use, so it stops where a run stops.
+
+    A file behind the one that defines the profile is never opened, so its
+    contents cannot turn this into a report about a problem no run would meet.
+    `--config validate` is the mode that reads every file.
+    """
+    cwd, home = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        'default_profile = "near"\n[profiles.near]\nadapter = "sqlite"\n'
+    )
+    (home / ".harlequin.toml").write_text("this is not toml\n")
+
+    info = info_of(hsql("--info"))
+    assert info["profile"] == {
+        "name": "near",
+        "options": {"adapter": "sqlite"},
+        "error": None,
+    }
+    # discovery still names it: it is a file on disk that a run may yet read
+    assert info["config"]["files"] == [
+        str(cwd / ".harlequin.toml"),
+        str(home / ".harlequin.toml"),
+    ]
 
 
 def test_info_reports_the_profile_named_none_as_the_defaults(

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -255,6 +255,33 @@ def test_spec_imports_only_the_adapter_it_was_narrowed_to(
     assert not forbidden
 
 
+def test_info_imports_only_the_adapter_it_was_narrowed_to(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """`--info` reads capabilities off the adapter class, so it imports one per
+    adapter it reports -- and under `-a`, exactly one.
+
+    It opens no connection, and it writes a document rather than rows, so no
+    pyarrow and no tomlkit either.
+    """
+    proc = run_python(
+        "import sys\n"
+        "sys.argv = ['hsql', '--info', '-a', 'sqlite']\n"
+        "from harlequin.hsql import main\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print(','.join(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith('harlequin_')})), file=sys.stderr)\n"
+        "print(','.join(m for m in ('duckdb', 'pyarrow', 'tomlkit') "
+        "if m in sys.modules), file=sys.stderr)\n"
+    )
+    adapters, forbidden = proc.stderr.split("\n")[:2]
+    assert adapters == "harlequin_sqlite"
+    assert not forbidden
+
+
 def test_public_names_still_resolve() -> None:
     """Every name `harlequin/__init__.py` exported before it went lazy.
 


### PR DESCRIPTION
M2 PR 5: the mode that reports on the installation rather than running SQL.
One JSON document with Harlequin's version, Python's, the platform, the config
files discovery found in precedence order, the profile a run would use, which
adapter it would connect with and what decided that, and what each installed
adapter declares it supports.

It opens no connection, which is the design decision rather than an omission:
the diagnostic a caller reaches for when the database is unreachable must not
itself require the database. Capabilities are read off the adapter class, so
they cost an import and never a connection, and the names come from the
`IMPLEMENTS_*` attributes on `HarlequinAdapter` rather than a second list, so a
capability added to the contract is reported as soon as it exists. An adapter
that will not import is reported with its capabilities `"unknown"` and the
import error beside them, never as `false`.

`-a NAME` narrows the document to one adapter and the import to one with it.
Every problem the mode can meet -- an unparseable config file, a `-P` that
names nothing, an adapter that will not import -- is part of the answer rather
than a refusal.

Adds `config.discover_config_files()` and `plugins.adapter_distributions()`,
both of which read without importing an adapter.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bkep6Hr4sKmNzfTozWURmj