### PR TITLE
Use a single TextArea for every buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ Both query workers are thin wrappers over the execution core above: `_execute_qu
 
 Adapters are third-party code: a raw driver exception (not a `HarlequinQueryError`) must surface as an error modal, never crash the app.
 
+**There is exactly one `CodeEditor`, however many buffers are open.** `EditorCollection` (`components/code_editor.py`) is a row of `Tabs` over that single editor; every other buffer lives in `buffer_states` as an `EditorState`, and activating a tab swaps the loaded buffer's state out and the new one's in. A `TextArea` costs a tree-sitter parse and a full widget mount to build, so the count of them is what start-up used to scale with. Anything the editor holds and a user would expect to survive a tab switch — text, selection, scroll position, undo history — has to be in `EditorState`, or it silently belongs to whichever buffer was last loaded.
+
 The Data Catalog (`components/data_catalog/database_tree.py`) loads by viewport, not eagerly: an `asyncio.PriorityQueue` feeds a background loader, with user-expanded nodes at `DEMAND_PRIORITY` jumping ahead of speculative `PREFETCH_PRIORITY` work near the viewport, and children added in chunks so a wide node can't stall rendering.
 
 ### Keys and actions (`actions.py`, `keymap.py`, `bindings.py`, `keys_app.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Harlequin and `hsql` now redact secrets instead of showing them in output ([#667](https://github.com/tconbeer/harlequin/issues/667)
 - A profile can now interpolate environment variables: write `password = "${MYPASSWORD}"`, or `host = "${MYHOST:-localhost}"` (to set a default) ([#898](https://github.com/tconbeer/harlequin/issues/898)). Use `$${` for a literal `${`.
 - Errors in Config files now reference the files and keys they originate from.
+- Harlequin now reopens the buffer you were last using, instead of always starting on the first one.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 
 - `hsql` and `harlequin` read config files in priority order and stop at the file that defines the requested profile. `hsql -P None` now reads none at all.
 - `harlequin` now imports only the adapter it is about to connect with, instead of every adapter you have installed ([#1047](https://github.com/tconbeer/harlequin/issues/1047)).
+- Harlequin now shares one Query Editor across all buffers, so start-up no longer slows down as you keep more buffers open ([#636](https://github.com/tconbeer/harlequin/issues/636)).
 
 ### Dependencies
 

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -19,7 +19,7 @@ from typing import (
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.css.query import DOMQuery, NoMatches
+from textual.css.query import DOMQuery
 from textual.dom import DOMNode
 from textual.driver import Driver
 from textual.lazy import Lazy
@@ -75,7 +75,7 @@ from harlequin.config import (
 )
 from harlequin.copy_formats import HARLEQUIN_COPY_FORMATS, WINDOWS_COPY_FORMATS
 from harlequin.driver import HarlequinDriver
-from harlequin.editor_cache import BufferState, Cache
+from harlequin.editor_cache import Cache
 from harlequin.editor_cache import write_cache as write_editor_cache
 from harlequin.exception import (
     HarlequinBindingError,
@@ -514,20 +514,7 @@ class Harlequin(AppBase):
     def update_internal_editor_state(
         self, message: EditorCollection.EditorSwitched
     ) -> None:
-        if message.active_editor is not None:
-            self.editor = message.active_editor
-        else:
-            try:
-                self.editor = self.editor_collection.current_editor
-            except NoMatches:
-                # This shouldn't happen, but sometimes on Windows we
-                # get into this state where we receive EditorSwitched
-                # but current_editor raises NoMatches because it
-                # can't find the ContentSwitcher. Recycle the event
-                # to try again.
-                callback = partial(self.post_message, message)
-                self.set_timer(delay=0.1, callback=callback)
-                return
+        self.editor = message.active_editor or self.editor_collection.current_editor
         self.editor.focus()
         self._sync_run_button_disabled()
         self._sync_run_button_text()
@@ -971,12 +958,12 @@ class Harlequin(AppBase):
         self.results_viewer.focus()
 
     async def action_quit(self) -> None:
-        buffers = []
-        for i, editor in enumerate(self.editor_collection.all_editors):
-            if editor == self.editor_collection.current_editor:
-                focus_index = i
-            buffers.append(BufferState(editor.selection, editor.text))
-        write_editor_cache(Cache(focus_index=focus_index, buffers=buffers))
+        write_editor_cache(
+            Cache(
+                focus_index=self.editor_collection.active_buffer_index,
+                buffers=self.editor_collection.buffers,
+            )
+        )
         update_catalog_cache(
             connection_hash=self.connection_hash,
             catalog=None,  # TODO: cache completions instead.

--- a/src/harlequin/app.tcss
+++ b/src/harlequin/app.tcss
@@ -148,7 +148,7 @@ EditorCollection.premount {
 }
 
 CodeEditor {
-    height: 100%;
+    height: 1fr;
     width: 100%;
 }
 

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import List, Union
 
 from sqlfmt.api import Mode, format_string
 from sqlfmt.exception import SqlfmtError
-from textual.content import ContentType
-from textual.css.query import InvalidQueryFormat, NoMatches
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.geometry import Offset
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import ContentSwitcher, TabbedContent, TabPane, Tabs
-from textual.widgets.text_area import Location, Selection
+from textual.widgets import Tab, Tabs
+from textual.widgets.text_area import EditHistory, Location, Selection
 from textual_textarea import TextAreaSaved, TextEditor
 
 from harlequin.autocomplete import MemberCompleter, WordCompleter
@@ -17,6 +19,25 @@ from harlequin.components.text_modal import ErrorModal
 from harlequin.editor_cache import BufferState, load_cache
 from harlequin.messages import WidgetMounted
 from harlequin.statements import find_separators
+
+
+@dataclass
+class EditorState:
+    """One buffer's state; the active buffer's lives in the editor, the rest here."""
+
+    text: str = ""
+    selection: Selection = field(default_factory=Selection)
+    scroll_offset: Offset = field(default_factory=Offset)
+    undo_history: Union[EditHistory, None] = None
+
+
+def _blank_history(template: EditHistory) -> EditHistory:
+    """Returns an empty undo history, configured like the template."""
+    return EditHistory(
+        max_checkpoints=template.max_checkpoints,
+        checkpoint_timer=template.checkpoint_timer,
+        checkpoint_max_characters=template.checkpoint_max_characters,
+    )
 
 
 class CodeEditor(TextEditor, inherit_bindings=False):
@@ -87,6 +108,34 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         # the cursor is in trailing whitespace after the last query.
         return [queries[-1][2]]
 
+    def capture_state(self) -> Union[EditorState, None]:
+        """
+        Returns the state of the buffer loaded in the editor, or None if the
+        editor has not yet composed its TextArea.
+        """
+        if self.text_input is None:
+            return None
+        return EditorState(
+            text=self.text_input.text,
+            selection=self.text_input.selection,
+            scroll_offset=self.text_input.scroll_offset,
+            undo_history=self.text_input.history,
+        )
+
+    def load_state(self, state: EditorState) -> None:
+        """Swaps a buffer's state into the editor, in place of what it holds now."""
+        if self.text_input is None:
+            return
+        # load_text clears the history it finds, so hand it a throwaway one and
+        # install the buffer's own history afterwards.
+        self.text_input.history = _blank_history(self.text_input.history)
+        self.text_input.load_text(state.text)
+        self.text_input.history = state.undo_history or _blank_history(
+            self.text_input.history
+        )
+        self.text_input.selection = state.selection
+        self.text_input.scroll_to(*state.scroll_offset, animate=False)
+
     def on_mount(self) -> None:
         self.post_message(EditorCollection.EditorSwitched(active_editor=self))
         self.post_message(WidgetMounted(widget=self))
@@ -146,7 +195,12 @@ class CodeEditor(TextEditor, inherit_bindings=False):
             self.app.action_focus_data_catalog()
 
 
-class EditorCollection(TabbedContent):
+class EditorCollection(Vertical):
+    """
+    A row of tabs over a single editor. Switching tabs swaps the loaded buffer's
+    state out of the editor and the newly-active buffer's state in.
+    """
+
     BORDER_TITLE = "Query Editor"
     theme: reactive[str] = reactive("harlequin")
 
@@ -157,8 +211,6 @@ class EditorCollection(TabbedContent):
 
     def __init__(
         self,
-        *titles: ContentType,
-        initial: str = "",
         name: Union[str, None] = None,
         id: Union[str, None] = None,  # noqa: A002
         classes: Union[str, None] = None,
@@ -167,41 +219,55 @@ class EditorCollection(TabbedContent):
         theme: str = "harlequin",
     ):
         super().__init__(
-            *titles,
-            initial=initial,
             name=name,
             id=id,
             classes=classes,
             disabled=disabled,
         )
         self.language = language
-        self.theme = theme
         self.counter = 0
         self._word_completer: WordCompleter | None = None
         self._member_completer: MemberCompleter | None = None
         self.startup_cache = load_cache()
+        self.buffer_states: dict[str, EditorState] = {}
+        self.loaded_buffer_id: str | None = None
+        self.tabs = Tabs()
+        self.tabs.can_focus = False
+        self.editor = CodeEditor(id="buffer", language=language, theme=theme)
+        self.theme = theme
+
+    def compose(self) -> ComposeResult:
+        yield self.tabs
+        yield self.editor
 
     @property
     def current_editor(self) -> CodeEditor:
-        content = self.query_one(ContentSwitcher)
-        active_tab_id = self.active
-        if active_tab_id:
-            try:
-                tab_pane = content.query_one(f"#{active_tab_id}", TabPane)
-                return tab_pane.query_one(CodeEditor)
-            except (NoMatches, InvalidQueryFormat):
-                pass
-        all_editors = content.query(CodeEditor)
-        return all_editors.first(CodeEditor)
+        return self.editor
 
     @property
-    def all_editors(self) -> List[CodeEditor]:
-        try:
-            content = self.query_one(ContentSwitcher)
-            all_editors = content.query(CodeEditor)
-        except NoMatches:
-            return []
-        return list(all_editors)
+    def active(self) -> Union[str, None]:
+        """The ID of the active buffer's tab."""
+        return self.tabs.active or None
+
+    @property
+    def tab_count(self) -> int:
+        return len(self.buffer_states)
+
+    @property
+    def buffers(self) -> List[BufferState]:
+        """The state of every buffer, in tab order, for the editor cache."""
+        self._save_loaded_buffer()
+        return [
+            BufferState(selection=state.selection, text=state.text)
+            for state in self.buffer_states.values()
+        ]
+
+    @property
+    def active_buffer_index(self) -> int:
+        buffer_ids = list(self.buffer_states)
+        if self.loaded_buffer_id is None or self.loaded_buffer_id not in buffer_ids:
+            return 0
+        return buffer_ids.index(self.loaded_buffer_id)
 
     @property
     def member_completer(self) -> MemberCompleter | None:
@@ -210,10 +276,7 @@ class EditorCollection(TabbedContent):
     @member_completer.setter
     def member_completer(self, new_completer: MemberCompleter) -> None:
         self._member_completer = new_completer
-        try:
-            self.current_editor.member_completer = new_completer
-        except NoMatches:
-            pass
+        self.editor.member_completer = new_completer
 
     @property
     def word_completer(self) -> WordCompleter | None:
@@ -222,96 +285,90 @@ class EditorCollection(TabbedContent):
     @word_completer.setter
     def word_completer(self, new_completer: WordCompleter) -> None:
         self._word_completer = new_completer
-        try:
-            self.current_editor.word_completer = new_completer
-        except NoMatches:
-            pass
+        self.editor.word_completer = new_completer
 
     async def on_mount(self) -> None:
-        if self.startup_cache is not None:
-            for _i, buffer in enumerate(self.startup_cache.buffers):
-                await self.action_new_buffer(state=buffer)
-                # we can't load the focus state here, since Tabs
-                # really wants to activate the first tab when it's
-                # mounted
+        if self.startup_cache is not None and self.startup_cache.buffers:
+            for buffer in self.startup_cache.buffers:
+                # the cache's focus state isn't restored, so the first
+                # buffer stays active, as it does on a cold start.
+                await self.action_new_buffer(state=buffer, activate=False)
         else:
             await self.action_new_buffer()
-        self.query_one(Tabs).can_focus = False
-        self.current_editor.word_completer = self.word_completer
-        self.current_editor.member_completer = self.member_completer
+        self.editor.theme = self.theme
+        self.editor.word_completer = self.word_completer
+        self.editor.member_completer = self.member_completer
         self.remove_class("premount")
         self.post_message(WidgetMounted(widget=self))
 
     def on_focus(self) -> None:
-        self.current_editor.focus()
+        self.editor.focus()
 
-    def on_tabbed_content_tab_activated(
-        self, message: TabbedContent.TabActivated
-    ) -> None:
+    def on_tabs_tab_activated(self, message: Tabs.TabActivated) -> None:
         message.stop()
-        self.post_message(self.EditorSwitched(active_editor=None))
-        self.current_editor.word_completer = self.word_completer
-        self.current_editor.member_completer = self.member_completer
-        self.current_editor.focus()
+        new_buffer_id = message.tab.id
+        if new_buffer_id is None or new_buffer_id == self.loaded_buffer_id:
+            return
+        self._save_loaded_buffer()
+        self.loaded_buffer_id = new_buffer_id
+        state = self.buffer_states.get(new_buffer_id)
+        if state is not None:
+            self.editor.load_state(state)
+        self.post_message(self.EditorSwitched(active_editor=self.editor))
+        self.editor.focus()
 
     def watch_theme(self, theme: str) -> None:
-        for editor in self.all_editors:
-            editor.theme = theme
+        if self.editor.is_mounted:
+            self.editor.theme = theme
 
     async def insert_buffer_with_text(self, query_text: str) -> None:
         state = BufferState(selection=Selection(), text=query_text)
-        new_editor = await self.action_new_buffer(state=state)
-        new_editor.focus()
+        await self.action_new_buffer(state=state)
 
     async def action_new_buffer(
-        self, state: Union[BufferState, None] = None
+        self, state: Union[BufferState, None] = None, activate: bool = True
     ) -> CodeEditor:
         self.counter += 1
-        new_tab_id = f"tab-{self.counter}"
-        editor = CodeEditor(
-            id=f"buffer-{self.counter}",
-            text=state.text if state is not None else "",
-            language=self.language,
-            theme=self.theme,
-            word_completer=self.word_completer,
-            member_completer=self.member_completer,
+        new_buffer_id = f"tab-{self.counter}"
+        self.buffer_states[new_buffer_id] = (
+            EditorState(text=state.text, selection=state.selection)
+            if state is not None
+            else EditorState()
         )
-        pane = TabPane(
-            f"Tab {self.counter}",
-            editor,
-            id=new_tab_id,
-        )
-        await self.add_pane(pane)
-        if state is not None:
-            editor.selection = state.selection
-        else:
-            self.active = new_tab_id
-            try:
-                self.current_editor.focus()
-            except NoMatches:
-                pass
+        await self.tabs.add_tab(Tab(f"Tab {self.counter}", id=new_buffer_id))
+        if activate:
+            # adding the first tab activates it; any later tab has to be
+            # activated here to swap its state into the editor.
+            self.tabs.active = new_buffer_id
+            self.editor.focus()
         if self.counter > 1:
             self.remove_class("hide-tabs")
-        return editor
+        return self.editor
 
     def action_close_buffer(self) -> None:
         if self.tab_count > 1:
             if self.tab_count == 2:
                 self.add_class("hide-tabs")
-            self.remove_pane(self.active)
+            closed_buffer_id = self.active
+            # the editor's contents belong to the buffer being closed, so they
+            # are dropped rather than saved when the next tab is activated.
+            self.loaded_buffer_id = None
+            if closed_buffer_id is not None:
+                self.buffer_states.pop(closed_buffer_id, None)
+                self.tabs.remove_tab(closed_buffer_id)
         else:
-            self.current_editor.text = ""
-            self.current_editor.cursor = (0, 0)  # type: ignore
-        self.current_editor.focus()
+            self.editor.load_state(EditorState())
+        self.editor.focus()
 
     def action_next_buffer(self) -> None:
-        active = self.active
-        if self.tab_count < 2 or active is None:
+        if self.tab_count < 2:
             return
-        tabs = self.query(TabPane)
-        next_tabs = tabs[1:]
-        next_tabs.append(tabs[0])
-        lookup = {t.id: nt.id for t, nt in zip(tabs, next_tabs, strict=False)}
-        self.active = lookup[active]  # type: ignore
-        self.post_message(self.EditorSwitched(active_editor=None))
-        self.current_editor.focus()
+        self.tabs.action_next_tab()
+
+    def _save_loaded_buffer(self) -> None:
+        """Copies the editor's contents back into the buffer they were loaded from."""
+        if self.loaded_buffer_id is None:
+            return
+        state = self.editor.capture_state()
+        if state is not None and self.loaded_buffer_id in self.buffer_states:
+            self.buffer_states[self.loaded_buffer_id] = state

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -290,9 +290,8 @@ class EditorCollection(Vertical):
     async def on_mount(self) -> None:
         if self.startup_cache is not None and self.startup_cache.buffers:
             for buffer in self.startup_cache.buffers:
-                # the cache's focus state isn't restored, so the first
-                # buffer stays active, as it does on a cold start.
                 await self.action_new_buffer(state=buffer, activate=False)
+            self._activate_cached_buffer(self.startup_cache.focus_index)
         else:
             await self.action_new_buffer()
         self.editor.theme = self.theme
@@ -364,6 +363,13 @@ class EditorCollection(Vertical):
         if self.tab_count < 2:
             return
         self.tabs.action_next_tab()
+
+    def _activate_cached_buffer(self, focus_index: int) -> None:
+        """Reopens the buffer that was active when the cache was written."""
+        buffer_ids = list(self.buffer_states)
+        if not 0 <= focus_index < len(buffer_ids):
+            focus_index = 0
+        self.tabs.active = buffer_ids[focus_index]
 
     def _save_loaded_buffer(self) -> None:
         """Copies the editor's contents back into the buffer they were loaded from."""

--- a/src/harlequin/editor_cache.py
+++ b/src/harlequin/editor_cache.py
@@ -17,7 +17,7 @@ class BufferState:
 
 @dataclass
 class Cache:
-    focus_index: int  # currently doesn't impact focus on load
+    focus_index: int
     buffers: List[BufferState]
 
 

--- a/tests/functional_tests/test_cache.py
+++ b/tests/functional_tests/test_cache.py
@@ -70,6 +70,9 @@ async def test_harlequin_loads_cache(cache: Cache, app: Harlequin) -> None:
         assert [buffer.text for buffer in app.editor_collection.buffers] == [
             buffer.text for buffer in cache.buffers
         ]
+        # the buffer that was active when the cache was written is active again
+        assert app.editor_collection.active_buffer_index == cache.focus_index
+        assert app.editor.text == cache.buffers[cache.focus_index].text
 
 
 @pytest.mark.use_cache
@@ -92,3 +95,4 @@ async def test_harlequin_writes_cache(app: Harlequin) -> None:
         cache = pickle.load(f)
     assert isinstance(cache, Cache)
     assert [buffer.text for buffer in cache.buffers] == ["first", "second"]
+    assert cache.focus_index == 1

--- a/tests/functional_tests/test_cache.py
+++ b/tests/functional_tests/test_cache.py
@@ -67,7 +67,7 @@ async def test_harlequin_loads_cache(cache: Cache, app: Harlequin) -> None:
         assert app.editor_collection is not None
         assert app.editor is not None
         assert app.editor_collection.tab_count == len(cache.buffers)
-        assert [editor.text for editor in app.editor_collection.all_editors] == [
+        assert [buffer.text for buffer in app.editor_collection.buffers] == [
             buffer.text for buffer in cache.buffers
         ]
 

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -115,6 +115,61 @@ async def test_multiple_buffers(
         assert all(snap_results)
 
 
+@pytest.mark.asyncio
+async def test_buffers_keep_their_state(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """Switching buffers has to carry everything the editor holds, not just the text."""
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        app.editor.focus()
+        await pilot.press(*"select 1")
+        await pilot.press("ctrl+n")
+        await pilot.pause()
+        await pilot.press(*"select 2")
+        await pilot.press("ctrl+k")
+        await pilot.pause()
+
+        assert app.editor_collection.active == "tab-1"
+        assert app.editor.text == "select 1"
+        assert app.editor.selection == Selection((0, 8), (0, 8))
+
+        # the undo history moves with the buffer: this undoes the typing
+        # in buffer one, not the switch that loaded it.
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+        assert app.editor.text == ""
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+        assert app.editor.text == ""
+
+        await pilot.press("ctrl+k")
+        await pilot.pause()
+        assert app.editor_collection.active == "tab-2"
+        assert app.editor.text == "select 2"
+
+        # a buffer scrolled away from its cursor comes back where it was,
+        # instead of snapping to the cursor.
+        assert app.editor.text_input is not None
+        app.editor.text = "\n".join(f"select {i}" for i in range(100))
+        await pilot.press("ctrl+down", "ctrl+down", "ctrl+down")
+        await pilot.pause()
+        scrolled_to = app.editor.text_input.scroll_offset
+        assert scrolled_to.y > 0
+        assert app.editor.selection == Selection((0, 0), (0, 0))
+
+        await pilot.press("ctrl+k")
+        await pilot.pause()
+        await pilot.press("ctrl+k")
+        await pilot.pause()
+        assert app.editor_collection.active == "tab-2"
+        assert app.editor.text_input.scroll_offset == scrolled_to
+
+
 @pytest.mark.flaky
 @pytest.mark.asyncio
 async def test_word_autocomplete(


### PR DESCRIPTION
Closes #636

**What** are the key elements of this solution?

`EditorCollection` was a `TabbedContent` that built a `CodeEditor` — and with it a `TextArea`, a tree-sitter parse, and a full widget mount — per open buffer. It is now a plain `Vertical` holding a row of `Tabs` over **one** `CodeEditor`.

- Every buffer but the active one lives in `EditorCollection.buffer_states` as an `EditorState`. Activating a tab saves the loaded buffer's state out of the editor and loads the new one's in, via `CodeEditor.capture_state()` / `load_state()`.
- `EditorState` carries text, selection, scroll offset, and undo history — everything a user expects to survive a tab switch.
- `app.action_quit` reads the editor cache through `editor_collection.buffers` / `active_buffer_index` instead of walking editors.
- The cache's `focus_index` is now honored on load, so Harlequin reopens the buffer you were last using instead of always starting on the first one. It has been recorded on quit all along; activating the right buffer on load is a tab switch like any other now that buffers are state rather than mounted editors.
- Two small follow-ons: `CodeEditor` CSS goes `height: 100%` → `1fr` so it does not overflow under the two-row tab strip, and the `EditorSwitched` handler loses a `NoMatches` recovery path that could only fire against the `ContentSwitcher` that no longer exists.

Start-up is now flat in the number of buffers rather than linear in it (app start with N cached buffers, measured with a variant of `scripts/profile_buffers.py`):

| buffers | before | after |
| --- | --- | --- |
| 10 | 3282 ms | 861 ms |
| 25 | 9402 ms | 1020 ms |

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Plain `Tabs` rather than `TabbedContent` because the tabs are now only an interface: there are no panes left to switch between, and `TabbedContent` exists to own a `ContentSwitcher`. Tab IDs are unchanged (`tab-1`, `tab-2`, …), tab clicks and `ctrl+n`/`ctrl+w`/`ctrl+k` behave as before, and every one of the 148 snapshots passes unchanged — the refactor is pixel-identical.

The state swap needs care in one place. `TextArea.load_text()` clears whatever `EditHistory` it finds, so `load_state()` hands it a throwaway and installs the buffer's own history afterwards. Without that, `ctrl+z` after a switch would try to undo the swap itself, and each buffer would lose its undo stack on every visit. Scroll offset is restored explicitly too, since restoring the selection alone would snap a buffer that had been scrolled away from its cursor.

An alternative would have been a `get_state`/`set_state` pair upstream in `textual-textarea`. It is a reasonable thing for that library to own eventually, but which buffers exist and what they hold is Harlequin's concept, and the swap needs only public API (`text_input`, `load_text`, `scroll_to`, and `EditHistory` as exported by `textual.widgets.text_area`), so it lives here.

One behavioral trade-off worth naming: find history is now shared across buffers, because there is one editor holding it. That seems like an improvement rather than a regression, but it is a change.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

`test_buffers_keep_their_state` pins selection, undo history, and scroll offset across switches; it fails if either the history swap or the scroll restore is removed. `test_harlequin_loads_cache` and `test_harlequin_writes_cache` now cover the `focus_index` round trip. The existing multi-buffer, cache, and history-screen tests carry the rest. Full suite: 973 passed, 6 skipped, 1 xfailed, plus the py12 subset, mypy, ruff, and `lint-imports`.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_019CNBmKKrfv7iHBYWZFPMJ9)_