### PR TITLE
feat: notify when a query is formatted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Adds `AbstractOption.to_dict()` to the adapter API, which serializes an option as plain data.
 - Config file errors now name the file the problem is written in, and the key it is written under. A key Harlequin does not recognize is reported with the nearest one it does.
 - Harlequin's Results Viewer can now show a cell's value in a scrollable modal (press `space`) ([#1011](https://github.com/tconbeer/harlequin/issues/1011)).
+- Formatting a query now shows a notification, so it is clear the formatter ran even when it changed little or nothing ([#874](https://github.com/tconbeer/harlequin/issues/874)).
 
 
 ### Bug Fixes

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -117,9 +117,10 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         if self.text_input is None:
             return
         old_selection = self.text_input.selection
+        old_text = self.text
 
         try:
-            self.text = format_string(self.text, Mode())
+            formatted_text = format_string(old_text, Mode())
         except SqlfmtError as e:
             self.app.push_screen(
                 ErrorModal(
@@ -129,7 +130,12 @@ class CodeEditor(TextEditor, inherit_bindings=False):
                 )
             )
         else:
-            self.text_input.selection = old_selection
+            if formatted_text != old_text:
+                self.text = formatted_text
+                self.text_input.selection = old_selection
+                self.app.notify("Formatted query.")
+            else:
+                self.app.notify("Query was already formatted; no changes made.")
 
     def action_focus_results_viewer(self) -> None:
         if hasattr(self.app, "action_focus_results_viewer"):

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -23,6 +23,12 @@ async def test_query_formatting(
 
         await pilot.press("f4")
         assert app.editor.text == "select 1 from foo\n"
+        assert list(app._notifications)[-1].message == "Formatted query."
+
+        # formatting an already-formatted query notifies that nothing changed
+        await pilot.press("f4")
+        assert app.editor.text == "select 1 from foo\n"
+        assert "no changes" in list(app._notifications)[-1].message
 
 
 @pytest.mark.flaky


### PR DESCRIPTION
Closes #874

**What** are the key elements of this solution?

`CodeEditor.action_format` now formats into a local, compares it to the buffer's old text, and notifies either way:

- text changed → assign it, restore the selection, and `notify("Formatted query.")`
- text unchanged → skip the assignment entirely and `notify("Query was already formatted; no changes made.")`

The error path is untouched — a `SqlfmtError` still pushes the `ErrorModal` and raises no toast.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The obvious version is one unconditional `notify("Formatted query.")` after the `try`, but that doesn't quite close the issue: the reported confusion is about the minimal-diff case, and a message that reads the same whether or not sqlfmt touched anything still leaves you unsure it looked at your text. Naming the no-op is what makes the toast informative.

Splitting the branches also means the unchanged case no longer assigns `self.text` at all, so a buffer that was already formatted isn't marked dirty and doesn't have its undo state disturbed by pressing `f4`.

Tradeoff: the comparison holds a second copy of the buffer's text for the duration of the call. For editor-sized text next to what `format_string` already allocates, that's not worth avoiding.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`test_query_formatting` now presses `f4` twice — once on an unformatted query, once on the result — and asserts the message each time. It reads `app._notifications` rather than a snapshot because `run_test` passes `notifications=False`, so no toast is ever mounted under test. Verified the toasts do render by driving the app with `notifications=True` and capturing screenshots.

Full suite on this branch, rebased onto `aa2d056`: 875 passed, 6 skipped, 1 xfailed; `ruff format`, `ruff check`, `mypy`, and `lint-imports` all clean.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_012U3SYnVgFXJabrjZTWGY4p)_