### PR TITLE
Add `hsql --catalog`, listing one level of the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+
 ## [2.10.0] - 2026-08-25
 
 ### Breaking Changes
@@ -21,7 +25,6 @@ All notable changes to this project will be documented in this file.
   - `validate` reports every problem in every discovered config file. It exits `2` on any validation errors. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
   - `schema` writes a JSON Schema for a Harlequin config file, including options for every installed adapter. Point your editor at it for completion and validation as you type in your `harlequin.toml`.
   - `init` creates a profile from the passed CLI options: `hsql --config init -P prod -a sqlite ./my.db --read-only` writes `[profiles.prod]` with the options you passed.
-- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Adds `hsql --spec`, a machine-readable `--help`: hsql's options and every installed adapter's connection options, as JSON. `-a NAME` narrows it to one adapter. 
 - Adds `hsql --info`, a JSON report on your installation: versions, platform, discovered config files, installed adapters, etc. `-a NAME` narrows it to one adapter. 
 - Harlequin and `hsql` now redact secrets instead of showing them in output ([#667](https://github.com/tconbeer/harlequin/issues/667)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - `validate` reports every problem in every discovered config file. It exits `2` on any validation errors. It is rows, so `--csv`, `-o` and `-t`/`-A` apply.
   - `schema` writes a JSON Schema for a Harlequin config file, including options for every installed adapter. Point your editor at it for completion and validation as you type in your `harlequin.toml`.
   - `init` creates a profile from the passed CLI options: `hsql --config init -P prod -a sqlite ./my.db --read-only` writes `[profiles.prod]` with the options you passed.
+- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Adds `hsql --spec`, a machine-readable `--help`: hsql's options and every installed adapter's connection options, as JSON. `-a NAME` narrows it to one adapter. 
 - Adds `hsql --info`, a JSON report on your installation: versions, platform, discovered config files, installed adapters, etc. `-a NAME` narrows it to one adapter. 
 - Harlequin and `hsql` now redact secrets instead of showing them in output ([#667](https://github.com/tconbeer/harlequin/issues/667)

--- a/docs/plans/m2-hsql-technical-plan.md
+++ b/docs/plans/m2-hsql-technical-plan.md
@@ -398,6 +398,15 @@ flag should not change meaning with context. An agent that has learned `-c` type
 lookup for a relation named `select 1`. `--path` also leaves `-c` free to mean what it
 means, if a later milestone wants `--catalog` and a query in one invocation.
 
+**Nor a value on `--catalog` itself** (Ted's question, taken after PR 9). `--catalog PATH`
+reads better and costs two tokens fewer, but click takes an optional value greedily -- the
+next token, whether or not an `=` is written -- and `CONN_STR` is a variadic positional. So
+`hsql --catalog mydb.db` would read the file as a catalog path against an in-memory
+database, which is the `hsql catalog`-versus-a-file-named-`catalog` ambiguity in a different
+spelling, and it would need the rule §3.1 exists to avoid. With `--path`, `CONN_STR` stays
+free to sit anywhere on the line and `hsql --catalog mydb.db` lists what is in `mydb.db`.
+`--find` composes either way: `--path` is the scope for it too (§3.8).
+
 **Which mode needs what**, because this is the table that keeps §3's second rule true:
 
 | mode | adapter import | connection | notable import |
@@ -995,8 +1004,10 @@ would land.
 
 - *Modes are options, not subcommands* (Ted's call, §3.1) — consistent with
   `harlequin --config`, and no verb-versus-conn_str ambiguity to adjudicate.
-- *The catalog path is `--path`*, not a reused `-c`, so no flag means SQL in one invocation
-  and an identifier in another (§3.1).
+- *The catalog path is `--path`*, not a reused `-c` and not a value on `--catalog` itself
+  (§3.1). `-c` would mean SQL in one invocation and an identifier in another; `--catalog
+  PATH` would take its value greedily and read `hsql --catalog mydb.db` as a path against an
+  in-memory database.
 - *One level, no `--depth`, no node budget* (§3.2). Recursion returns with
   `fetch_descendants()`, which is what would make it one round trip instead of 403.
 - *No `child_count` field* (§1.3). A count is only knowable by fetching, and `len(children)`

--- a/docs/plans/m2-hsql-technical-plan.md
+++ b/docs/plans/m2-hsql-technical-plan.md
@@ -465,6 +465,12 @@ filters one resolved parent's children in the client and stays one round trip.
 `--path *.orders` cannot be evaluated without fetching every candidate level, so it belongs
 to `--find` (§3.8) and is refused here rather than quietly walked.
 
+**Quoting is this syntax's own, not a database's.** A segment holding a dot, a quote or a
+wildcard is written in double quotes on every adapter -- not MySQL's backticks or SQL
+Server's brackets, since accepting those would make a label that *contains* one unreachable,
+and a path an agent copies out of a listing would then depend on which adapter wrote it. A
+path is `spell()`'s output, and the `path` column of a listing is where a caller gets one.
+
 There is nothing to instrument, either. An earlier draft had `--stats` report `round_trips`,
 which existed to make a recursive walk's cost visible after the fact; without recursion the
 number is `len(path) + 1` and a caller can read it off the path they typed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ source_modules = [
     "harlequin.config",
     "harlequin.exception",
     "harlequin.keymap",
+    "harlequin.navigate",
     "harlequin.options",
     "harlequin.plugins",
     "harlequin.redact",

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -25,6 +25,12 @@ class HarlequinBindingError(HarlequinError):
     pass
 
 
+class HarlequinCatalogPathError(HarlequinError):
+    """A path into the catalog that cannot be read, or names nothing."""
+
+    pass
+
+
 class HarlequinConnectionError(HarlequinError):
     pass
 

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -17,13 +17,14 @@ one is the default.
 A **mode** is the third shape. `--config MODE` reports on the config files --
 or, under `init`, writes a profile into one -- `--spec` reports on the command
 itself and `--info` on the installation, rather than any of them running SQL, so
-the first pass skips the profile. It names no adapter either, and the command
-carries no connection options at all, except for `--config init`: the options it
-writes into a profile are the ones an adapter declares. Modes are options rather
-than subcommands because `CONN_STR` is positional: `hsql catalog` and a DuckDB
-file named `catalog` would have needed a rule, and `--catalog` needs none. They are
-mutually exclusive, and each lives in `harlequin.hsql.modes`, imported by the
-callback when it is chosen.
+the first pass skips the profile. None of them names an adapter either, and the
+command carries no connection options at all, except for `--config init`: the
+options it writes into a profile are the ones an adapter declares. `--catalog`
+is the mode that does connect, so it takes a profile and an adapter exactly as a
+run does. Modes are options rather than subcommands because `CONN_STR` is
+positional: `hsql catalog` and a DuckDB file named `catalog` would have needed a
+rule, and `--catalog` needs none. They are mutually exclusive, and each lives in
+`harlequin.hsql.modes`, imported by the callback when it is chosen.
 """
 
 from __future__ import annotations
@@ -47,6 +48,7 @@ from harlequin.config import (
     parse_row_count,
 )
 from harlequin.exception import (
+    HarlequinCatalogPathError,
     HarlequinConfigError,
     HarlequinConnectionError,
     HarlequinError,
@@ -65,6 +67,7 @@ from harlequin.redact import hide_secrets_in
 if TYPE_CHECKING:
     from harlequin.adapter import HarlequinAdapter, HarlequinConnection
     from harlequin.layout import LayoutOptions
+    from harlequin.navigate import CatalogPath
     from harlequin.query import ExecutedStatement, OnError, ResultSet, RowLimit
     from harlequin.statements import Statement
 
@@ -112,6 +115,10 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
+            # not a mode, and not read here: declared so that the probe consumes
+            # its value the way the real parse will, rather than leaving a path
+            # among the arguments for `-a` or `-P` to trip over.
+            click.Option(["--path"]),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -260,6 +267,26 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         ),
     )
     @click.option(
+        "--catalog",
+        is_flag=True,
+        help=(
+            "List the catalog objects one level below --path, and exit without "
+            "running SQL."
+        ),
+    )
+    # `--path`, and not a reused `-c`: `-c` means SQL here, in psql and in
+    # duckdb, and a flag that means an identifier in one invocation and a query
+    # in another is one an agent will sooner or later get wrong in the direction
+    # that runs something.
+    @click.option(
+        "--path",
+        metavar="TEXT",
+        help=(
+            "Where in the catalog --catalog looks. Dotted segments, named by the "
+            "adapter; the top of the catalog by default. A trailing * filters."
+        ),
+    )
+    @click.option(
         "--spec",
         is_flag=True,
         help=(
@@ -325,6 +352,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         config_mode: str | None,
         spec: bool,
         info: bool,
+        catalog: bool,
+        path: str | None,
         **kwargs: Any,
     ) -> None:
         """Execute SQL and exit.
@@ -391,7 +420,14 @@ def build_cli(argv: Sequence[str]) -> click.Command:
 
         sources: list[tuple[str, tuple[str, ...]]] = ctx.meta.get(SOURCES, [])
 
-        mode = _one_mode(ctx, config_mode=config_mode, spec=spec, info=info)
+        mode = _one_mode(
+            ctx, catalog=catalog, config_mode=config_mode, spec=spec, info=info
+        )
+        if path is not None and not catalog:
+            # `--path` says where in the catalog to look, so on its own there is
+            # nothing for it to say it about.
+            diagnostics.error("--path says where --catalog looks; pass --catalog.")
+            ctx.exit(ExitCode.USAGE)
         if mode is not None and sources:
             # a mode does not run SQL, so `-c` or `-f` beside one is two
             # invocations spelled as one, and refusing is the safer half of the
@@ -402,6 +438,12 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 f"or drop {mode.split()[0]}."
             )
             ctx.exit(ExitCode.USAGE)
+
+        if "tuples_only" in explicitly_set:
+            # ahead of everything it could explain, including the connection:
+            # `-t nord` does not reliably fail, so there may be no error for
+            # this to attach itself to.
+            diagnostics.report_theme_confusion(conn_str)
 
         if info:
             ctx.exit(
@@ -471,6 +513,30 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 )
             )
 
+        if catalog:
+            catalog_path = _catalog_path(ctx, path)
+            if "limit" in explicitly_set:
+                # ahead of the connection, so that a caller who capped a listing
+                # that cannot be capped hears about it whether or not the
+                # database answers.
+                diagnostics.report_limit_ignored()
+            ctx.exit(
+                _report_catalog(
+                    ctx,
+                    _connect(ctx, adapter=adapter, conn_str=conn_str, values=values),
+                    catalog_path,
+                    destination=destination,
+                    format_name=format_name,
+                    display_rows=raw_display_rows,
+                    tuples_only=tuples_only,
+                    no_align=no_align,
+                    no_header=no_header,
+                    no_footer=no_footer,
+                    null_string=null_string,
+                    color=_use_color(color_when, destination),
+                )
+            )
+
         if not sources:
             diagnostics.error(
                 "no SQL to run. Pass -c/--command or -f/--file, "
@@ -503,23 +569,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             detect_overflow=limit is not None,
         )
 
-        if "tuples_only" in explicitly_set:
-            # ahead of the connection rather than after it: `-t nord` does not
-            # reliably fail, so there may be no error for this to explain.
-            diagnostics.report_theme_confusion(conn_str)
-
-        try:
-            adapter_instance = load_adapter(adapter)(conn_str=conn_str, **values)
-        except HarlequinConfigError as e:
-            diagnostics.report_error(e)
-            ctx.exit(ExitCode.USAGE)
-
-        connection: HarlequinConnection
-        try:
-            connection = adapter_instance.connect()
-        except HarlequinConnectionError as e:
-            diagnostics.report_error(e)
-            ctx.exit(ExitCode.CONNECTION)
+        connection = _connect(ctx, adapter=adapter, conn_str=conn_str, values=values)
 
         run = _Run()
         executed = _execute_all(
@@ -602,7 +652,12 @@ def build_cli(argv: Sequence[str]) -> click.Command:
 
 
 def _one_mode(
-    ctx: click.Context, *, config_mode: str | None, spec: bool, info: bool
+    ctx: click.Context,
+    *,
+    catalog: bool,
+    config_mode: str | None,
+    spec: bool,
+    info: bool,
 ) -> str | None:
     """The one mode this invocation chose, or exit having named the two it did.
 
@@ -611,6 +666,7 @@ def _one_mode(
     answer that is not a guess about which they meant.
     """
     asked = (
+        ("--catalog", catalog),
         (f"--config {config_mode}", config_mode is not None),
         ("--spec", spec),
         ("--info", info),
@@ -622,6 +678,102 @@ def _one_mode(
         )
         ctx.exit(ExitCode.USAGE)
     return chosen[0] if chosen else None
+
+
+def _connect(
+    ctx: click.Context,
+    *,
+    adapter: str,
+    conn_str: Sequence[str],
+    values: Mapping[str, Any],
+) -> "HarlequinConnection":
+    """The connection this invocation runs on, or exit having said why not.
+
+    Two exit codes, because they are two different things to fix: options the
+    adapter refused are the caller's, and a database that would not answer is
+    the database's.
+    """
+    try:
+        adapter_instance = load_adapter(adapter)(conn_str=conn_str, **values)
+    except HarlequinConfigError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+
+    try:
+        return adapter_instance.connect()
+    except HarlequinConnectionError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.CONNECTION)
+
+
+def _catalog_path(ctx: click.Context, raw: str | None) -> "CatalogPath":
+    """What `--path` named, or exit having said why it cannot be read.
+
+    Ahead of the connection: a wildcard in the middle of a path is refused by
+    the grammar, and refusing it after opening a connection would make the
+    caller wait to be told they typed something this cannot answer.
+    """
+    from harlequin.navigate import CatalogPath
+
+    try:
+        return CatalogPath.parse(raw)
+    except HarlequinCatalogPathError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+
+
+def _report_catalog(
+    ctx: click.Context,
+    connection: "HarlequinConnection",
+    path: "CatalogPath",
+    *,
+    destination: Path | None,
+    format_name: str,
+    display_rows: Any,
+    **output_options: Any,
+) -> ExitCode:
+    """Write one level of the catalog and return its code, or exit saying why not.
+
+    A listing is rows, so it takes the same options a result set does and says
+    the same thing on stderr when the row cap dropped some of them.
+    """
+    # here rather than at module scope, for the reason each mode lives in its
+    # own module: this one reaches the catalog walk and the row machinery, and a
+    # run that is not asking for a listing should pay for neither.
+    from harlequin.hsql.modes import catalog as catalog_mode
+
+    try:
+        display_limit = _display_limit(display_rows, format_name)
+    except HarlequinConfigError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    layout_options, file_options = _output_options(
+        format_name=format_name, display_limit=display_limit, **output_options
+    )
+
+    try:
+        with _sink(destination) as out:
+            result = catalog_mode.report(
+                out,
+                connection=connection,
+                path=path,
+                format_name=format_name,
+                layout_options=layout_options,
+                file_options=file_options,
+            )
+            out.flush()
+    except OSError as e:
+        # a `-o PATH` it could not write, which is the caller's to fix
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    except Exception as e:  # noqa: BLE001 -- adapters are third-party code
+        # a path that names nothing, and whatever the adapter raised fetching a
+        # level. Both are the answer to what was asked, so both get a code
+        # rather than a traceback.
+        diagnostics.report_error(e)
+        ctx.exit(diagnostics.exit_code_for(e))
+    _report_hidden_rows(result, layout_options)
+    return ExitCode.OK
 
 
 def _report_info(
@@ -1166,6 +1318,12 @@ def _epilog(installed: Sequence[str], adapter: str | None) -> str:
             "Limits:\n"
             "  --limit N         rows fetched from the database. -1 for all\n"
             "  --display-rows N  rows the text layouts print, of those fetched"
+        ),
+        (
+            "Catalog:\n"
+            f"  {PROGRAM} --catalog                     the top of the catalog\n"
+            f"  {PROGRAM} --catalog --path db.schema    one level below that\n"
+            f"  {PROGRAM} --catalog --path db.sch.tbl   a relation's columns"
         ),
         (
             "Exit codes:\n"

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -115,10 +115,6 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
-            # not a mode, and not read here: declared so that the probe consumes
-            # its value the way the real parse will, rather than leaving a path
-            # among the arguments for `-a` or `-P` to trip over.
-            click.Option(["--path"]),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -274,10 +270,6 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             "running SQL."
         ),
     )
-    # `--path`, and not a reused `-c`: `-c` means SQL here, in psql and in
-    # duckdb, and a flag that means an identifier in one invocation and a query
-    # in another is one an agent will sooner or later get wrong in the direction
-    # that runs something.
     @click.option(
         "--path",
         metavar="TEXT",
@@ -424,9 +416,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx, catalog=catalog, config_mode=config_mode, spec=spec, info=info
         )
         if path is not None and not catalog:
-            # `--path` says where in the catalog to look, so on its own there is
-            # nothing for it to say it about.
-            diagnostics.error("--path says where --catalog looks; pass --catalog.")
+            diagnostics.error("--path must be used with --catalog.")
             ctx.exit(ExitCode.USAGE)
         if mode is not None and sources:
             # a mode does not run SQL, so `-c` or `-f` beside one is two
@@ -440,9 +430,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.exit(ExitCode.USAGE)
 
         if "tuples_only" in explicitly_set:
-            # ahead of everything it could explain, including the connection:
-            # `-t nord` does not reliably fail, so there may be no error for
-            # this to attach itself to.
+            # ahead of the modes as well as the connection: `-t nord` does not
+            # reliably fail, so there may be no error for this to explain.
             diagnostics.report_theme_confusion(conn_str)
 
         if info:
@@ -516,9 +505,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         if catalog:
             catalog_path = _catalog_path(ctx, path)
             if "limit" in explicitly_set:
-                # ahead of the connection, so that a caller who capped a listing
-                # that cannot be capped hears about it whether or not the
-                # database answers.
+                # ahead of the connection, so it is said whether or not the
+                # database answers
                 diagnostics.report_limit_ignored()
             ctx.exit(
                 _report_catalog(
@@ -687,12 +675,7 @@ def _connect(
     conn_str: Sequence[str],
     values: Mapping[str, Any],
 ) -> "HarlequinConnection":
-    """The connection this invocation runs on, or exit having said why not.
-
-    Two exit codes, because they are two different things to fix: options the
-    adapter refused are the caller's, and a database that would not answer is
-    the database's.
-    """
+    """The connection this invocation runs on, or exit having said why not."""
     try:
         adapter_instance = load_adapter(adapter)(conn_str=conn_str, **values)
     except HarlequinConfigError as e:
@@ -709,9 +692,8 @@ def _connect(
 def _catalog_path(ctx: click.Context, raw: str | None) -> "CatalogPath":
     """What `--path` named, or exit having said why it cannot be read.
 
-    Ahead of the connection: a wildcard in the middle of a path is refused by
-    the grammar, and refusing it after opening a connection would make the
-    caller wait to be told they typed something this cannot answer.
+    Called ahead of the connection, so a path this cannot read is refused
+    without waiting on a database.
     """
     from harlequin.navigate import CatalogPath
 
@@ -732,14 +714,9 @@ def _report_catalog(
     display_rows: Any,
     **output_options: Any,
 ) -> ExitCode:
-    """Write one level of the catalog and return its code, or exit saying why not.
-
-    A listing is rows, so it takes the same options a result set does and says
-    the same thing on stderr when the row cap dropped some of them.
-    """
+    """Write one level of the catalog and return its code, or exit saying why not."""
     # here rather than at module scope, for the reason each mode lives in its
-    # own module: this one reaches the catalog walk and the row machinery, and a
-    # run that is not asking for a listing should pay for neither.
+    # own module: this one reaches the catalog walk and the row machinery.
     from harlequin.hsql.modes import catalog as catalog_mode
 
     try:
@@ -767,9 +744,8 @@ def _report_catalog(
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
     except Exception as e:  # noqa: BLE001 -- adapters are third-party code
-        # a path that names nothing, and whatever the adapter raised fetching a
-        # level. Both are the answer to what was asked, so both get a code
-        # rather than a traceback.
+        # a path that names nothing, or whatever the adapter raised fetching a
+        # level: a code rather than a traceback for both.
         diagnostics.report_error(e)
         ctx.exit(diagnostics.exit_code_for(e))
     _report_hidden_rows(result, layout_options)

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -24,6 +24,7 @@ from enum import IntEnum
 from typing import Any, Sequence
 
 from harlequin.exception import (
+    HarlequinCatalogPathError,
     HarlequinConfigError,
     HarlequinConnectionError,
     HarlequinError,
@@ -83,7 +84,9 @@ def exit_code_for(error: BaseException) -> ExitCode:
     """The code hsql exits with, having failed with `error`."""
     if isinstance(error, KeyboardInterrupt):
         return ExitCode.INTERRUPT
-    if isinstance(error, HarlequinConfigError):
+    if isinstance(error, (HarlequinCatalogPathError, HarlequinConfigError)):
+        # a path that names nothing is a bad argument, not a failed query: the
+        # catalog answered, and what it answered is that there is no such item.
         return ExitCode.USAGE
     if isinstance(error, HarlequinConnectionError):
         return ExitCode.CONNECTION
@@ -166,6 +169,20 @@ def report_row_cap_ignored(format_name: str) -> None:
     note(
         f"--display-rows caps the text layouts, so it had no effect on "
         f"{format_name}; use --limit to fetch fewer rows"
+    )
+
+
+def report_limit_ignored() -> None:
+    """Say that `--limit` does not reach a listing.
+
+    It is the *hard* limit -- fewer rows leave the database -- and a catalog
+    listing is however many objects the adapter reported. Silence would read as
+    a limit that was applied, and a caller who thinks they capped a listing at
+    ten and got four hundred rows has no way to tell which happened.
+    """
+    note(
+        "--limit fetches fewer rows from the database, so it had no effect on "
+        "--catalog; use --display-rows to print fewer of them"
     )
 
 

--- a/src/harlequin/hsql/modes/__init__.py
+++ b/src/harlequin/hsql/modes/__init__.py
@@ -1,8 +1,8 @@
 """One module per `hsql` mode, imported only when that mode is asked for.
 
-A mode is an option rather than a subcommand (`--config show`, `--spec`,
-`--info`, and later `--catalog`), so the command stays one click command with one
-parse. What each mode costs is why they live in separate modules: the callback
+A mode is an option rather than a subcommand (`--catalog`, `--config show`,
+`--spec`, `--info`), so the command stays one click command with one parse.
+What each mode costs is why they live in separate modules: the callback
 imports the one it was given and nothing else, so that no mode pays for what it
 did not ask for -- `--spec` imports every installed adapter, and is the clearest
 case of a cost that must not reach the query path.

--- a/src/harlequin/hsql/modes/catalog.py
+++ b/src/harlequin/hsql/modes/catalog.py
@@ -1,23 +1,4 @@
-"""`--catalog`: what is one level below `--path`, as rows.
-
-A listing is rows -- `path`, `name`, `type`, `query_name` -- so it goes out
-through the same writer a query's results do. That is what makes `--format csv`,
-`-o PATH`, `-t`/`-A` and `--display-rows` mean here exactly what they mean
-there, and it is why M2 adds no output subsystem at all: a second renderer for
-the same job is how `--format json` and a catalog's JSON end up disagreeing
-about how to spell a null.
-
-**`path` is written to be passed back.** Each row's path is the one that lists
-*that* item's children, quoted where a label needs it, so walking down a catalog
-is copying a cell from the last answer rather than guessing at a spelling.
-**`query_name` is written for the same reason**: the adapter has already worked
-out whether this backend wants `"Orders"` or `` `orders` ``, and emitting it
-means the agent never has to.
-
-Describing a relation is listing it: `--path db.schema.orders` is the columns of
-`orders`, with their types and their quoted identifiers, which is everything a
-`describe` was going to print.
-"""
+"""Implements `hsql --catalog`: one level of the catalog, as rows."""
 
 from __future__ import annotations
 
@@ -29,13 +10,7 @@ if TYPE_CHECKING:
     from harlequin.navigate import CatalogPath
     from harlequin.query import ResultSet
 
-COLUMNS = ("path", "name", "type", "query_name")
-"""The columns of a listing, whatever level it came from.
-
-`type` is the catalog's short label -- `t`, `sch`, `##` -- which is what a level
-tells you about itself; §1.2 of the M2 plan is why there is nothing else it
-could say, since what a level *is* belongs to the adapter.
-"""
+COLUMNS = ("path", "name", "type_label", "query_name")
 
 
 def report(
@@ -50,23 +25,19 @@ def report(
     """Write one level of the catalog, and return the rows it wrote.
 
     The rows come back so the caller can say on stderr that a row cap dropped
-    some of them, which is the one thing a listing cannot say for itself under
-    `-t`.
+    some of them, which a listing cannot say for itself under `-t`.
 
     Raises: HarlequinCatalogPathError if the path names nothing, and whatever
     the adapter raises while fetching a level.
     """
     # deferred, both of them: the row machinery is pyarrow, and the walk is only
-    # reachable from this mode. Nothing else in hsql should pay for either.
+    # reachable from this mode.
     from harlequin.hsql import output
     from harlequin.navigate import list_children, spell
     from harlequin.query import rows_to_result
 
     listing = list_children(connection, path)
-    # in the order the adapter reported them, and not sorted: a relation's
-    # children are its columns, whose order is the table's rather than the
-    # alphabet's, and sorting them would throw away the one thing that order
-    # carries.
+    # not sorted, to preserve ordinal ordering for columns
     rows = [
         (
             spell([*path.segments, item.label]),

--- a/src/harlequin/hsql/modes/catalog.py
+++ b/src/harlequin/hsql/modes/catalog.py
@@ -1,0 +1,87 @@
+"""`--catalog`: what is one level below `--path`, as rows.
+
+A listing is rows -- `path`, `name`, `type`, `query_name` -- so it goes out
+through the same writer a query's results do. That is what makes `--format csv`,
+`-o PATH`, `-t`/`-A` and `--display-rows` mean here exactly what they mean
+there, and it is why M2 adds no output subsystem at all: a second renderer for
+the same job is how `--format json` and a catalog's JSON end up disagreeing
+about how to spell a null.
+
+**`path` is written to be passed back.** Each row's path is the one that lists
+*that* item's children, quoted where a label needs it, so walking down a catalog
+is copying a cell from the last answer rather than guessing at a spelling.
+**`query_name` is written for the same reason**: the adapter has already worked
+out whether this backend wants `"Orders"` or `` `orders` ``, and emitting it
+means the agent never has to.
+
+Describing a relation is listing it: `--path db.schema.orders` is the columns of
+`orders`, with their types and their quoted identifiers, which is everything a
+`describe` was going to print.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, BinaryIO, Mapping
+
+if TYPE_CHECKING:
+    from harlequin.adapter import HarlequinConnection
+    from harlequin.layout import LayoutOptions
+    from harlequin.navigate import CatalogPath
+    from harlequin.query import ResultSet
+
+COLUMNS = ("path", "name", "type", "query_name")
+"""The columns of a listing, whatever level it came from.
+
+`type` is the catalog's short label -- `t`, `sch`, `##` -- which is what a level
+tells you about itself; §1.2 of the M2 plan is why there is nothing else it
+could say, since what a level *is* belongs to the adapter.
+"""
+
+
+def report(
+    out: BinaryIO,
+    *,
+    connection: "HarlequinConnection",
+    path: "CatalogPath",
+    format_name: str,
+    layout_options: "LayoutOptions",
+    file_options: Mapping[str, Any],
+) -> "ResultSet":
+    """Write one level of the catalog, and return the rows it wrote.
+
+    The rows come back so the caller can say on stderr that a row cap dropped
+    some of them, which is the one thing a listing cannot say for itself under
+    `-t`.
+
+    Raises: HarlequinCatalogPathError if the path names nothing, and whatever
+    the adapter raises while fetching a level.
+    """
+    # deferred, both of them: the row machinery is pyarrow, and the walk is only
+    # reachable from this mode. Nothing else in hsql should pay for either.
+    from harlequin.hsql import output
+    from harlequin.navigate import list_children, spell
+    from harlequin.query import rows_to_result
+
+    listing = list_children(connection, path)
+    # in the order the adapter reported them, and not sorted: a relation's
+    # children are its columns, whose order is the table's rather than the
+    # alphabet's, and sorting them would throw away the one thing that order
+    # carries.
+    rows = [
+        (
+            spell([*path.segments, item.label]),
+            item.label,
+            item.type_label,
+            item.query_name,
+        )
+        for item in listing.items
+    ]
+    result = rows_to_result(COLUMNS, rows)
+    output.write(
+        result,
+        format_name,
+        out,
+        layout_options=layout_options,
+        file_options=file_options,
+    )
+    return result

--- a/src/harlequin/navigate.py
+++ b/src/harlequin/navigate.py
@@ -28,6 +28,14 @@ MUST_QUOTE = '."' + WILDCARDS
 _SEGMENT = re.compile(r'"(?P<quoted>(?:[^"]|"")*)"|(?P<bare>[^."]*)')
 """One path segment: a quoted run, or a run holding neither a dot nor a quote."""
 
+_SEGMENTS = re.compile(rf"(?:{_SEGMENT.pattern})(?P<end>\.|\Z)|(?P<misplaced>[\s\S])")
+"""Every segment, with the dot or end of path that closes it.
+
+The last alternative is where a quote that closes no segment lands. `finditer`
+skips text that matches nothing, so without it `"a"b` would quietly parse as
+`b` -- a path that names something, rather than the error it is.
+"""
+
 
 @dataclass(frozen=True)
 class CatalogPath:
@@ -139,23 +147,19 @@ def _split(text: str) -> list[tuple[str, bool]]:
     already said is a character.
     """
     segments: list[tuple[str, bool]] = []
-    position = 0
-    while True:
-        segment = _SEGMENT.match(text, position)
-        # `bare` matches the empty string, so there is always a match
-        assert segment is not None
-        quoted = segment["quoted"]
+    for match in _SEGMENTS.finditer(text):
+        if match["misplaced"] is not None:
+            raise _misplaced_quote(text, match.start())
+        quoted = match["quoted"]
         segments.append(
-            (str(segment["bare"]), False)
+            (str(match["bare"]), False)
             if quoted is None
             else (quoted.replace('""', '"'), True)
         )
-        position = segment.end()
-        if position == len(text):
+        if not match["end"]:
+            # the end of the path rather than a dot. It is zero-width, so
+            # another empty match is waiting at this same position.
             break
-        if text[position] != ".":
-            raise _misplaced_quote(text, position)
-        position += 1
     for value, was_quoted in segments:
         if not value and not was_quoted:
             raise HarlequinCatalogPathError(

--- a/src/harlequin/navigate.py
+++ b/src/harlequin/navigate.py
@@ -1,27 +1,8 @@
-"""Standing somewhere in a catalog, and listing what is directly under it.
+"""Resolving a dotted path into a catalog, and listing the level below it.
 
-The catalog contract is lazy in one direction only: `get_catalog()` returns the
-top level, and every level below it is a `fetch_children()` call on the item you
-are already holding. So there is no way to *reach* an item except by fetching
-its ancestors, and this module is that walk -- one round trip per path segment,
-plus one for the level being listed.
-
-**One level, always.** A listing is the children of the item a path names, and
-nothing deeper, because what recursion costs depends entirely on where it
-starts: a second level below a database is one call per database, and a second
-level below a schema is one call per relation -- 401 calls on a schema with 400
-of them, on the call an agent most wants to make.
-
-**A trailing wildcard is sugar; an interior one is a different question.**
-`analytics.ord*` filters one resolved parent's children in the client and stays
-one round trip. `*.orders` cannot be answered without fetching every candidate
-level, so it is refused here rather than quietly walked.
-
-Paths are **positional segments**, and what a level means belongs to the adapter:
-DuckDB and Postgres are database.schema.relation.column, SQLite is
-database.relation.column, and BigQuery's project.dataset.table is four levels
-wearing different words. Nothing in the contract says how deep a catalog goes, so
-this module counts segments and lets each item's own type label say what it is.
+The catalog only hands out an item's children, so reaching an item means
+fetching its ancestors: one round trip per path segment, plus one for the level
+being listed.
 """
 
 from __future__ import annotations
@@ -38,12 +19,12 @@ if TYPE_CHECKING:
     from harlequin.adapter import HarlequinConnection
 
 WILDCARDS = "*?"
-"""What makes a segment a filter rather than a name, outside of quotes."""
+"""What makes an unquoted segment a filter rather than a name."""
 
 
 @dataclass(frozen=True)
 class CatalogPath:
-    """Where in a catalog to stand, and optionally which children to keep."""
+    """A dotted path into a catalog, and an optional filter on the level it names."""
 
     segments: tuple[str, ...] = ()
     """The items to walk through, outermost first. Empty is the top level."""
@@ -55,12 +36,11 @@ class CatalogPath:
     def parse(cls, text: str | None) -> "CatalogPath":
         """Read a dotted path, honoring double quotes around a segment.
 
-        Quoting is how a label containing a dot, or a literal `*`, is spelled --
-        the same escape SQL uses, so a `query_name` an adapter emitted can be
-        pasted back in as a path.
+        A label containing a dot, or a literal `*`, is written in quotes, as it
+        is in SQL.
 
         Raises: HarlequinCatalogPathError for an unterminated quote, an empty
-        segment, or a wildcard anywhere but at the end.
+        segment, or a wildcard anywhere but the last segment.
         """
         if text is None or not text.strip():
             return cls()
@@ -69,10 +49,10 @@ class CatalogPath:
         for value, was_quoted in ancestors:
             if not was_quoted and _has_wildcard(value):
                 raise HarlequinCatalogPathError(
-                    f"{value!r} is a wildcard in the middle of a path, which "
-                    "cannot be answered without fetching every level it could "
-                    "match. A wildcard is only allowed on the last segment.",
-                    title="Harlequin could not read that catalog path.",
+                    f"{value!r} contains a wildcard in the middle of a path, "
+                    "which is not supported. "
+                    "A wildcard is only allowed in the last path segment.",
+                    title="Invalid catalog path.",
                 )
         if not last_was_quoted and _has_wildcard(last):
             return cls(segments=tuple(value for value, _ in ancestors), glob=last)
@@ -92,9 +72,6 @@ class Listing:
 def resolve(connection: "HarlequinConnection", path: CatalogPath) -> CatalogItem | None:
     """The item `path` names, or None for the top of the catalog.
 
-    Costs one round trip per segment: the catalog can only hand out an item's
-    children, so every ancestor is fetched on the way past.
-
     Raises: HarlequinCatalogPathError if a segment names nothing.
     """
     item: CatalogItem | None = None
@@ -109,8 +86,8 @@ def resolve(connection: "HarlequinConnection", path: CatalogPath) -> CatalogItem
 def list_children(connection: "HarlequinConnection", path: CatalogPath) -> Listing:
     """The children of the item `path` names, and that item.
 
-    One round trip more than `resolve()`, and no more than that: a trailing
-    wildcard filters the children this fetched rather than widening the walk.
+    A trailing wildcard filters the children this fetched, rather than widening
+    the walk.
 
     Raises: HarlequinCatalogPathError if a segment names nothing.
     """
@@ -144,8 +121,7 @@ def _has_wildcard(segment: str) -> bool:
 def _split(text: str) -> list[tuple[str, bool]]:
     """Each segment of a dotted path, and whether it was written in quotes.
 
-    Quoted is carried alongside the value because it is what decides whether a
-    `*` in it is a wildcard or a character in a name.
+    A `*` in a quoted segment is a character in a name, not a wildcard.
     """
     segments: list[tuple[str, bool]] = []
     value: list[str] = []
@@ -174,7 +150,7 @@ def _split(text: str) -> list[tuple[str, bool]]:
         raise HarlequinCatalogPathError(
             f"{text!r} opens a quoted path segment and never closes it. "
             'Write a literal quote inside one as "".',
-            title="Harlequin could not read that catalog path.",
+            title="Invalid catalog path.",
         )
     segments.append(("".join(value), quoted))
     for segment, was_quoted in segments:
@@ -182,7 +158,7 @@ def _split(text: str) -> list[tuple[str, bool]]:
             raise HarlequinCatalogPathError(
                 f"{text!r} has an empty path segment. Segments are separated by "
                 "a dot, and a name that contains one is written in quotes.",
-                title="Harlequin could not read that catalog path.",
+                title="Invalid catalog path.",
             )
     return segments
 
@@ -192,9 +168,7 @@ def _find(
 ) -> CatalogItem:
     """The item in this level labelled `segment`.
 
-    Raises: HarlequinCatalogPathError naming what is there instead. A path an
-    agent guessed at is the common case, so the error is the one chance to
-    answer the question it was asking.
+    Raises: HarlequinCatalogPathError naming what is there instead.
     """
     for item in items:
         if item.label == segment:
@@ -213,15 +187,14 @@ def _find(
         hint = " That level has nothing under it."
     raise HarlequinCatalogPathError(
         f"There is no {segment!r} {where}.{hint}",
-        title="Harlequin could not find that catalog path.",
+        title="Invalid catalog path.",
     )
 
 
 def _children_of(item: CatalogItem) -> list[CatalogItem]:
-    """One item's children, fetching them if this is the first time it was asked.
+    """One item's children, fetching them the first time it is asked.
 
-    The same two questions the Data Catalog asks before it fetches: children it
-    already holds are the answer, and an item that says it is loaded has none.
+    The same two checks the Data Catalog makes before it fetches.
     """
     if item.children:
         return list(item.children)

--- a/src/harlequin/navigate.py
+++ b/src/harlequin/navigate.py
@@ -1,0 +1,233 @@
+"""Standing somewhere in a catalog, and listing what is directly under it.
+
+The catalog contract is lazy in one direction only: `get_catalog()` returns the
+top level, and every level below it is a `fetch_children()` call on the item you
+are already holding. So there is no way to *reach* an item except by fetching
+its ancestors, and this module is that walk -- one round trip per path segment,
+plus one for the level being listed.
+
+**One level, always.** A listing is the children of the item a path names, and
+nothing deeper, because what recursion costs depends entirely on where it
+starts: a second level below a database is one call per database, and a second
+level below a schema is one call per relation -- 401 calls on a schema with 400
+of them, on the call an agent most wants to make.
+
+**A trailing wildcard is sugar; an interior one is a different question.**
+`analytics.ord*` filters one resolved parent's children in the client and stays
+one round trip. `*.orders` cannot be answered without fetching every candidate
+level, so it is refused here rather than quietly walked.
+
+Paths are **positional segments**, and what a level means belongs to the adapter:
+DuckDB and Postgres are database.schema.relation.column, SQLite is
+database.relation.column, and BigQuery's project.dataset.table is four levels
+wearing different words. Nothing in the contract says how deep a catalog goes, so
+this module counts segments and lets each item's own type label say what it is.
+"""
+
+from __future__ import annotations
+
+import difflib
+import fnmatch
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Sequence
+
+from harlequin.catalog import CatalogItem, InteractiveCatalogItem
+from harlequin.exception import HarlequinCatalogPathError
+
+if TYPE_CHECKING:
+    from harlequin.adapter import HarlequinConnection
+
+WILDCARDS = "*?"
+"""What makes a segment a filter rather than a name, outside of quotes."""
+
+
+@dataclass(frozen=True)
+class CatalogPath:
+    """Where in a catalog to stand, and optionally which children to keep."""
+
+    segments: tuple[str, ...] = ()
+    """The items to walk through, outermost first. Empty is the top level."""
+
+    glob: str | None = None
+    """A trailing wildcard, applied to the listed children's labels."""
+
+    @classmethod
+    def parse(cls, text: str | None) -> "CatalogPath":
+        """Read a dotted path, honoring double quotes around a segment.
+
+        Quoting is how a label containing a dot, or a literal `*`, is spelled --
+        the same escape SQL uses, so a `query_name` an adapter emitted can be
+        pasted back in as a path.
+
+        Raises: HarlequinCatalogPathError for an unterminated quote, an empty
+        segment, or a wildcard anywhere but at the end.
+        """
+        if text is None or not text.strip():
+            return cls()
+        parsed = _split(text)
+        *ancestors, (last, last_was_quoted) = parsed
+        for value, was_quoted in ancestors:
+            if not was_quoted and _has_wildcard(value):
+                raise HarlequinCatalogPathError(
+                    f"{value!r} is a wildcard in the middle of a path, which "
+                    "cannot be answered without fetching every level it could "
+                    "match. A wildcard is only allowed on the last segment.",
+                    title="Harlequin could not read that catalog path.",
+                )
+        if not last_was_quoted and _has_wildcard(last):
+            return cls(segments=tuple(value for value, _ in ancestors), glob=last)
+        return cls(segments=tuple(value for value, _ in parsed))
+
+
+@dataclass
+class Listing:
+    """One level of a catalog: an item, and the children directly under it."""
+
+    parent: CatalogItem | None = None
+    """The item the path named, or None at the top level."""
+
+    items: list[CatalogItem] = field(default_factory=list)
+
+
+def resolve(connection: "HarlequinConnection", path: CatalogPath) -> CatalogItem | None:
+    """The item `path` names, or None for the top of the catalog.
+
+    Costs one round trip per segment: the catalog can only hand out an item's
+    children, so every ancestor is fetched on the way past.
+
+    Raises: HarlequinCatalogPathError if a segment names nothing.
+    """
+    item: CatalogItem | None = None
+    for depth, segment in enumerate(path.segments):
+        level = (
+            _children_of(item) if item is not None else connection.get_catalog().items
+        )
+        item = _find(segment, level, walked=path.segments[:depth])
+    return item
+
+
+def list_children(connection: "HarlequinConnection", path: CatalogPath) -> Listing:
+    """The children of the item `path` names, and that item.
+
+    One round trip more than `resolve()`, and no more than that: a trailing
+    wildcard filters the children this fetched rather than widening the walk.
+
+    Raises: HarlequinCatalogPathError if a segment names nothing.
+    """
+    parent = resolve(connection, path)
+    items = (
+        _children_of(parent) if parent is not None else connection.get_catalog().items
+    )
+    if path.glob is not None:
+        # `fnmatchcase`, not `fnmatch`: the latter normalizes case on Windows,
+        # and a listing that depends on the platform is not a listing a script
+        # can rely on.
+        items = [item for item in items if fnmatch.fnmatchcase(item.label, path.glob)]
+    return Listing(parent=parent, items=list(items))
+
+
+def spell(segments: Sequence[str]) -> str:
+    """Segments as a path `parse()` reads back as the same segments."""
+    return ".".join(_spell_segment(segment) for segment in segments)
+
+
+def _spell_segment(segment: str) -> str:
+    if segment and not any(char in segment for char in '."' + WILDCARDS):
+        return segment
+    return '"' + segment.replace('"', '""') + '"'
+
+
+def _has_wildcard(segment: str) -> bool:
+    return any(char in segment for char in WILDCARDS)
+
+
+def _split(text: str) -> list[tuple[str, bool]]:
+    """Each segment of a dotted path, and whether it was written in quotes.
+
+    Quoted is carried alongside the value because it is what decides whether a
+    `*` in it is a wildcard or a character in a name.
+    """
+    segments: list[tuple[str, bool]] = []
+    value: list[str] = []
+    quoted = False
+    in_quotes = False
+    position = 0
+    while position < len(text):
+        char = text[position]
+        if in_quotes:
+            if char != '"':
+                value.append(char)
+            elif text[position + 1 : position + 2] == '"':
+                value.append('"')
+                position += 1
+            else:
+                in_quotes = False
+        elif char == '"':
+            in_quotes = quoted = True
+        elif char == ".":
+            segments.append(("".join(value), quoted))
+            value, quoted = [], False
+        else:
+            value.append(char)
+        position += 1
+    if in_quotes:
+        raise HarlequinCatalogPathError(
+            f"{text!r} opens a quoted path segment and never closes it. "
+            'Write a literal quote inside one as "".',
+            title="Harlequin could not read that catalog path.",
+        )
+    segments.append(("".join(value), quoted))
+    for segment, was_quoted in segments:
+        if not segment and not was_quoted:
+            raise HarlequinCatalogPathError(
+                f"{text!r} has an empty path segment. Segments are separated by "
+                "a dot, and a name that contains one is written in quotes.",
+                title="Harlequin could not read that catalog path.",
+            )
+    return segments
+
+
+def _find(
+    segment: str, items: Sequence[CatalogItem], walked: Sequence[str]
+) -> CatalogItem:
+    """The item in this level labelled `segment`.
+
+    Raises: HarlequinCatalogPathError naming what is there instead. A path an
+    agent guessed at is the common case, so the error is the one chance to
+    answer the question it was asking.
+    """
+    for item in items:
+        if item.label == segment:
+            return item
+    where = f"under {spell(walked)}" if walked else "at the top of the catalog"
+    labels = [item.label for item in items]
+    close = difflib.get_close_matches(segment, labels, n=3)
+    if close:
+        hint = f" Did you mean {', '.join(close)}?"
+    elif labels:
+        shown = ", ".join(labels[:5])
+        hint = f" That level has {len(labels)}: {shown}" + (
+            ", ..." if len(labels) > 5 else ""
+        )
+    else:
+        hint = " That level has nothing under it."
+    raise HarlequinCatalogPathError(
+        f"There is no {segment!r} {where}.{hint}",
+        title="Harlequin could not find that catalog path.",
+    )
+
+
+def _children_of(item: CatalogItem) -> list[CatalogItem]:
+    """One item's children, fetching them if this is the first time it was asked.
+
+    The same two questions the Data Catalog asks before it fetches: children it
+    already holds are the answer, and an item that says it is loaded has none.
+    """
+    if item.children:
+        return list(item.children)
+    if isinstance(item, InteractiveCatalogItem) and not item.loaded:
+        children = list(item.fetch_children())
+        item.children = children
+        item.loaded = True
+        return children
+    return []

--- a/src/harlequin/navigate.py
+++ b/src/harlequin/navigate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import difflib
 import fnmatch
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Sequence
 
@@ -20,6 +21,14 @@ if TYPE_CHECKING:
 
 WILDCARDS = "*?"
 """What makes an unquoted segment a filter rather than a name."""
+
+MUST_QUOTE = '."' + WILDCARDS
+"""Characters a segment cannot hold without being written in quotes."""
+
+_TOKEN = re.compile(
+    r'"(?P<quoted>(?:[^"]|"")*)"|(?P<bare>[^."]+)|(?P<dot>\.)|(?P<unterminated>")'
+)
+"""One path token. The last alternative is a quote no closing quote matched."""
 
 
 @dataclass(frozen=True)
@@ -36,8 +45,8 @@ class CatalogPath:
     def parse(cls, text: str | None) -> "CatalogPath":
         """Read a dotted path, honoring double quotes around a segment.
 
-        A label containing a dot, or a literal `*`, is written in quotes, as it
-        is in SQL.
+        Double quotes on every adapter, whatever that database quotes its own
+        identifiers with: a path is `spell()`'s output, not SQL.
 
         Raises: HarlequinCatalogPathError for an unterminated quote, an empty
         segment, or a wildcard anywhere but the last segment.
@@ -109,9 +118,15 @@ def spell(segments: Sequence[str]) -> str:
 
 
 def _spell_segment(segment: str) -> str:
-    if segment and not any(char in segment for char in '."' + WILDCARDS):
+    # `parse()` reads a blank path as the top level, so a label that is empty or
+    # padded has to come back quoted or it would name the whole catalog
+    if segment.strip() == segment and segment and not _needs_quoting(segment):
         return segment
     return '"' + segment.replace('"', '""') + '"'
+
+
+def _needs_quoting(segment: str) -> bool:
+    return any(char in segment for char in MUST_QUOTE)
 
 
 def _has_wildcard(segment: str) -> bool:
@@ -126,32 +141,22 @@ def _split(text: str) -> list[tuple[str, bool]]:
     segments: list[tuple[str, bool]] = []
     value: list[str] = []
     quoted = False
-    in_quotes = False
-    position = 0
-    while position < len(text):
-        char = text[position]
-        if in_quotes:
-            if char != '"':
-                value.append(char)
-            elif text[position + 1 : position + 2] == '"':
-                value.append('"')
-                position += 1
-            else:
-                in_quotes = False
-        elif char == '"':
-            in_quotes = quoted = True
-        elif char == ".":
+    for token in _TOKEN.finditer(text):
+        kind = token.lastgroup
+        if kind == "dot":
             segments.append(("".join(value), quoted))
             value, quoted = [], False
+        elif kind == "quoted":
+            value.append(str(token["quoted"]).replace('""', '"'))
+            quoted = True
+        elif kind == "bare":
+            value.append(str(token["bare"]))
         else:
-            value.append(char)
-        position += 1
-    if in_quotes:
-        raise HarlequinCatalogPathError(
-            f"{text!r} opens a quoted path segment and never closes it. "
-            'Write a literal quote inside one as "".',
-            title="Invalid catalog path.",
-        )
+            raise HarlequinCatalogPathError(
+                f"{text!r} opens a quoted path segment and never closes it. "
+                'Write a literal quote inside one as "".',
+                title="Invalid catalog path.",
+            )
     segments.append(("".join(value), quoted))
     for segment, was_quoted in segments:
         if not segment and not was_quoted:

--- a/src/harlequin/navigate.py
+++ b/src/harlequin/navigate.py
@@ -25,10 +25,8 @@ WILDCARDS = "*?"
 MUST_QUOTE = '."' + WILDCARDS
 """Characters a segment cannot hold without being written in quotes."""
 
-_TOKEN = re.compile(
-    r'"(?P<quoted>(?:[^"]|"")*)"|(?P<bare>[^."]+)|(?P<dot>\.)|(?P<unterminated>")'
-)
-"""One path token. The last alternative is a quote no closing quote matched."""
+_SEGMENT = re.compile(r'"(?P<quoted>(?:[^"]|"")*)"|(?P<bare>[^."]*)')
+"""One path segment: a quoted run, or a run holding neither a dot nor a quote."""
 
 
 @dataclass(frozen=True)
@@ -136,36 +134,57 @@ def _has_wildcard(segment: str) -> bool:
 def _split(text: str) -> list[tuple[str, bool]]:
     """Each segment of a dotted path, and whether it was written in quotes.
 
-    A `*` in a quoted segment is a character in a name, not a wildcard.
+    A segment is one or the other and never a mix, so `"a"b` is refused rather
+    than read as `ab` -- and `"a"*` cannot ask for a wildcard the quotes have
+    already said is a character.
     """
     segments: list[tuple[str, bool]] = []
-    value: list[str] = []
-    quoted = False
-    for token in _TOKEN.finditer(text):
-        kind = token.lastgroup
-        if kind == "dot":
-            segments.append(("".join(value), quoted))
-            value, quoted = [], False
-        elif kind == "quoted":
-            value.append(str(token["quoted"]).replace('""', '"'))
-            quoted = True
-        elif kind == "bare":
-            value.append(str(token["bare"]))
-        else:
-            raise HarlequinCatalogPathError(
-                f"{text!r} opens a quoted path segment and never closes it. "
-                'Write a literal quote inside one as "".',
-                title="Invalid catalog path.",
-            )
-    segments.append(("".join(value), quoted))
-    for segment, was_quoted in segments:
-        if not segment and not was_quoted:
+    position = 0
+    while True:
+        segment = _SEGMENT.match(text, position)
+        # `bare` matches the empty string, so there is always a match
+        assert segment is not None
+        quoted = segment["quoted"]
+        segments.append(
+            (str(segment["bare"]), False)
+            if quoted is None
+            else (quoted.replace('""', '"'), True)
+        )
+        position = segment.end()
+        if position == len(text):
+            break
+        if text[position] != ".":
+            raise _misplaced_quote(text, position)
+        position += 1
+    for value, was_quoted in segments:
+        if not value and not was_quoted:
             raise HarlequinCatalogPathError(
                 f"{text!r} has an empty path segment. Segments are separated by "
                 "a dot, and a name that contains one is written in quotes.",
                 title="Invalid catalog path.",
             )
     return segments
+
+
+def _misplaced_quote(text: str, position: int) -> HarlequinCatalogPathError:
+    """Which of the two things a quote that did not end a segment was.
+
+    A quote with no closing quote after it opened a segment that never ends;
+    one with a closing quote made a segment part quoted and part not.
+    """
+    opened = _SEGMENT.match(text, position)
+    assert opened is not None
+    if text[position] == '"' and opened["quoted"] is None:
+        return HarlequinCatalogPathError(
+            f"{text!r} opens a quoted path segment and never closes it. "
+            'Write a literal quote inside one as "".',
+            title="Invalid catalog path.",
+        )
+    return HarlequinCatalogPathError(
+        f"{text!r} quotes part of a path segment. A segment is quoted whole or "
+        'not at all, and a literal quote inside a quoted one is written as "".',
+        title="Invalid catalog path.",
+    )
 
 
 def _find(

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -190,6 +190,15 @@
           ],
           "description": "Report on the config files hsql found, or write a profile into one, and exit without running SQL. One of: show, list-profiles, validate, schema, init."
         },
+        "catalog": {
+          "type": "boolean",
+          "description": "List the catalog objects one level below --path, and exit without running SQL.",
+          "default": false
+        },
+        "path": {
+          "type": "string",
+          "description": "Where in the catalog --catalog looks. Dotted segments, named by the adapter; the top of the catalog by default. A trailing * filters."
+        },
         "spec": {
           "type": "boolean",
           "description": "Every option here, plus every installed adapter's, as JSON. -a narrows it to one adapter.",

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -2548,6 +2548,295 @@ def test_info_is_in_the_help(hsql: Hsql) -> None:
     assert f"{PROGRAM} --info" in res.output
 
 
+# --- `--catalog`, the mode that lists one level of the catalog ----------------
+
+CATALOG_DDL = (
+    "create schema analytics; "
+    "create table analytics.orders "
+    "(id bigint, customer_id bigint, total decimal(18,2)); "
+    "create view analytics.order_summary as select 1 as n; "
+    'create schema "empty schema"; '
+    'create schema "my.schema"; '
+    'create table "my.schema"."t" (n bigint); '
+    "create schema \u5206\u6790"
+)
+"""Two levels below the database, a node with no children, and two labels a path
+cannot spell without quoting one and measuring the other in terminal cells."""
+
+
+def cells(stdout: str) -> list[list[str]]:
+    """One `-tA` listing, as rows of cells."""
+    return [row.split("|") for row in stdout.splitlines()]
+
+
+def path_of(stdout: str, name: str) -> str:
+    """The path cell of the row named `name`, which lists that item's children."""
+    return next(row[0] for row in cells(stdout) if row[1] == name)
+
+
+@pytest.fixture
+def catalog_db(hsql: Hsql, tmp_path: Path) -> list[str]:
+    """The arguments that reach a DuckDB file with a known catalog in it."""
+    argv = ["-a", "duckdb", "--no-init", str(tmp_path / "cat.db")]
+    res = hsql(*argv, "--format", "none", "-c", CATALOG_DDL)
+    assert res.exit_code == ExitCode.OK
+    return argv
+
+
+def test_catalog_lists_the_top_level(hsql: Hsql, catalog_db: list[str]) -> None:
+    res = hsql(*catalog_db, "--catalog", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == 'cat|cat|db|"cat"\n'
+
+
+def test_catalog_lists_one_level_below_path(hsql: Hsql, catalog_db: list[str]) -> None:
+    res = hsql(*catalog_db, "--catalog", "--path", "cat", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert [row[1] for row in cells(res.stdout)] == [
+        "analytics",
+        "empty schema",
+        "main",
+        "my.schema",
+        "\u5206\u6790",
+    ]
+
+
+def test_catalog_describes_a_relation_by_listing_it(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """There is no second mode for describing: a relation's children are its
+    columns, with their types and their quoted identifiers."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics.orders", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert cells(res.stdout) == [
+        ["cat.analytics.orders.customer_id", "customer_id", "##", '"customer_id"'],
+        ["cat.analytics.orders.id", "id", "##", '"id"'],
+        ["cat.analytics.orders.total", "total", "#.#", '"total"'],
+    ]
+
+
+def test_the_path_column_is_what_lists_that_items_children(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """Walking a catalog is copying a cell out of the last answer.
+
+    A path an agent has to spell for itself is one it will spell wrong for a
+    label with a dot in it, which is the case this walks through.
+    """
+    path = ""
+    for name in ("cat", "my.schema", "t"):
+        argv = ["--catalog", *(["--path", path] if path else [])]
+        res = hsql(*catalog_db, *argv, "-tA")
+        assert res.exit_code == ExitCode.OK, res.stderr
+        path = path_of(res.stdout, name)
+    assert path == 'cat."my.schema".t'
+
+    res = hsql(*catalog_db, "--catalog", "--path", path, "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert [row[1] for row in cells(res.stdout)] == ["n"]
+
+
+def test_catalog_measures_a_label_in_terminal_cells(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """A listing is laid out like any other result set: two ideographs are four
+    cells, where `len()` would call them two."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat")
+    assert res.exit_code == ExitCode.OK
+    # the path column is as wide as `cat.empty schema` and the name column as
+    # wide as `empty schema`; measured with len() these would be two cells short
+    assert (
+        ' cat.\u5206\u6790         | \u5206\u6790         | sch  | "cat"."\u5206\u6790"'
+    ) in res.stdout
+
+
+def test_catalog_query_name_is_the_adapters_own_quoting(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """The reason it is a column: the agent never guesses at a spelling."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert '"analytics"."orders"' in res.stdout
+
+
+def test_a_trailing_wildcard_filters_one_level(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics.order_s*", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert [row[1] for row in cells(res.stdout)] == ["order_summary"]
+
+
+def test_an_interior_wildcard_is_a_usage_error(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """It cannot be answered in one round trip, so it is refused rather than
+    quietly walked."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.*.orders")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "wildcard" in res.stderr
+
+
+def test_a_path_that_names_nothing_says_what_is_there(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytic")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "Did you mean analytics?" in res.stderr
+
+
+def test_a_node_with_no_children_is_zero_rows(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """Not an error: an empty schema is an answer, and the footer says so."""
+    res = hsql(*catalog_db, "--catalog", "--path", 'cat."empty schema"')
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.endswith("(0 rows)\n")
+
+
+def test_catalog_takes_every_format_a_result_set_does(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """A listing is rows, so it inherits the output layer rather than adding one."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--csv")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.splitlines()[0] == "path,name,type,query_name"
+
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--json")
+    assert res.exit_code == ExitCode.OK
+    assert [row["name"] for row in json.loads(res.stdout)] == [
+        "order_summary",
+        "orders",
+    ]
+
+
+def test_catalog_goes_to_the_file_dash_o_names(
+    hsql: Hsql, catalog_db: list[str], tmp_path: Path
+) -> None:
+    destination = tmp_path / "catalog.csv"
+    res = hsql(*catalog_db, "--catalog", "-o", str(destination), "--csv")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+    assert destination.read_text(encoding="utf-8").splitlines()[1].startswith("cat,cat")
+
+
+def test_catalog_writes_nothing_under_format_none(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    res = hsql(*catalog_db, "--catalog", "--format", "none")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+
+
+def test_display_rows_caps_a_listing(hsql: Hsql, catalog_db: list[str]) -> None:
+    """A listing with four hundred rows in it is a display problem, and the
+    layouts already solved it."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat", "--display-rows", "2")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.endswith("(2 of 5 rows)\n")
+
+
+def test_display_rows_says_on_stderr_what_the_footer_cannot(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    res = hsql(*catalog_db, "--catalog", "--path", "cat", "--display-rows", "2", "-t")
+    assert res.exit_code == ExitCode.OK
+    assert len(res.stdout.splitlines()) == 2
+    assert "printed 2 of 5 rows" in res.stderr
+
+
+def test_limit_says_it_did_not_reach_the_listing(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """It is the hard fetch limit, and a listing is however many objects the
+    adapter reported. Silence would read as a limit that was applied."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat", "--limit", "1", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert len(res.stdout.splitlines()) == 5
+    assert "--limit" in res.stderr and "no effect" in res.stderr
+
+
+def test_limit_left_at_its_default_says_nothing(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    res = hsql(*catalog_db, "--catalog", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stderr == ""
+
+
+def test_catalog_does_not_run_sql(hsql: Hsql, catalog_db: list[str]) -> None:
+    res = hsql(*catalog_db, "--catalog", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "does not run SQL" in res.stderr
+
+
+@pytest.mark.parametrize("other", [["--info"], ["--spec"], ["--config", "show"]])
+def test_catalog_beside_another_mode_is_a_usage_error(
+    hsql: Hsql, other: list[str]
+) -> None:
+    res = hsql("--catalog", *other)
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "--catalog" in res.stderr
+
+
+def test_path_without_catalog_is_a_usage_error(hsql: Hsql, duck: list[str]) -> None:
+    """`-c` means SQL in this CLI, so `--path` is what names a relation -- and a
+    flag that silently did nothing is the thing this command does not have."""
+    res = hsql(*duck, "--path", "main", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "--catalog" in res.stderr
+
+
+def test_catalog_carries_the_adapters_options(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """It connects, so unlike the other modes it takes what a connection takes.
+
+    `--force-install-extensions` because it reaches the adapter and changes
+    nothing on the way: with no `--extension` beside it there is nothing to
+    install.
+    """
+    res = hsql(*catalog_db, "--catalog", "--force-install-extensions", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == 'cat|cat|db|"cat"\n'
+
+
+def test_catalog_reads_the_profile_a_run_would(
+    hsql: Hsql, catalog_db: list[str], tmp_path: Path
+) -> None:
+    """It connects like a run, so it is configured like one."""
+    config_file = tmp_path / "profile.toml"
+    config_file.write_text(
+        f'[profiles.cat]\nadapter = "duckdb"\nconn_str = ["{catalog_db[-1]}"]\n'
+        "no_init = true\n"
+    )
+    res = hsql("--config-path", str(config_file), "-P", "cat", "--catalog", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == 'cat|cat|db|"cat"\n'
+
+
+def test_catalog_answers_for_every_bundled_adapter(
+    hsql: Hsql, both_adapters: list[str]
+) -> None:
+    """Every adapter names its levels differently, and every one has a top."""
+    res = hsql(*both_adapters, "--catalog", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.count("|db|") == 1
+
+
+def test_catalog_is_in_the_help(hsql: Hsql) -> None:
+    res = hsql("--help")
+    assert res.exit_code == ExitCode.OK
+    assert "--catalog" in res.output
+    assert "--path" in res.output
+    assert f"{PROGRAM} --catalog --path" in res.output
+
+
 # --- secrets, and the promise that none of them is printed -------------------
 
 SECRET = "hunter2-and-then-some"

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -2808,8 +2808,11 @@ def test_catalog_reads_the_profile_a_run_would(
 ) -> None:
     """It connects like a run, so it is configured like one."""
     config_file = tmp_path / "profile.toml"
+    # json.dumps, not an f-string: TOML reads a backslash in a basic string as
+    # an escape, so a Windows path would be a parse error rather than a path.
     config_file.write_text(
-        f'[profiles.cat]\nadapter = "duckdb"\nconn_str = ["{catalog_db[-1]}"]\n'
+        f'[profiles.cat]\nadapter = "duckdb"\n'
+        f"conn_str = [{json.dumps(catalog_db[-1])}]\n"
         "no_init = true\n"
     )
     res = hsql("--config-path", str(config_file), "-P", "cat", "--catalog", "-tA")

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -2645,9 +2645,7 @@ def test_catalog_measures_a_label_in_terminal_cells(
     assert res.exit_code == ExitCode.OK
     # the path column is as wide as `cat.empty schema` and the name column as
     # wide as `empty schema`; measured with len() these would be two cells short
-    assert (
-        ' cat.\u5206\u6790         | \u5206\u6790         | sch  | "cat"."\u5206\u6790"'
-    ) in res.stdout
+    assert " cat.\u5206\u6790         | \u5206\u6790         |" in res.stdout
 
 
 def test_catalog_query_name_is_the_adapters_own_quoting(
@@ -2702,7 +2700,7 @@ def test_catalog_takes_every_format_a_result_set_does(
     """A listing is rows, so it inherits the output layer rather than adding one."""
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--csv")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout.splitlines()[0] == "path,name,type,query_name"
+    assert res.stdout.splitlines()[0] == "path,name,type_label,query_name"
 
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--json")
     assert res.exit_code == ExitCode.OK
@@ -2784,12 +2782,11 @@ def test_catalog_beside_another_mode_is_a_usage_error(
 
 
 def test_path_without_catalog_is_a_usage_error(hsql: Hsql, duck: list[str]) -> None:
-    """`-c` means SQL in this CLI, so `--path` is what names a relation -- and a
-    flag that silently did nothing is the thing this command does not have."""
+    """A flag that silently did nothing is the thing this command does not have."""
     res = hsql(*duck, "--path", "main", "-c", "select 1")
     assert res.exit_code == ExitCode.USAGE
     assert res.stdout == ""
-    assert "--catalog" in res.stderr
+    assert "--path must be used with --catalog" in res.stderr
 
 
 def test_catalog_carries_the_adapters_options(

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -28,6 +28,7 @@ HEADLESS_IMPORTS = [
     "import harlequin.hsql.cli",
     "import harlequin.keymap",
     "import harlequin.layout",
+    "import harlequin.navigate",
     "import harlequin.options",
     "import harlequin.plugins",
     "import harlequin.redact",
@@ -234,6 +235,52 @@ def test_the_config_modes_import_no_database(
     )
     leaked = [m for m in proc.stderr.strip().replace("\n", ",").split(",") if m]
     assert not leaked, f"`hsql --config {mode}` imported {leaked}"
+
+
+def test_the_catalog_mode_imports_only_the_adapter_it_connects_with(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """A listing is rows that never went through a database, so nothing casts.
+
+    `ResultSet.text_columns()` returns strings unchanged, which is what keeps
+    duckdb out of a listing from any other adapter -- it is ~85ms, on the one
+    mode whose whole job is a fast look at what is there.
+    """
+    proc = run_python(
+        "import sys\n"
+        "sys.argv = ['hsql', '-a', 'sqlite', '--catalog', ':memory:']\n"
+        "from harlequin.hsql import main\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print(','.join(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith('harlequin_')})), file=sys.stderr)\n"
+        "print(','.join(m for m in ('duckdb', 'tomlkit') if m in sys.modules), "
+        "file=sys.stderr)\n"
+    )
+    adapters, forbidden = proc.stderr.split("\n")[:2]
+    assert adapters == "harlequin_sqlite"
+    assert not forbidden
+
+
+def test_a_run_does_not_import_the_catalog_walk(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """The other half of the mode-per-module rule: a query pays for no mode."""
+    proc = run_python(
+        "import sys\n"
+        "sys.argv = ['hsql', '-c', 'select 1']\n"
+        "from harlequin.hsql import main\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print(','.join(m for m in sys.modules "
+        "if m.startswith('harlequin.hsql.modes.') "
+        "or m == 'harlequin.navigate'), file=sys.stderr)\n"
+    )
+    assert not proc.stderr.strip()
 
 
 def test_config_validate_imports_only_the_adapters_its_profiles_name(

--- a/tests/unit_tests/test_navigate.py
+++ b/tests/unit_tests/test_navigate.py
@@ -137,6 +137,18 @@ def test_an_unterminated_quote_is_refused() -> None:
         CatalogPath.parse('mydb."analytics')
 
 
+@pytest.mark.parametrize("text", ['"a"b', 'a"b"c', 'schema."quoted rel"*'])
+def test_a_segment_quoted_in_part_is_refused(text: str) -> None:
+    """A segment is quoted whole or not at all.
+
+    Concatenating the two would leave one `quoted` flag describing a segment
+    that was half quoted -- and `"rel"*` would then ask for a wildcard the
+    quotes have already said is a character.
+    """
+    with pytest.raises(HarlequinCatalogPathError, match="quotes part of"):
+        CatalogPath.parse(text)
+
+
 @pytest.mark.parametrize(
     "segments",
     [

--- a/tests/unit_tests/test_navigate.py
+++ b/tests/unit_tests/test_navigate.py
@@ -12,6 +12,7 @@ assert against a shape no bundled adapter has.
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass, field
 from typing import Iterator, Sequence
 
@@ -152,6 +153,54 @@ def test_a_spelled_path_parses_back_to_the_same_segments(
     """The property the `path` column depends on: a cell from one listing is
     the argument that lists that item's children."""
     assert CatalogPath.parse(spell(segments)).segments == segments
+
+
+NASTY = ["a", ".", '"', "`", "[", "]", "*", "?", " ", "\\", "'"]
+"""Every character that could break a splitter, plus one that could not."""
+
+
+def test_every_label_a_catalog_can_hand_us_round_trips() -> None:
+    """`spell()` and `parse()` are inverses, over labels nobody would type.
+
+    An adapter's label is whatever the database holds, so a label this pair
+    disagrees about is a row whose `path` column names something the next
+    invocation cannot reach.
+    """
+    for size in (1, 2, 3):
+        for combination in itertools.product(NASTY, repeat=size):
+            label = "".join(combination)
+            assert CatalogPath.parse(spell([label])).segments == (label,), label
+
+
+def test_two_such_labels_round_trip_together() -> None:
+    """The same, where a dot between the two is the thing being escaped."""
+    labels = ["".join(pair) for pair in itertools.product(NASTY, repeat=2)]
+    for first, second in itertools.product(labels, repeat=2):
+        parsed = CatalogPath.parse(spell([first, second])).segments
+        assert parsed == (first, second), (first, second)
+
+
+@pytest.mark.parametrize("label", ["my`table", "[bracketed]", "'quoted'"])
+def test_another_dialects_quoting_is_a_label_like_any_other(label: str) -> None:
+    """A backtick or a bracket is a character in a name here, not quoting.
+
+    Treating either as a quote would make a MySQL table named ``my`table``
+    unreachable, which is the cost of accepting more than one spelling.
+    """
+    connection = FakeConnection(item(label))
+    listing = list_children(connection, CatalogPath.parse(spell([label])))
+    assert listing.parent is not None
+    assert listing.parent.label == label
+
+
+@pytest.mark.parametrize("typed", ["`mydb`", "[mydb]"])
+def test_a_path_quoted_for_a_database_says_what_to_type_instead(
+    connection: FakeConnection, typed: str
+) -> None:
+    """So an agent that reached for its dialect's quoting is told the spelling
+    this takes, rather than left with a path that names nothing."""
+    with pytest.raises(HarlequinCatalogPathError, match="Did you mean mydb"):
+        list_children(connection, CatalogPath.parse(typed))
 
 
 def test_a_plain_segment_is_spelled_without_quotes() -> None:

--- a/tests/unit_tests/test_navigate.py
+++ b/tests/unit_tests/test_navigate.py
@@ -1,0 +1,258 @@
+"""The path grammar, and the walk it drives.
+
+Two things are asserted here that nothing else can: that a path spelled by a
+listing is a path `parse()` reads back as the same segments -- which is what
+lets an agent walk a catalog by copying a cell out of the last answer -- and
+that the walk costs one `fetch_children()` per level and no more.
+
+The catalog is hand-built rather than a database's: what varies between adapters
+is how deep it goes and what a level is called, and a fake is the only way to
+assert against a shape no bundled adapter has.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, Sequence
+
+import pytest
+
+from harlequin.adapter import HarlequinConnection, HarlequinCursor
+from harlequin.catalog import Catalog, CatalogItem, InteractiveCatalogItem
+from harlequin.exception import HarlequinCatalogPathError
+from harlequin.navigate import CatalogPath, list_children, resolve, spell
+
+FETCHES: list[str] = []
+"""Every `fetch_children()` the walk made, in order. One entry is one round trip."""
+
+
+@dataclass
+class FakeItem(InteractiveCatalogItem["FakeConnection"]):
+    """A node that records the times it was asked to fetch."""
+
+    to_fetch: list["FakeItem"] = field(default_factory=list)
+
+    def fetch_children(self) -> Sequence[CatalogItem]:
+        FETCHES.append(self.label)
+        return self.to_fetch
+
+
+def item(label: str, *children: FakeItem, type_label: str = "t") -> FakeItem:
+    return FakeItem(
+        qualified_identifier=label,
+        query_name=f'"{label}"',
+        label=label,
+        type_label=type_label,
+        to_fetch=list(children),
+    )
+
+
+class FakeConnection(HarlequinConnection):
+    """Just enough connection for the walk: a catalog, and a count of asks."""
+
+    def __init__(self, *items: CatalogItem) -> None:
+        super().__init__()
+        self.items = list(items)
+        self.catalog_calls = 0
+
+    def execute(self, query: str) -> HarlequinCursor | None:
+        raise AssertionError("the walk ran SQL")
+
+    def get_catalog(self) -> Catalog:
+        self.catalog_calls += 1
+        return Catalog(items=list(self.items))
+
+
+@pytest.fixture(autouse=True)
+def fetches() -> Iterator[list[str]]:
+    FETCHES.clear()
+    yield FETCHES
+    FETCHES.clear()
+
+
+@pytest.fixture
+def connection() -> FakeConnection:
+    return FakeConnection(
+        item(
+            "mydb",
+            item(
+                "analytics",
+                item("orders", item("id", type_label="##")),
+                item("order_items"),
+                type_label="sch",
+            ),
+            item("empty", type_label="sch"),
+            type_label="db",
+        )
+    )
+
+
+# --- the grammar -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,segments",
+    [
+        (None, ()),
+        ("", ()),
+        ("   ", ()),
+        ("mydb", ("mydb",)),
+        ("mydb.analytics", ("mydb", "analytics")),
+        ('mydb."my.schema"', ("mydb", "my.schema")),
+        ('"quoted ""name"""', ('quoted "name"',)),
+        ('mydb."has*star"', ("mydb", "has*star")),
+        ('""', ("",)),
+    ],
+)
+def test_a_path_is_dotted_segments(text: str | None, segments: tuple[str, ...]) -> None:
+    parsed = CatalogPath.parse(text)
+    assert parsed.segments == segments
+    assert parsed.glob is None
+
+
+@pytest.mark.parametrize("text", ["mydb.ord*", "ord*", "mydb.analytics.?d"])
+def test_a_trailing_wildcard_is_a_filter_not_a_segment(text: str) -> None:
+    parsed = CatalogPath.parse(text)
+    assert parsed.glob == text.rsplit(".", 1)[-1]
+    assert parsed.segments == tuple(text.split(".")[:-1])
+
+
+@pytest.mark.parametrize("text", ["*.orders", "mydb.*.orders", "my?b.analytics"])
+def test_an_interior_wildcard_is_refused(text: str) -> None:
+    """It cannot be answered without fetching every level it could match, so it
+    is refused rather than quietly walked."""
+    with pytest.raises(HarlequinCatalogPathError, match="wildcard"):
+        CatalogPath.parse(text)
+
+
+@pytest.mark.parametrize("text", ["mydb.", ".mydb", "mydb..analytics"])
+def test_an_empty_segment_is_refused(text: str) -> None:
+    with pytest.raises(HarlequinCatalogPathError, match="empty path segment"):
+        CatalogPath.parse(text)
+
+
+def test_an_unterminated_quote_is_refused() -> None:
+    with pytest.raises(HarlequinCatalogPathError, match="never closes"):
+        CatalogPath.parse('mydb."analytics')
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        ("mydb", "analytics"),
+        ("my.db", "analytics"),
+        ('a "quoted" one', "b"),
+        ("has*star",),
+        ("",),
+    ],
+)
+def test_a_spelled_path_parses_back_to_the_same_segments(
+    segments: tuple[str, ...],
+) -> None:
+    """The property the `path` column depends on: a cell from one listing is
+    the argument that lists that item's children."""
+    assert CatalogPath.parse(spell(segments)).segments == segments
+
+
+def test_a_plain_segment_is_spelled_without_quotes() -> None:
+    """A path a person reads should look like the one they would have typed."""
+    assert spell(["mydb", "analytics", "orders"]) == "mydb.analytics.orders"
+
+
+# --- the walk ----------------------------------------------------------------
+
+
+def test_the_top_level_is_the_catalog(connection: FakeConnection) -> None:
+    listing = list_children(connection, CatalogPath.parse(None))
+    assert listing.parent is None
+    assert [child.label for child in listing.items] == ["mydb"]
+    assert connection.catalog_calls == 1
+
+
+def test_a_listing_is_one_round_trip_per_segment_plus_one(
+    connection: FakeConnection,
+) -> None:
+    """The cost this module promises, and the reason there is no `--depth`."""
+    listing = list_children(connection, CatalogPath.parse("mydb.analytics"))
+    assert listing.parent is not None
+    assert listing.parent.label == "analytics"
+    assert [child.label for child in listing.items] == ["orders", "order_items"]
+
+    # one for the catalog, and one per segment walked past -- and nothing else
+    assert connection.catalog_calls == 1
+    assert FETCHES == ["mydb", "analytics"]
+
+
+def test_listing_a_relation_is_describing_it(connection: FakeConnection) -> None:
+    listing = list_children(connection, CatalogPath.parse("mydb.analytics.orders"))
+    assert [(child.label, child.type_label) for child in listing.items] == [
+        ("id", "##")
+    ]
+
+
+def test_a_node_with_no_children_lists_nothing(connection: FakeConnection) -> None:
+    """Zero rows, not an error: an empty schema is an answer."""
+    assert list_children(connection, CatalogPath.parse("mydb.empty")).items == []
+
+
+def test_a_trailing_wildcard_filters_one_level(connection: FakeConnection) -> None:
+    listing = list_children(connection, CatalogPath.parse("mydb.analytics.order*"))
+    assert [child.label for child in listing.items] == ["orders", "order_items"]
+    # the parent it filtered, not a level below it
+    assert listing.parent is not None
+    assert listing.parent.label == "analytics"
+
+
+def test_a_wildcard_that_matches_nothing_lists_nothing(
+    connection: FakeConnection,
+) -> None:
+    assert list_children(connection, CatalogPath.parse("mydb.z*")).items == []
+
+
+def test_a_segment_that_names_nothing_says_what_is_there(
+    connection: FakeConnection,
+) -> None:
+    """A guessed path is the common case, so the error answers the question."""
+    with pytest.raises(HarlequinCatalogPathError) as excinfo:
+        list_children(connection, CatalogPath.parse("mydb.analytic"))
+    assert "analytic" in excinfo.value.msg
+    assert "Did you mean analytics?" in excinfo.value.msg
+
+
+def test_a_top_level_miss_says_where_it_looked(connection: FakeConnection) -> None:
+    with pytest.raises(HarlequinCatalogPathError, match="top of the catalog"):
+        list_children(connection, CatalogPath.parse("nope"))
+
+
+def test_a_miss_under_a_childless_node_says_so(connection: FakeConnection) -> None:
+    with pytest.raises(HarlequinCatalogPathError, match="nothing under it"):
+        list_children(connection, CatalogPath.parse("mydb.empty.orders"))
+
+
+def test_resolve_fetches_the_ancestors_and_not_the_level(
+    connection: FakeConnection,
+) -> None:
+    """`resolve()` is the walk without the listing, and costs one call less."""
+    found = resolve(connection, CatalogPath.parse("mydb.analytics"))
+    assert found is not None and found.label == "analytics"
+    assert FETCHES == ["mydb"]
+
+
+def test_children_already_loaded_are_not_fetched_again(
+    connection: FakeConnection,
+) -> None:
+    """An adapter that hands over a whole subtree is not asked to do it twice."""
+    path = CatalogPath.parse("mydb.analytics")
+    list_children(connection, path)
+    list_children(connection, path)
+    assert FETCHES == ["mydb", "analytics"]
+
+
+def test_a_plain_catalog_item_has_no_children_to_fetch() -> None:
+    """The degradation path: an adapter whose items are not interactive."""
+    connection = FakeConnection(
+        CatalogItem(
+            qualified_identifier="db", query_name='"db"', label="db", type_label="db"
+        )
+    )
+    assert list_children(connection, CatalogPath.parse("db")).items == []


### PR DESCRIPTION
No existing open issue — this is **PR 9 of the M2 plan** in `docs/plans/m2-hsql-technical-plan.md` (Release B, the catalog).

**What** are the key elements of this solution?

- **`harlequin.navigate`** — a new core module that resolves a dotted `CatalogPath` and lists the level below it. `resolve()` walks to the item a path names; `list_children()` fetches its children. The catalog only hands out an item's children, so this costs one round trip per path segment plus one, and nothing deeper.
- **`hsql --catalog` and `--path`** — a fourth mode, mutually exclusive with `--config`, `--spec` and `--info`. Unlike those three it connects, so it carries the adapter's connection options and reads a profile exactly as a run does.
- **Listings are `ResultSet`s.** Rows are `path`, `name`, `type_label`, `query_name`, built with `query.rows_to_result()`, so `--format`, `-o PATH`, `-t`/`-A` and `--display-rows` all work with no new output code. `text_columns()`'s string short-circuit (already in `main`) keeps duckdb out of a `-a postgres --catalog`.
- **`path` is written to be passed back.** Each row's `path` is the argument that lists *that* item's children, quoted where a label needs it, so walking a catalog is copying a cell out of the last answer. `query_name` is emitted for the same reason: the adapter has already worked out whether this backend wants `"Orders"` or `` `orders` ``.
- **Describing a relation is listing it.** `--path db.schema.orders` is that table's columns, with their types and quoted identifiers. There is no separate `--describe`.
- A trailing `*` filters one resolved parent's children client-side and stays one round trip; an interior one is refused, since it cannot be answered without fetching every level it could match.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**One level, no `--depth`.** What recursion costs depends entirely on where it starts: a second level below a database is one call per database, but a second level below a schema is one call per relation — 401 calls on a schema with 400 of them, which is the call an agent most wants to make. Recursion should arrive with `fetch_descendants()` on the adapter contract, which would make it one query instead, not ahead of it.

**`--path`, not a value on `--catalog`.** `--catalog mydb.analytics` reads better and is two tokens shorter, but click takes an optional value greedily — the next token, whether or not an `=` is written — and `CONN_STR` is a variadic positional. So `hsql --catalog mydb.db` would read the file as a catalog path against an in-memory database. That is the `hsql catalog`-versus-a-file-named-`catalog` ambiguity that made these modes options rather than subcommands in the first place. With `--path`, `CONN_STR` stays free to sit anywhere on the line and `hsql --catalog mydb.db` lists what is in `mydb.db`. Recorded in §3.1 and §6 of the plan.

**Path quoting is this syntax's own, not a database's.** A segment holding a dot, a quote or a wildcard is written in double quotes on every adapter — not MySQL's backticks or SQL Server's brackets. Accepting those would make a label that *contains* one unreachable (a MySQL table named ``my`table`` is an ordinary label here), and a path copied out of a listing would depend on which adapter wrote it. An agent that reaches for its own dialect gets a usable error: ``--path `mydb` `` answers ``There is no '`mydb`' at the top of the catalog. Did you mean mydb?``

Tree-sitter was considered for the path grammar and rejected on measurement: it parses `[mydb].[orders]` as a subscript with a MISSING node and reads `mydb.ord*` as a multiplication, so it settles neither dialect brackets nor the glob — and a path is not SQL.

**No `type_name` yet.** PR 10 puts it on the `CatalogItem` contract and populates it from data both bundled adapters already fetch. The column here is `type_label`, the catalog's short glyph, leaving the name free.

**No sorting.** A relation's children are its columns, whose order is the table's rather than the alphabet's.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: a Catalog and Introspection page under "Headless & Agents" covering `--catalog`, `--path`, the path grammar and the listing's columns. The plan schedules this as PR 12, alongside `--find` and `type_name`.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`tests/unit_tests/test_navigate.py` is new: the path grammar, the walk (asserting the round-trip count per level), and two sweeps proving `spell()` and `parse()` are inverses over every label built from ``. " ` [ ] * ? \ '``, space and newline — which is what caught a bug where an all-whitespace label round-tripped to the top of the catalog. `test_hsql.py` gains a `--catalog` section covering every format, the psql switches, `-o`, `--display-rows`, the mode exclusions and the error paths. `test_import_hygiene.py` gains two: `hsql -a sqlite --catalog` imports no duckdb, and a plain run imports no mode module.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. *(No issue exists for this change, so the entry has no link.)*
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR8cqMjxyMgS6rkv54bw7m)_