### PR TITLE
Merge config writes into the tomlkit doc instead of replacing tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - A `default_profile` that names no profile now only stops an invocation that was going to use it: `harlequin -P other` and `harlequin -P None` start, as `hsql` does, instead of refusing over a key neither of them read.
 - `hsql --format markdown` no longer breaks the table when `--null-string` contains a `|` or a newline.
 - `harlequin --config` and `harlequin --keys` no longer strip the comments you wrote inside a profile or keymap table; a value they did not change now keeps the comments and formatting you gave it ([#1033](https://github.com/tconbeer/harlequin/issues/1033)).
+- `harlequin --config` now removes `default_profile` from your config file when you choose `[No default]`, instead of leaving the old default in place.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Config file errors now name the file the problem is written in, and the key it is written under. A key Harlequin does not recognize is reported with the nearest one it does, so `read-only`, `reed_only` and `keymap_names` each name the option they were probably meant to be.
 - A `default_profile` that names no profile now only stops an invocation that was going to use it: `harlequin -P other` and `harlequin -P None` start, as `hsql` does, instead of refusing over a key neither of them read.
 - `hsql --format markdown` no longer breaks the table when `--null-string` contains a `|` or a newline.
+- `harlequin --config` and `harlequin --keys` no longer strip the comments you wrote inside a profile or keymap table; a value they did not change now keeps the comments and formatting you gave it ([#1033](https://github.com/tconbeer/harlequin/issues/1033)).
 
 ### Performance
 

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -308,11 +308,16 @@ class ConfigFile:
             ) from e
         return self._doc
 
-    def update(self, config: Mapping[str, Any]) -> None:
+    def update(self, config: Mapping[str, Any], *, whole_section: bool = False) -> None:
         """
         Merge the updated config into the relevant section of the in-memory
         TOML doc, key by key, so a table nobody edited keeps its own nodes --
         and with them the comments written inside it.
+
+        `whole_section` says `config` is everything the section should say, so
+        a top-level key missing from it is one the caller means to delete --
+        which `harlequin --config` needs to turn a `default_profile` off. It is
+        off by default, for the keymap editor, which passes `keymaps` alone.
         """
         doc = self._editable()
         if self.is_pyproject:
@@ -320,9 +325,9 @@ class ConfigFile:
                 doc["tool"] = {"harlequin": {}}
             elif "harlequin" not in doc["tool"]:
                 doc["tool"]["harlequin"] = {}
-            _merge_into_doc(doc["tool"]["harlequin"], config)
+            _merge_into_doc(doc["tool"]["harlequin"], config, prune=whole_section)
         else:
-            _merge_into_doc(doc, config)
+            _merge_into_doc(doc, config, prune=whole_section)
 
     def write(self) -> None:
         """
@@ -773,8 +778,8 @@ def _merge_into_doc(
     A node carries the comments and formatting around it, so an unchanged value
     is not written at all, and a table on both sides is merged into rather than
     assigned. `prune` makes `source` the whole table: a key it does not have is
-    a key the caller deleted. Off at the top level, where the keymap editor
-    writes `{"keymaps": ...}` alone and must not take the profiles with it.
+    a key the caller deleted, which is always true of a table the caller named
+    and only true at the top level when it passed the whole section.
     """
     for key, value in source.items():
         existing = target.get(key, _MISSING)

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -57,6 +57,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     cast,
@@ -309,8 +310,9 @@ class ConfigFile:
 
     def update(self, config: Mapping[str, Any]) -> None:
         """
-        Replace the relevant section of the in-memory TOML doc with the updated
-        Config.
+        Merge the updated config into the relevant section of the in-memory
+        TOML doc, key by key, so a table nobody edited keeps its own nodes --
+        and with them the comments written inside it.
         """
         doc = self._editable()
         if self.is_pyproject:
@@ -318,9 +320,9 @@ class ConfigFile:
                 doc["tool"] = {"harlequin": {}}
             elif "harlequin" not in doc["tool"]:
                 doc["tool"]["harlequin"] = {}
-            doc["tool"]["harlequin"].update(config)
+            _merge_into_doc(doc["tool"]["harlequin"], config)
         else:
-            doc.update(config)
+            _merge_into_doc(doc, config)
 
     def write(self) -> None:
         """
@@ -754,6 +756,43 @@ def _merge(
         into.profiles.setdefault(profile_name, profile)
     for keymap_name, bindings in from_file.keymaps.items():
         into.keymaps.setdefault(keymap_name, bindings)
+
+
+_MISSING = object()
+"""What a key not in a TOML table reads as; TOML has no null to collide with."""
+
+
+def _merge_into_doc(
+    target: MutableMapping[str, Any],
+    source: Mapping[str, Any],
+    *,
+    prune: bool = False,
+) -> None:
+    """Write `source` into a tomlkit table, leaving every node it can in place.
+
+    A node carries the comments and formatting around it, so an unchanged value
+    is not written at all, and a table on both sides is merged into rather than
+    assigned. `prune` makes `source` the whole table: a key it does not have is
+    a key the caller deleted. Off at the top level, where the keymap editor
+    writes `{"keymaps": ...}` alone and must not take the profiles with it.
+    """
+    for key, value in source.items():
+        existing = target.get(key, _MISSING)
+        if isinstance(value, Mapping) and isinstance(existing, MutableMapping):
+            _merge_into_doc(existing, value, prune=True)
+        elif existing is _MISSING or _plain(existing) != value:
+            target[key] = value
+
+    if prune:
+        for key in [key for key in target if key not in source]:
+            del target[key]
+
+
+def _plain(value: Any) -> Any:
+    """A tomlkit node's value, without the styling wrapped around it, so that an
+    unchanged value compares equal to the plain data `relevant_config` hands out."""
+    unwrap = getattr(value, "unwrap", None)
+    return unwrap() if unwrap is not None else value
 
 
 def _select_profile(

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -192,7 +192,9 @@ def _wizard(config_path: Path | None) -> None:
 
     config["profiles"][profile_name] = new_profile
 
-    config_file.update(config=config)
+    # the wizard holds the file's whole Harlequin section, so a key it no
+    # longer has -- a `default_profile` turned off -- is one to delete
+    config_file.update(config=config, whole_section=True)
     config_file.write()
 
 

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -435,6 +435,40 @@ class TestConfigFileRoundTrip:
         assert reread.profiles["one"] == {"theme": "fruity"}
         assert reread.keymaps["mine"] == [{"keys": "ctrl+j", "action": "quit"}]
 
+    def test_a_write_of_the_whole_section_removes_a_top_level_key_it_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        """How `harlequin --config` turns a `default_profile` back off.
+
+        The wizard hands back the whole Harlequin section, so a key missing
+        from it is one the user turned off, and leaving it behind would write
+        back a default nobody asked for.
+        """
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            "# a file someone wrote by hand\n"
+            'default_profile = "one"\n'
+            "\n"
+            "[profiles.one]\n"
+            "# keep me\n"
+            'theme = "fruity"\n'
+        )
+
+        config_file = ConfigFile(path)
+        config = config_file.relevant_config
+        del config["default_profile"]
+        config_file.update(config, whole_section=True)
+        config_file.write()
+
+        written = path.read_text()
+        assert "default_profile" not in written
+        # the key went; the comments around what stayed did not
+        assert "# a file someone wrote by hand" in written
+        assert "# keep me" in written
+        reread = load_config(config_path=path)
+        assert reread.default_profile is None
+        assert reread.profiles["one"] == {"theme": "fruity"}
+
     def test_a_write_to_pyproject_touches_only_the_harlequin_table(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -322,10 +322,10 @@ class TestConfigFileRoundTrip:
     ) -> None:
         """Which is why writing still goes through tomlkit.
 
-        Note the limit, which is not new: `relevant_config` hands back plain
-        data, so `update()` replaces a whole table rather than editing inside
-        it, and comments *within* a rewritten table do not survive. Comments
-        elsewhere in the file do.
+        `relevant_config` hands back plain data -- every reader wants that, and
+        it is on the hot path -- so it falls to `update()` to merge that data
+        back into the tomlkit document key by key. A table nobody edited keeps
+        its own nodes, and with them the comments written inside it.
         """
         path = tmp_path / ".harlequin.toml"
         path.write_text(
@@ -334,6 +334,7 @@ class TestConfigFileRoundTrip:
             "\n"
             "# and a note further down\n"
             "[profiles.one]\n"
+            "# I like this theme best\n"
             'theme = "fruity"\n'
         )
 
@@ -346,11 +347,93 @@ class TestConfigFileRoundTrip:
         written = path.read_text()
         assert "# a file someone wrote by hand" in written
         assert "# and a note further down" in written
+        # nothing was asked to change about profile one, inside it or around it
+        assert "# I like this theme best" in written
         # and the new profile arrived, without disturbing the old one
         reread = load_config(config_path=path)
         assert reread.profiles["two"] == {"theme": "monokai"}
         assert reread.profiles["one"] == {"theme": "fruity"}
         assert reread.default_profile == "one"
+
+    def test_a_write_preserves_the_comments_around_the_value_it_changed(
+        self, tmp_path: Path
+    ) -> None:
+        """Editing one key in a table is not a reason to reflow the table."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            "[profiles.one]\n"
+            "# I like this theme best\n"
+            'theme = "fruity"\n'
+            "# the database I use every day\n"
+            'conn_str = ["analytics.db"]\n'
+        )
+
+        config_file = ConfigFile(path)
+        config = config_file.relevant_config
+        config["profiles"]["one"]["theme"] = "monokai"
+        config_file.update(config)
+        config_file.write()
+
+        written = path.read_text()
+        assert "# I like this theme best" in written
+        assert "# the database I use every day" in written
+        assert load_config(config_path=path).profiles["one"] == {
+            "theme": "monokai",
+            "conn_str": ["analytics.db"],
+        }
+
+    def test_a_write_removes_the_keys_the_caller_dropped(self, tmp_path: Path) -> None:
+        """A merge, but the caller's table is still the whole table.
+
+        `harlequin --config` hands back the profile it just built, so a key
+        that is not in it is a key the user turned off -- and leaving it behind
+        would be writing back an option nobody asked for.
+        """
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            "[profiles.one]\n"
+            'theme = "fruity"\n'
+            "show_files = '/home/me'\n"
+            "\n"
+            "[profiles.two]\n"
+            'theme = "monokai"\n'
+        )
+
+        config_file = ConfigFile(path)
+        config = config_file.relevant_config
+        config["profiles"]["one"] = {"theme": "fruity"}
+        del config["profiles"]["two"]
+        config_file.update(config)
+        config_file.write()
+
+        reread = load_config(config_path=path)
+        assert reread.profiles == {"one": {"theme": "fruity"}}
+
+    def test_a_write_leaves_alone_the_top_level_keys_it_was_not_given(
+        self, tmp_path: Path
+    ) -> None:
+        """What the keymap editor depends on: it writes `keymaps` and nothing
+        else, and must not take the profiles with it."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            'default_profile = "one"\n'
+            "\n"
+            "[profiles.one]\n"
+            "# still mine\n"
+            'theme = "fruity"\n'
+        )
+
+        config_file = ConfigFile(path)
+        config_file.update(
+            {"keymaps": {"mine": [{"keys": "ctrl+j", "action": "quit"}]}}
+        )
+        config_file.write()
+
+        assert "# still mine" in path.read_text()
+        reread = load_config(config_path=path)
+        assert reread.default_profile == "one"
+        assert reread.profiles["one"] == {"theme": "fruity"}
+        assert reread.keymaps["mine"] == [{"keys": "ctrl+j", "action": "quit"}]
 
     def test_a_write_to_pyproject_touches_only_the_harlequin_table(
         self, tmp_path: Path
@@ -361,6 +444,7 @@ class TestConfigFileRoundTrip:
             'name = "someone-elses-project"\n'
             "\n"
             "[tool.harlequin.profiles.one]\n"
+            "# I like this theme best\n"
             'theme = "fruity"\n'
         )
 
@@ -373,8 +457,11 @@ class TestConfigFileRoundTrip:
         reread = ConfigFile(path)
         assert reread.relevant_config["default_profile"] == "one"
         assert reread.relevant_config["profiles"]["one"] == {"theme": "fruity"}
+        written = path.read_text()
         # the rest of the file is not ours to rewrite
-        assert 'name = "someone-elses-project"' in path.read_text()
+        assert 'name = "someone-elses-project"' in written
+        # and neither is the inside of a table we did not change
+        assert "# I like this theme best" in written
 
     def test_a_write_creates_a_file_that_does_not_exist_yet(
         self, tmp_path: Path

--- a/tests/unit_tests/test_config_wizard.py
+++ b/tests/unit_tests/test_config_wizard.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import pytest
+
+from harlequin.config import load_config
+from harlequin.config_wizard import _wizard
+
+
+class FakePrompt:
+    """One questionary prompt, answered without a terminal."""
+
+    def __init__(self, answer: Any) -> None:
+        self.answer = answer
+
+    def ask(self) -> Any:
+        return self.answer
+
+    def unsafe_ask(self) -> Any:
+        return self.answer
+
+
+@pytest.fixture
+def run_wizard(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Run the real wizard, with every prompt answered from a dict.
+
+    Answers are keyed by a substring of the prompt's message; a prompt no test
+    answers takes what the wizard offered it -- the value already in the
+    profile, or the first choice -- so a test names only the prompts it is about.
+    """
+    import questionary
+
+    def fake(
+        answers: dict[str, Any], fallback: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        def prompt(message: str = "", **kwargs: Any) -> FakePrompt:
+            for substring, answer in answers.items():
+                if substring in message:
+                    return FakePrompt(answer)
+            return FakePrompt(fallback(**kwargs))
+
+        return prompt
+
+    def first_choice(choices: Sequence[Any], **_: Any) -> Any:
+        return choices[0]
+
+    def the_default(default: Any = "", **_: Any) -> Any:
+        return default
+
+    def nothing_checked(**_: Any) -> list[Any]:
+        return []
+
+    def yes(**_: Any) -> bool:
+        return True
+
+    def run(config_path: Path, answers: dict[str, Any]) -> None:
+        fallbacks: tuple[tuple[str, Callable[..., Any]], ...] = (
+            ("select", first_choice),
+            ("text", the_default),
+            ("path", the_default),
+            ("checkbox", nothing_checked),
+            ("confirm", yes),
+        )
+        for name, fallback in fallbacks:
+            monkeypatch.setattr(questionary, name, fake(answers, fallback))
+        _wizard(config_path=config_path)
+
+    return run
+
+
+class TestDefaultProfile:
+    def test_choosing_no_default_removes_it_from_the_file(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """Turning a default off has to reach the file, or it did not happen.
+
+        `[No default]` is the first choice the prompt offers, which is what the
+        unanswered prompts take -- so this names it by leaving it unanswered.
+        """
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            'default_profile = "one"\n\n[profiles.one]\n# keep me\ntheme = "fruity"\n'
+        )
+
+        run_wizard(path, {"Which profile would you like to update?": "one"})
+
+        assert load_config(config_path=path).default_profile is None
+        written = path.read_text()
+        assert "default_profile" not in written
+        # and the write is still a write that keeps the file someone typed
+        assert "# keep me" in written
+
+    def test_setting_a_default_writes_it(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\n# keep me\ntheme = "fruity"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Would you like to set a default profile?": "one",
+            },
+        )
+
+        assert load_config(config_path=path).default_profile == "one"
+        assert "# keep me" in path.read_text()
+
+
+class TestProfileWrite:
+    def test_the_wizard_keeps_the_comments_in_a_profile_it_did_not_touch(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            'default_profile = "one"\n'
+            "\n"
+            "[profiles.one]\n"
+            "# I like this theme best\n"
+            'theme = "fruity"\n'
+            "# the database I use every day\n"
+            'conn_str = ["analytics.db"]\n'
+        )
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "[Create a New Profile]",
+                "What would you like to name your profile?": "two",
+                "Would you like to set a default profile?": "one",
+            },
+        )
+
+        written = path.read_text()
+        assert "# I like this theme best" in written
+        assert "# the database I use every day" in written
+        config = load_config(config_path=path)
+        assert config.profiles["one"] == {
+            "theme": "fruity",
+            "conn_str": ["analytics.db"],
+        }
+        assert "two" in config.profiles
+        assert config.default_profile == "one"


### PR DESCRIPTION
`harlequin --config` and the keymap editor read plain data from
`relevant_config` and handed it straight back to `update()`, which
assigned it over the tomlkit document. Assigning replaces a table's
nodes, so every comment inside a profile or keymap table was dropped --
including in profiles the write never touched.

`update()` now merges key by key: an unchanged value is not written at
all, a table on both sides is merged into, and only a value that
actually changed becomes a new node. Within a table the caller named,
a key it no longer has is deleted, so a profile the wizard rebuilt does
not keep options nobody asked for; top-level keys the caller did not
name are still left alone, which is what lets the keymap editor write
`keymaps` without touching the profiles.

Closes #1033

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hbu6unnJXfXa3shRKF1PjK