### PR TITLE
Add -o/--output: a default path for the Data Exporter, and a directory for hsql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
-- Harlequin now takes `-o/--output`, the default directory or file path for the Data Exporter, so exports can default to a folder like `.harlequin/` ([#926](https://github.com/tconbeer/harlequin/issues/926)). It is created on the first export if it does not exist.
+- Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
 
 ## [2.10.0] - 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+- Harlequin now takes `-o/--output`, the path the Data Exporter starts with, so exports can default to a folder like `.harlequin/` ([#926](https://github.com/tconbeer/harlequin/issues/926)). It is created on the first export if it does not exist.
+- `hsql -o` now takes a directory as well as a file name, and writes one file per result set into it -- so `hsql --parquet -o ~/exports -c 'select 1' -c 'select 2'` writes both.
 
 ## [2.10.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
-- Harlequin now takes `-o/--output`, the path the Data Exporter starts with, so exports can default to a folder like `.harlequin/` ([#926](https://github.com/tconbeer/harlequin/issues/926)). It is created on the first export if it does not exist.
-- `hsql -o` now takes a directory as well as a file name, and writes one file per result set into it -- so `hsql --parquet -o ~/exports -c 'select 1' -c 'select 2'` writes both.
+- Harlequin now takes `-o/--output`, the default directory or file path for the Data Exporter, so exports can default to a folder like `.harlequin/` ([#926](https://github.com/tconbeer/harlequin/issues/926)). It is created on the first export if it does not exist.
+- `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
 
 ## [2.10.0] - 2026-08-25
 

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -217,8 +217,7 @@ class Harlequin(AppBase):
         self.history: History | None = None
         self.show_files = show_files
         self.show_s3 = show_s3 or None
-        # kept as text: what the Data Exporter starts with is what a user typed
-        # at `-o`, trailing separator and `~` included
+        # kept as text: it is what the Data Exporter's path input starts with
         self.export_path = str(export_path) if export_path is not None else None
         # None is no cap: the viewer holds every row that was fetched. So are 0
         # and -1, which the CLI has already normalized -- a Results Viewer that

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -198,6 +198,7 @@ class Harlequin(AppBase):
         theme: str = "harlequin",
         show_files: Path | None = None,
         show_s3: str | None = None,
+        export_path: Path | str | None = None,
         viewer_max_rows: int | str | None = 100_000,
         query_limit: int | str | None = None,
         driver_class: Union[Type[Driver], None] = None,
@@ -216,6 +217,9 @@ class Harlequin(AppBase):
         self.history: History | None = None
         self.show_files = show_files
         self.show_s3 = show_s3 or None
+        # kept as text: what the Data Exporter starts with is what a user typed
+        # at `-o`, trailing separator and `~` included
+        self.export_path = str(export_path) if export_path is not None else None
         # None is no cap: the viewer holds every row that was fetched. So are 0
         # and -1, which the CLI has already normalized -- a Results Viewer that
         # holds no rows serves nobody, so neither spelling can mean that here.
@@ -910,6 +914,7 @@ class Harlequin(AppBase):
                     if sys.platform == "win32"
                     else HARLEQUIN_COPY_FORMATS
                 ),
+                default_path=self.export_path,
                 id="export_screen",
             ),
             callback,

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -374,12 +374,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     @click.option(
         "-o",
         "--output",
-        metavar="PATH",
-        help=(
-            "The default directory or file path for the Data Exporter. A "
-            "directory -- an existing one, a trailing separator, or a name with "
-            "no extension -- is created on the first export."
-        ),
+        type=click.Path(file_okay=True, dir_okay=True, path_type=Path),
+        help="The default directory or file path for the Data Exporter.",
     )
     @click.option(
         "--adapter",

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -134,6 +134,7 @@ HARLEQUIN_OPTION_GROUPS: list[OptionGroupDict] = [
             "--keymap-name",
             "--viewer-max-rows",
             "--limit",
+            "--output",
             "--config-path",
             "--locale",
             "--no-download-tzdata",
@@ -371,6 +372,16 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         ),
     )
     @click.option(
+        "-o",
+        "--output",
+        metavar="PATH",
+        help=(
+            "The path the Data Exporter starts with. A directory -- an existing "
+            "one, a trailing separator, or a name with no extension -- is the "
+            "folder it exports into, and is created on the first export."
+        ),
+    )
+    @click.option(
         "--adapter",
         "-a",
         default=DEFAULT_ADAPTER,
@@ -532,6 +543,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 )
                 ctx.exit(2)
         show_s3: str | None = config.pop("show_s3", None)
+        export_path: Path | str | None = config.pop("output", None)
 
         # instantiate the adapter, which was named and imported above -- the
         # key comes off either way, because what is left is its options
@@ -559,6 +571,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             theme=theme,
             show_files=show_files,
             show_s3=show_s3,
+            export_path=export_path,
         )
         tui.run()
 

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -376,9 +376,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         "--output",
         metavar="PATH",
         help=(
-            "The path the Data Exporter starts with. A directory -- an existing "
-            "one, a trailing separator, or a name with no extension -- is the "
-            "folder it exports into, and is created on the first export."
+            "The default directory or file path for the Data Exporter. A "
+            "directory -- an existing one, a trailing separator, or a name with "
+            "no extension -- is created on the first export."
         ),
     )
     @click.option(

--- a/src/harlequin/components/export_screen.py
+++ b/src/harlequin/components/export_screen.py
@@ -62,7 +62,7 @@ def export_callback(
         error_callback(e)
 
 
-def _starting_text(default_path: str | None) -> str:
+def _normalize_default_path(default_path: str | None) -> str:
     """What the path input starts with, for the `-o` the IDE was given.
 
     A folder gets a trailing separator: what follows it is the file name, and
@@ -139,7 +139,7 @@ class ExportScreen(ModalScreen[Tuple[Path, str, ExportOptions]]):
     ) -> None:
         super().__init__(name, id, classes)
         self.formats = formats
-        self.starting_text = _starting_text(default_path)
+        self.default_path = _normalize_default_path(default_path)
 
     def compose(self) -> ComposeResult:
         assert self.formats is not None
@@ -180,11 +180,11 @@ class ExportScreen(ModalScreen[Tuple[Path, str, ExportOptions]]):
             "#options_container", NoFocusVerticalScroll
         )
         self.export_button = self.query_one("#export", Button)
-        if self.starting_text:
+        if self.default_path:
             # assigning posts Input.Changed, so a path with an extension picks
             # its format the way a typed one does, and the cursor lands at the
             # end -- after a folder's separator, ready for a file name
-            self.file_input.value = self.starting_text
+            self.file_input.value = self.default_path
         self.file_input.focus()
 
     def on_key(self, event: events.Key) -> None:

--- a/src/harlequin/components/export_screen.py
+++ b/src/harlequin/components/export_screen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Sequence, Tuple
 
@@ -16,7 +17,7 @@ from textual_textarea import PathInput
 from harlequin.components.results_viewer import ResultsTable
 from harlequin.components.text_modal import ErrorModal
 from harlequin.exception import HarlequinCopyError
-from harlequin.export import write_file
+from harlequin.export import names_a_directory, write_file
 from harlequin.options import AbstractOption, HarlequinCopyFormat
 
 ExportOptions = Dict[str, Any]
@@ -59,6 +60,19 @@ def export_callback(
         success_callback()
     except (OSError, HarlequinCopyError) as e:
         error_callback(e)
+
+
+def _starting_text(default_path: str | None) -> str:
+    """What the path input starts with, for the `-o` the IDE was given.
+
+    A folder gets a trailing separator: what follows it is the file name, and
+    the input's autocomplete offers what is already in there.
+    """
+    if not default_path:
+        return ""
+    if not names_a_directory(default_path):
+        return default_path
+    return f"{default_path.rstrip('/' + os.sep)}{os.sep}"
 
 
 class NoFocusVerticalScroll(VerticalScroll, can_focus=False):
@@ -118,12 +132,14 @@ class ExportScreen(ModalScreen[Tuple[Path, str, ExportOptions]]):
     def __init__(
         self,
         formats: list[HarlequinCopyFormat],
+        default_path: str | None = None,
         name: str | None = None,
         id: str | None = None,  # noqa: A002
         classes: str | None = None,
     ) -> None:
         super().__init__(name, id, classes)
         self.formats = formats
+        self.starting_text = _starting_text(default_path)
 
     def compose(self) -> ComposeResult:
         assert self.formats is not None
@@ -164,6 +180,11 @@ class ExportScreen(ModalScreen[Tuple[Path, str, ExportOptions]]):
             "#options_container", NoFocusVerticalScroll
         )
         self.export_button = self.query_one("#export", Button)
+        if self.starting_text:
+            # assigning posts Input.Changed, so a path with an extension picks
+            # its format the way a typed one does, and the cursor lands at the
+            # end -- after a folder's separator, ready for a file name
+            self.file_input.value = self.starting_text
         self.file_input.focus()
 
     def on_key(self, event: events.Key) -> None:

--- a/src/harlequin/export.py
+++ b/src/harlequin/export.py
@@ -48,13 +48,7 @@ def file_suffix(format_name: str) -> str:
 
 
 def names_a_directory(destination: str | Path) -> bool:
-    """Whether a destination names a folder to write into, rather than a file.
-
-    A folder that has not been made yet is still a folder, so the filesystem
-    cannot be the only question: a trailing separator or a name with no
-    extension names one too, which is what lets `-o ~/exports` mean the same
-    thing before and after the first write.
-    """
+    """Whether a destination names a folder to write into, rather than a file."""
     path = Path(destination).expanduser()
     if path.exists():
         return path.is_dir()

--- a/src/harlequin/export.py
+++ b/src/harlequin/export.py
@@ -7,6 +7,7 @@ defaults, and any option the caller passes overrides a default.
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from dataclasses import dataclass, field
@@ -41,6 +42,25 @@ def file_format_names() -> list[str]:
     return list(_FILE_FORMATS)
 
 
+def file_suffix(format_name: str) -> str:
+    """The extension `format_name` writes under, for a caller naming a file."""
+    return _get_format(format_name).suffix
+
+
+def names_a_directory(destination: str | Path) -> bool:
+    """Whether a destination names a folder to write into, rather than a file.
+
+    A folder that has not been made yet is still a folder, so the filesystem
+    cannot be the only question: a trailing separator or a name with no
+    extension names one too, which is what lets `-o ~/exports` mean the same
+    thing before and after the first write.
+    """
+    path = Path(destination).expanduser()
+    if path.exists():
+        return path.is_dir()
+    return str(destination).endswith(("/", os.sep)) or not path.suffix
+
+
 def write_file(
     data: "pa.Table",
     path: Path,
@@ -51,11 +71,16 @@ def write_file(
 
     Zero rows is not an error: an empty file is how "the query matched nothing"
     is told apart from "the query failed".
+
+    The directory `path` is in is created if it is not there: a caller who
+    names a folder to export into names one that may not exist yet.
     """
     fmt = _get_format(format_name)
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
     fmt.exporter(
         _deduplicate_column_names(data),
-        str(path.expanduser()),
+        str(destination),
         **_merge_options(fmt, options),
     )
 

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -182,12 +182,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         "-o",
         "--output",
         metavar="PATH",
-        help=(
-            "Write results to PATH instead of stdout. A directory -- an "
-            "existing one, a trailing separator, or a name with no extension "
-            "-- takes one file per result set, and is created if it is not "
-            "there."
-        ),
+        help="Write results to PATH instead of stdout. Accepts a file or directory.",
     )
     # long spelling only: -F is psql's --field-separator, and a flag that sets
     # a delimiter in one command and picks a format in the other is a mistake
@@ -998,12 +993,11 @@ class _Destination:
     is_directory: bool = False
 
     @classmethod
-    def parse(cls, raw: Any) -> _Destination:
+    def parse(cls, raw: str | Path | None) -> _Destination:
         """One `-o` value, as typed or as a profile wrote it."""
         if raw is None or raw == "":
             return cls()
-        text = str(raw)
-        return cls(path=Path(text).expanduser(), is_directory=names_a_directory(text))
+        return cls(path=Path(raw).expanduser(), is_directory=names_a_directory(raw))
 
     @property
     def directory(self) -> Path | None:

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -30,6 +30,7 @@ rule, and `--catalog` needs none. They are mutually exclusive, and each lives in
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 import sys
 import time
@@ -53,6 +54,7 @@ from harlequin.exception import (
     HarlequinConnectionError,
     HarlequinError,
 )
+from harlequin.export import names_a_directory
 from harlequin.first_pass import (
     attach_adapter_options,
     command_spellings,
@@ -179,9 +181,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     @click.option(
         "-o",
         "--output",
-        type=click.Path(dir_okay=False, path_type=Path),
         metavar="PATH",
-        help="Write results to PATH instead of stdout.",
+        help=(
+            "Write results to PATH instead of stdout. A directory -- an "
+            "existing one, a trailing separator, or a name with no extension "
+            "-- takes one file per result set, and is created if it is not "
+            "there."
+        ),
     )
     # long spelling only: -F is psql's --field-separator, and a flag that sets
     # a delimiter in one command and picks a format in the other is a mistake
@@ -388,7 +394,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         if isinstance(conn_str, str):
             conn_str = (conn_str,)
         adapter: str = values.pop("adapter", DEFAULT_ADAPTER)
-        destination: Path | None = values.pop("output", None)
+        destination = _Destination.parse(values.pop("output", None))
         result_spec: str = str(values.pop("result", "all"))
         raw_on_error = str(values.pop("on_error", "stop"))
         if raw_on_error not in ("stop", "continue"):
@@ -567,11 +573,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         selected = _select_results(executed, result_spec)
         if selected is None:
             ctx.exit(ExitCode.USAGE)
-        if len(selected) > 1 and not output.holds_many(format_name):
+        if (
+            len(selected) > 1
+            and not destination.is_directory
+            and not output.holds_many(format_name)
+        ):
             n = len(selected)
             diagnostics.error(
                 f"{n} result sets, but {format_name} holds one; "
-                f"use --result last or --result {n}"
+                f"use --result last, --result {n}, or -o DIR for one file each"
             )
             ctx.exit(ExitCode.USAGE)
 
@@ -587,10 +597,10 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         )
 
         try:
-            with _sink(destination) as out:
-                _emit(
+            if (directory := destination.directory) is not None:
+                _emit_files(
                     selected,
-                    out,
+                    directory,
                     limit=row_limit,
                     format_name=format_name,
                     layout_options=layout_options,
@@ -598,6 +608,20 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                     on_error=on_error,
                     run=run,
                 )
+            else:
+                with _sink(
+                    destination, filename=f"results{output.suffix(format_name)}"
+                ) as out:
+                    _emit(
+                        selected,
+                        out,
+                        limit=row_limit,
+                        format_name=format_name,
+                        layout_options=layout_options,
+                        file_options=file_options,
+                        on_error=on_error,
+                        run=run,
+                    )
         except OSError as e:
             diagnostics.report_error(e)
             ctx.exit(ExitCode.USAGE)
@@ -709,7 +733,7 @@ def _report_catalog(
     connection: "HarlequinConnection",
     path: "CatalogPath",
     *,
-    destination: Path | None,
+    destination: _Destination,
     format_name: str,
     display_rows: Any,
     **output_options: Any,
@@ -729,7 +753,7 @@ def _report_catalog(
     )
 
     try:
-        with _sink(destination) as out:
+        with _sink(destination, filename=f"catalog{output.suffix(format_name)}") as out:
             result = catalog_mode.report(
                 out,
                 connection=connection,
@@ -758,7 +782,7 @@ def _report_info(
     adapter: str | None,
     profile_name: str | None,
     config_path: Path | None,
-    destination: Path | None,
+    destination: _Destination,
     format_name: str,
     format_chosen: bool,
 ) -> ExitCode:
@@ -774,7 +798,7 @@ def _report_info(
     from harlequin.hsql.modes import info as info_mode
 
     try:
-        with _sink(destination) as out:
+        with _sink(destination, filename=info_mode.FILENAME) as out:
             code = info_mode.report(
                 out,
                 adapter=adapter,
@@ -796,7 +820,7 @@ def _report_spec(
     ctx: click.Context,
     *,
     adapter: str | None,
-    destination: Path | None,
+    destination: _Destination,
     format_name: str,
     format_chosen: bool,
 ) -> ExitCode:
@@ -812,7 +836,7 @@ def _report_spec(
     from harlequin.hsql.modes import spec as spec_mode
 
     try:
-        with _sink(destination) as out:
+        with _sink(destination, filename=spec_mode.FILENAME) as out:
             code = spec_mode.report(
                 out,
                 adapter=adapter,
@@ -832,7 +856,7 @@ def _report_config(
     mode: str,
     *,
     config_path: Path | None,
-    destination: Path | None,
+    destination: _Destination,
     format_name: str,
     format_chosen: bool,
     display_rows: Any,
@@ -852,7 +876,9 @@ def _report_config(
         layout_options, file_options = _output_options(
             format_name=format_name, display_limit=display_limit, **output_options
         )
-        with _sink(destination) as out:
+        with _sink(
+            destination, filename=config_mode.filename(mode, format_name)
+        ) as out:
             code = config_mode.report(
                 mode,
                 out,
@@ -959,6 +985,42 @@ def bare_command() -> click.Command:
     return build_cli(["-P", "None", "--help"])
 
 
+@dataclass(frozen=True)
+class _Destination:
+    """Where `-o` said to write: a file, a folder to name files in, or stdout.
+
+    A folder is what lets a format that holds one result set take a script that
+    produced several -- one file each, named here rather than by the caller,
+    which is why `diagnostics.report_written()` says what they were called.
+    """
+
+    path: Path | None = None
+    is_directory: bool = False
+
+    @classmethod
+    def parse(cls, raw: Any) -> _Destination:
+        """One `-o` value, as typed or as a profile wrote it."""
+        if raw is None or raw == "":
+            return cls()
+        text = str(raw)
+        return cls(path=Path(text).expanduser(), is_directory=names_a_directory(text))
+
+    @property
+    def directory(self) -> Path | None:
+        """The folder to write files into, or None for a file and for stdout."""
+        return self.path if self.is_directory else None
+
+    def file(self, filename: str) -> Path | None:
+        """The one file to write, for a caller that writes exactly one.
+
+        None is stdout. In a folder it is `filename`, which whatever is being
+        written names -- a document has no position to be numbered by.
+        """
+        if self.path is None or not self.is_directory:
+            return self.path
+        return self.path / filename
+
+
 @dataclass
 class _Run:
     """What one invocation did, accumulated as it does it.
@@ -1033,32 +1095,114 @@ def _emit(
     on_error: OnError,
     run: _Run,
 ) -> None:
-    """Fetch each selected result set and write it out."""
+    """Fetch each selected result set and write them all to one open stream."""
+    for _, result in _fetched(selected, limit=limit, on_error=on_error, run=run):
+        _write_result(
+            result,
+            out,
+            limit=limit,
+            format_name=format_name,
+            layout_options=layout_options,
+            file_options=file_options,
+            run=run,
+        )
+    out.flush()
+
+
+def _emit_files(
+    selected: Sequence[ExecutedStatement],
+    directory: Path,
+    *,
+    limit: RowLimit,
+    format_name: str,
+    layout_options: LayoutOptions,
+    file_options: Mapping[str, Any],
+    on_error: OnError,
+    run: _Run,
+) -> None:
+    """Fetch each selected result set and write it to its own file in `directory`.
+
+    Numbered as `--result` numbers them, so the second result set is
+    `results_2` whether it was written beside four others or on its own.
+    """
+    if format_name == output.NONE:
+        # the rows are discarded, so there is no file to name and no directory
+        # to make -- but the fetch still runs, for --stats and for errors
+        _emit(
+            selected,
+            io.BytesIO(),
+            limit=limit,
+            format_name=format_name,
+            layout_options=layout_options,
+            file_options=file_options,
+            on_error=on_error,
+            run=run,
+        )
+        return
+    directory.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for position, result in _fetched(selected, limit=limit, on_error=on_error, run=run):
+        path = directory / f"results_{position}{output.suffix(format_name)}"
+        with path.open("wb") as f:
+            _write_result(
+                result,
+                f,
+                limit=limit,
+                format_name=format_name,
+                layout_options=layout_options,
+                file_options=file_options,
+                run=run,
+            )
+        written.append(path)
+    diagnostics.report_written(written)
+
+
+def _fetched(
+    selected: Sequence[ExecutedStatement],
+    *,
+    limit: RowLimit,
+    on_error: OnError,
+    run: _Run,
+) -> Iterator[tuple[int, ResultSet]]:
+    """Each selected result set, fetched, with its position among them."""
     from harlequin.query import fetch
 
-    for item in selected:
+    for position, item in enumerate(selected, start=1):
         try:
             result = fetch(item, limit=limit)
         except Exception as e:  # noqa: BLE001 -- adapters are third-party code
             run.failure = e
             diagnostics.report_error(e)
             if on_error == "stop":
-                break
+                return
             continue
-        output.write(
-            result,
-            format_name,
-            out,
-            layout_options=layout_options,
-            file_options=file_options,
-        )
-        run.rows += result.row_count
-        run.truncated = run.truncated or result.truncated
-        run.columns = result.columns
-        if result.truncated and limit.max_rows is not None:
-            diagnostics.report_truncation(limit.max_rows)
-        _report_hidden_rows(result, layout_options)
-    out.flush()
+        yield position, result
+
+
+def _write_result(
+    result: ResultSet,
+    out: BinaryIO,
+    *,
+    limit: RowLimit,
+    format_name: str,
+    layout_options: LayoutOptions,
+    file_options: Mapping[str, Any],
+    run: _Run,
+) -> None:
+    """Write one fetched result set, and record what it was."""
+    output.write(
+        result,
+        format_name,
+        out,
+        layout_options=layout_options,
+        file_options=file_options,
+    )
+    run.rows += result.row_count
+    run.truncated = run.truncated or result.truncated
+    run.columns = result.columns
+    if result.truncated and limit.max_rows is not None:
+        diagnostics.report_truncation(limit.max_rows)
+    _report_hidden_rows(result, layout_options)
 
 
 def _report_hidden_rows(result: ResultSet, layout_options: LayoutOptions) -> None:
@@ -1229,14 +1373,14 @@ def _output_options(
     return layout_options, file_options
 
 
-def _use_color(when: str, destination: Path | None) -> bool:
+def _use_color(when: str, destination: _Destination) -> bool:
     """Whether to style text output.
 
     The default is `never`, so the bytes do not depend on what stdout happens
     to be. `auto` opts into that dependence, and honors NO_COLOR; `always` is
     the caller saying they meant it. A file never gets escapes either way.
     """
-    if destination is not None or when == "never":
+    if destination.path is not None or when == "never":
         return False
     if when == "always":
         return True
@@ -1244,18 +1388,25 @@ def _use_color(when: str, destination: Path | None) -> bool:
 
 
 @contextlib.contextmanager
-def _sink(destination: Path | None) -> Iterator[BinaryIO]:
-    """Where result sets go: a path, or stdout.
+def _sink(destination: _Destination, *, filename: str) -> Iterator[BinaryIO]:
+    """Where one document or one run of result sets goes: a path, or stdout.
 
     Binary in both cases. duckdb writes `\\n` and the layouts write `\\n`, and
     text-mode translation would turn that into `\\r\\n` on Windows for the same
     query that produced `\\n` everywhere else.
+
+    The directory the file is in is created if it is not there, so that a path
+    a caller has not made yet is a path they can write to.
     """
-    if destination is None:
+    path = destination.file(filename)
+    if path is None:
         yield click.get_binary_stream("stdout")
-    else:
-        with destination.expanduser().open("wb") as f:
-            yield f
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        yield f
+    if destination.is_directory:
+        diagnostics.report_written([path])
 
 
 def _message_for(failure: BaseException | None) -> str | None:

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import sys
 from enum import IntEnum
+from pathlib import Path
 from typing import Any, Sequence
 
 from harlequin.exception import (
@@ -198,6 +199,21 @@ def report_document_format_ignored(mode: str, format_name: str) -> None:
         f"{mode} writes a document, so --format {format_name} had no effect; "
         "--format json is the machine-readable one"
     )
+
+
+def report_written(paths: Sequence[Path]) -> None:
+    """Name the files a directory `-o` wrote, since the caller did not name them.
+
+    A file the caller named needs no line -- they know where it is. What hsql
+    chose is the one thing about the run that stdout cannot carry.
+    """
+    if not paths:
+        return
+    if len(paths) == 1:
+        note(f"wrote {paths[0]}")
+    else:
+        listed = ", ".join(path.name for path in paths)
+        note(f"wrote {len(paths)} files to {paths[0].parent}: {listed}")
 
 
 def report_stats(

--- a/src/harlequin/hsql/modes/config.py
+++ b/src/harlequin/hsql/modes/config.py
@@ -76,6 +76,24 @@ JSON = "json"
 NONE = "none"
 
 
+def filename(mode: str, format_name: str) -> str:
+    """What a mode's answer is called when `-o` names a folder to write it into.
+
+    Three of these write a document -- JSON, or the TOML a config file is
+    written in -- and two write rows, which take the format's own extension.
+    """
+    if mode == SCHEMA:
+        return "config-schema.json"
+    if mode == SHOW:
+        return f"config-show{'.json' if format_name == JSON else '.toml'}"
+
+    # deferred like the writing itself: a document mode does not pay for the
+    # execution core to learn what a row-shaped one would have been called
+    from harlequin.hsql import output
+
+    return f"config-{mode}{output.suffix(format_name)}"
+
+
 def report(
     mode: str,
     out: BinaryIO,

--- a/src/harlequin/hsql/modes/info.py
+++ b/src/harlequin/hsql/modes/info.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
 
     from harlequin.adapter import HarlequinAdapter
 
+FILENAME = "info.json"
+"""What this document is called when `-o` names a folder to write it into."""
+
 JSON = "json"
 """The one `--format` a document mode answers to. `none` writes nothing."""
 

--- a/src/harlequin/hsql/modes/spec.py
+++ b/src/harlequin/hsql/modes/spec.py
@@ -49,6 +49,9 @@ from harlequin.redact import REDACTED
 if TYPE_CHECKING:
     from harlequin.options import AbstractOption
 
+FILENAME = "spec.json"
+"""What this document is called when `-o` names a folder to write it into."""
+
 JSON = "json"
 """The one `--format` a document mode answers to. `none` writes nothing."""
 

--- a/src/harlequin/hsql/output.py
+++ b/src/harlequin/hsql/output.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 import io
 from typing import TYPE_CHECKING, Any, BinaryIO, Mapping
 
-from harlequin.export import file_format_names, write_stream
-from harlequin.layout import get_layout, layout_names
+from harlequin.export import file_format_names, file_suffix, write_stream
+from harlequin.layout import get_layout, layout_names, layout_suffix
 
 if TYPE_CHECKING:
     from harlequin.layout import LayoutOptions
@@ -41,6 +41,20 @@ def is_layout(format_name: str) -> bool:
     switches are the layouts', and a file format has neither.
     """
     return format_name in layout_names()
+
+
+def suffix(format_name: str) -> str:
+    """The extension a file of this format gets, when hsql has to name one.
+
+    Empty for `none`, which discards the rows and so names no file.
+    """
+    if format_name == NONE:
+        return ""
+    return (
+        layout_suffix(format_name)
+        if is_layout(format_name)
+        else file_suffix(format_name)
+    )
 
 
 def holds_many(format_name: str) -> bool:

--- a/src/harlequin/layout.py
+++ b/src/harlequin/layout.py
@@ -88,6 +88,14 @@ def layout_names() -> list[str]:
     return list(_LAYOUTS)
 
 
+def layout_suffix(name: str) -> str:
+    """The extension a layout's text is saved under, for a caller naming a file."""
+    try:
+        return _LAYOUTS[name].SUFFIX
+    except KeyError as e:
+        raise ValueError(f"{name} is not a layout Harlequin can render.") from e
+
+
 def default_max_rows(name: str) -> int:
     """How many rows `name` prints when its caller has no preference.
 
@@ -113,6 +121,7 @@ def get_layout(name: str, options: LayoutOptions | None = None) -> Layout:
 
 class _BaseLayout:
     DEFAULT_MAX_ROWS = 40
+    SUFFIX = ".txt"
 
     def __init__(self, options: LayoutOptions) -> None:
         self.options = options
@@ -239,6 +248,8 @@ class _MarkdownLayout(_BaseLayout):
     The one layout that escapes what it prints: an unescaped `|` in a value
     would start a new cell, and a newline would end the row.
     """
+
+    SUFFIX = ".md"
 
     MIN_WIDTH = 3
     """The shortest delimiter row GFM accepts is `---`."""

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -94,7 +94,7 @@
         },
         "output": {
           "type": "string",
-          "description": "Write results to PATH instead of stdout."
+          "description": "Write results to PATH instead of stdout. A directory -- an existing one, a trailing separator, or a name with no extension -- takes one file per result set, and is created if it is not there."
         },
         "format": {
           "type": "string",

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -94,7 +94,7 @@
         },
         "output": {
           "type": "string",
-          "description": "Write results to PATH instead of stdout. A directory -- an existing one, a trailing separator, or a name with no extension -- takes one file per result set, and is created if it is not there."
+          "description": "Write results to PATH instead of stdout. Accepts a file or directory."
         },
         "format": {
           "type": "string",

--- a/tests/functional_tests/test_export.py
+++ b/tests/functional_tests/test_export.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from typing import Awaitable, Callable, List
@@ -5,6 +6,7 @@ from typing import Awaitable, Callable, List
 import pytest
 
 from harlequin import Harlequin
+from harlequin.adapter import HarlequinAdapter
 from harlequin.components import ExportScreen
 
 
@@ -159,3 +161,73 @@ async def test_export_under_a_limit_stops_at_the_limit(
         await pilot.pause()
 
         assert len(export_path.read_text().splitlines()) == 6  # header and 5 rows
+
+
+@pytest.mark.asyncio
+async def test_export_starts_at_the_export_path(
+    duckdb_adapter: type[HarlequinAdapter],
+    tmp_path: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """`-o` names the folder the Data Exporter opens in, so a user who exports
+    into the same place every time types a file name and nothing else."""
+    app = Harlequin(
+        duckdb_adapter([":memory:"], no_init=True),
+        connection_hash="foo",
+        export_path=str(tmp_path / "exports"),
+    )
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        app.editor.text = "select 1 as a"
+        await pilot.press("ctrl+j")
+        for _ in range(3):
+            await wait_for_workers(app)
+            await pilot.pause()
+
+        await pilot.press("ctrl+e")
+        await pilot.pause()
+        assert isinstance(app.screen, ExportScreen)
+        assert app.screen.file_input.value == f"{tmp_path / 'exports'}{os.sep}"
+
+        # the folder does not exist yet, and exporting into it makes it
+        app.screen.file_input.value += "one.csv"
+        await pilot.pause()
+        await pilot.press("enter")
+        await wait_for_workers(app)
+        await pilot.pause()
+
+        assert (tmp_path / "exports" / "one.csv").read_text() == "a\n1\n"
+        assert len(app.screen_stack) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_export_path_with_a_file_name_picks_its_format(
+    duckdb_adapter: type[HarlequinAdapter],
+    tmp_path: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """A whole path prefills whole, and the extension chooses the format the
+    same way a typed one does."""
+    export_path = tmp_path / "out.parquet"
+    app = Harlequin(
+        duckdb_adapter([":memory:"], no_init=True),
+        connection_hash="foo",
+        export_path=str(export_path),
+    )
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        app.editor.text = "select 1 as a"
+        await pilot.press("ctrl+j")
+        for _ in range(3):
+            await wait_for_workers(app)
+            await pilot.pause()
+
+        await pilot.press("ctrl+e")
+        await pilot.pause()
+        assert isinstance(app.screen, ExportScreen)
+        assert app.screen.file_input.value == str(export_path)
+        assert app.screen.format_select.value == "parquet"

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -139,6 +139,7 @@ def test_default(
         theme=DEFAULT_THEME,
         show_files=None,
         show_s3=None,
+        export_path=None,
     )
 
 
@@ -307,6 +308,31 @@ def test_show_files(
     mock_harlequin.assert_called_once()
     assert mock_harlequin.call_args
     assert mock_harlequin.call_args.kwargs["show_files"] == Path(".")
+
+
+@pytest.mark.parametrize(
+    "harlequin_args,export_path",
+    [
+        ("--output .harlequin", ".harlequin"),
+        ("-o .harlequin/", ".harlequin/"),
+        ("-o exports/out.csv", "exports/out.csv"),
+        ("", None),
+    ],
+)
+def test_output_sets_the_export_path(
+    mock_harlequin: MagicMock,
+    mock_adapter: MagicMock,
+    harlequin_args: str,
+    export_path: str | None,
+    mock_empty_config: None,
+) -> None:
+    """`-o` reaches the app as text: the Data Exporter starts with what was
+    typed, trailing separator and all."""
+    runner = CliRunner()
+    res = invoke(runner, harlequin_args)
+    assert res.exit_code == 0
+    assert mock_harlequin.call_args
+    assert mock_harlequin.call_args.kwargs["export_path"] == export_path
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -313,9 +313,9 @@ def test_show_files(
 @pytest.mark.parametrize(
     "harlequin_args,export_path",
     [
-        ("--output .harlequin", ".harlequin"),
-        ("-o .harlequin/", ".harlequin/"),
-        ("-o exports/out.csv", "exports/out.csv"),
+        ("--output .harlequin", Path(".harlequin")),
+        ("-o .harlequin/", Path(".harlequin")),
+        ("-o exports/out.csv", Path("exports/out.csv")),
         ("", None),
     ],
 )
@@ -323,11 +323,11 @@ def test_output_sets_the_export_path(
     mock_harlequin: MagicMock,
     mock_adapter: MagicMock,
     harlequin_args: str,
-    export_path: str | None,
+    export_path: Path | None,
     mock_empty_config: None,
 ) -> None:
-    """`-o` reaches the app as text: the Data Exporter starts with what was
-    typed, trailing separator and all."""
+    """`-o` is where the Data Exporter starts, whether it names a folder or a
+    file."""
     runner = CliRunner()
     res = invoke(runner, harlequin_args)
     assert res.exit_code == 0

--- a/tests/unit_tests/test_export.py
+++ b/tests/unit_tests/test_export.py
@@ -18,9 +18,12 @@ from harlequin.exception import HarlequinCopyError
 from harlequin.export import (
     _deduplicate_column_names,
     file_format_names,
+    file_suffix,
+    names_a_directory,
     write_file,
     write_stream,
 )
+from harlequin.layout import layout_suffix
 from harlequin.options import HarlequinCopyFormat, SelectOption
 
 TEXT_FORMATS = ["csv", "tsv", "json", "jsonl", "ndjson"]
@@ -389,3 +392,52 @@ class TestStream:
         """duckdb writes \\n. The copy out is binary so that Python's text-mode
         translation cannot turn it into \\r\\n on Windows."""
         assert b"\r\n" not in to_bytes(data, format_name)
+
+
+class TestDestinationPaths:
+    """What a `-o` value names, which both commands ask before writing."""
+
+    @pytest.mark.parametrize(
+        "destination", ["exports", "exports/", "~/exports", ".harlequin"]
+    )
+    def test_a_path_with_no_extension_is_a_directory(self, destination: str) -> None:
+        assert names_a_directory(destination)
+
+    @pytest.mark.parametrize("destination", ["out.csv", "exports/out.parquet"])
+    def test_a_path_with_an_extension_is_a_file(self, destination: str) -> None:
+        assert not names_a_directory(destination)
+
+    def test_an_existing_directory_is_one_whatever_it_is_called(
+        self, tmp_path: Path
+    ) -> None:
+        dotted = tmp_path / "exports.old"
+        dotted.mkdir()
+        assert names_a_directory(dotted)
+
+    def test_an_existing_file_is_one_whatever_it_is_called(
+        self, tmp_path: Path
+    ) -> None:
+        extensionless = tmp_path / "exports"
+        extensionless.write_text("")
+        assert not names_a_directory(extensionless)
+
+    def test_a_missing_parent_is_created(self, data: pa.Table, tmp_path: Path) -> None:
+        """A caller who names a folder to export into names one that may not
+        exist yet."""
+        path = tmp_path / "exports" / "nested" / "out.csv"
+        write_file(data, path, "csv")
+        assert path.is_file()
+
+
+class TestSuffixes:
+    @pytest.mark.parametrize("format_name", TEXT_FORMATS + BINARY_FORMATS)
+    def test_every_file_format_names_its_extension(self, format_name: str) -> None:
+        assert file_suffix(format_name).lstrip(".") == format_name
+
+    def test_a_layout_names_one_too(self) -> None:
+        assert layout_suffix("table") == ".txt"
+        assert layout_suffix("markdown") == ".md"
+
+    def test_an_unknown_layout_raises(self) -> None:
+        with pytest.raises(ValueError):
+            layout_suffix("csv")

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -471,6 +471,7 @@ def test_two_result_sets_will_not_fit_in_a_csv(hsql: Hsql, duck: list[str]) -> N
     assert res.stdout == ""
     assert "2 result sets, but csv holds one" in res.stderr
     assert "--result last" in res.stderr
+    assert "-o DIR" in res.stderr
 
 
 def test_two_result_sets_do_fit_in_jsonl(hsql: Hsql, duck: list[str]) -> None:
@@ -570,9 +571,119 @@ def test_a_file_never_gets_color(hsql: Hsql, duck: list[str], tmp_path: Path) ->
 def test_an_unwritable_destination_is_a_usage_error(
     hsql: Hsql, duck: list[str], tmp_path: Path
 ) -> None:
-    res = hsql(*duck, "-o", str(tmp_path / "nope" / "out.csv"), "-c", "select 1")
+    in_the_way = tmp_path / "not-a-directory"
+    in_the_way.write_text("")
+    res = hsql(*duck, "-o", str(in_the_way / "out.csv"), "-c", "select 1")
     assert res.exit_code == ExitCode.USAGE
     assert res.stderr.startswith("hsql: error: ")
+
+
+def test_a_missing_parent_directory_is_created(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    destination = tmp_path / "exports" / "nested" / "out.csv"
+    res = hsql(*duck, "-o", str(destination), "-tA", "-c", "select 1")
+    assert res.exit_code == ExitCode.OK
+    assert destination.read_text() == "1\n"
+
+
+# --- writing to a directory --------------------------------------------------
+
+
+def test_a_directory_takes_one_file_per_result_set(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    """A folder is what lets a format that holds one result set take a script
+    that produced several."""
+    destination = tmp_path / "exports"
+    res = hsql(*duck, "--csv", "-o", str(destination), "-c", "select 1; select 2")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+    assert (destination / "results_1.csv").read_text() == "1\n1\n"
+    assert (destination / "results_2.csv").read_text() == "2\n2\n"
+
+
+def test_a_directory_names_what_it_wrote_on_stderr(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    """The caller did not name these files, so stderr says what they are."""
+    destination = tmp_path / "exports"
+    res = hsql(*duck, "--csv", "-o", str(destination), "-c", "select 1; select 2")
+    assert "results_1.csv" in res.stderr
+    assert "results_2.csv" in res.stderr
+
+
+def test_a_named_file_is_not_named_again(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    destination = tmp_path / "out.csv"
+    res = hsql(*duck, "-o", str(destination), "-c", "select 1")
+    assert res.stderr == ""
+
+
+@pytest.mark.parametrize("format_name", FILE_FORMATS + LAYOUTS)
+def test_a_directory_file_holds_what_the_same_format_writes(
+    hsql: Hsql, duck: list[str], tmp_path: Path, format_name: str
+) -> None:
+    destination = tmp_path / "exports"
+    hsql(*duck, "--format", format_name, "-o", str(destination), "-c", "select 1 as a")
+    (written,) = destination.iterdir()
+    piped = hsql(*duck, "--format", format_name, "-c", "select 1 as a")
+    assert written.read_bytes() == piped.stdout_bytes
+
+
+def test_a_directory_is_created_when_it_is_not_there(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    destination = tmp_path / "exports" / "nested"
+    res = hsql(*duck, "--csv", "-o", f"{destination}/", "-c", "select 1")
+    assert res.exit_code == ExitCode.OK
+    assert (destination / "results_1.csv").is_file()
+
+
+def test_an_existing_directory_takes_files_whatever_it_is_called(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    destination = tmp_path / "exports.old"
+    destination.mkdir()
+    res = hsql(*duck, "--csv", "-o", str(destination), "-c", "select 1")
+    assert res.exit_code == ExitCode.OK
+    assert (destination / "results_1.csv").is_file()
+
+
+@pytest.mark.parametrize(
+    "args,written",
+    [
+        (("--info",), "info.json"),
+        (("--spec",), "spec.json"),
+        (("--config", "show"), "config-show.toml"),
+        (("--config", "show", "--format", "json"), "config-show.json"),
+        (("--config", "schema"), "config-schema.json"),
+        (("--config", "list-profiles", "--csv"), "config-list-profiles.csv"),
+    ],
+)
+def test_a_mode_names_its_document_in_a_directory(
+    hsql: Hsql, tmp_path: Path, args: tuple[str, ...], written: str
+) -> None:
+    """A document has no position to be numbered by, so it takes its own name --
+    and the extension of what it is actually written as."""
+    destination = tmp_path / "exports"
+    res = hsql(*args, "-o", str(destination))
+    assert res.stdout == ""
+    assert (destination / written).stat().st_size > 0
+    assert written in res.stderr
+
+
+def test_format_none_names_no_file(hsql: Hsql, duck: list[str], tmp_path: Path) -> None:
+    """The rows are discarded, so there is no file to write and no folder to
+    make -- but the run still reports what it did."""
+    destination = tmp_path / "exports"
+    res = hsql(
+        *duck, "--format", "none", "-o", str(destination), "--stats", "-c", "select 1"
+    )
+    assert res.exit_code == ExitCode.OK
+    assert not destination.exists()
+    assert json.loads(res.stderr.splitlines()[-1])["rows"] == 1
 
 
 # --- color -------------------------------------------------------------------


### PR DESCRIPTION
Closes #926

**What** are the key elements of this solution?

- **`harlequin -o PATH`** sets the default directory or file path for the Data Exporter. A folder prefills the dialog's path input with a trailing separator, so a user who exports into the same place every time types a file name and nothing else; a whole path prefills whole, and its extension picks the format the way a typed one does. `export.write_file()` creates the parent directory, so `-o .harlequin/` works before that folder exists.
- **`hsql -o` now takes a folder as well as a file**, and writes one file per result set into it — `results_1.csv`, `results_2.csv`, numbered as `--result` numbers them, with a line on stderr naming what it wrote. That is what lets a format holding one result set take a script that produced several, so `hsql --parquet -o ~/exports -c ... -c ...` is no longer refused; the error for the stdout case now offers `-o DIR` as a third remedy.
- A mode writing a document names its own file in a folder — `info.json`, `spec.json`, `config-show.toml`/`.json`, `catalog.csv` — with the extension of what it is actually written as, rather than of `--format`.
- What counts as a folder is one rule, in `export.names_a_directory()`: an existing directory, a trailing separator, or a name with no extension. `--format none` names no file and makes no directory.
- Incidental fix: a profile's `output` key arrived as a `str` where the code assumed a `Path`. It is normalized in one place now (`_Destination.parse`), which is also what lets one profile's `output` serve both commands.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The issue asks for a default export directory, and the option that already means "where output goes" is hsql's `-o`. Sharing the spelling means one profile key serves both commands — which is what forced the question of what `hsql -o DIR` should do, since hsql writes exactly one file and a folder gives it no name. Three answers were on the table: refuse it, fall back to stdout with a note, or write into it under generated names. The first two make a profile written for the IDE break or silently redirect every headless run; the third keeps the profile working and makes `--parquet -o ~/output` with several queries expressible, which it was not before. The cost is that the file names are hsql's choice rather than the caller's, so stderr names them — the one thing about the run stdout cannot carry.

File names are numbered even for a single result set (`results_1.csv`, not `results.csv`): a script can predict the name without knowing how many result sets it produced.

`_emit()` grew a sibling rather than a flag: `_fetched()` yields each fetched result set and `_write_result()` writes one, so the stream path and the file-per-result path share the fetch, the error handling and the `--stats` bookkeeping without either branching inside the other.

One behavior note: the IDE's `-o` is a `click.Path`, which normalizes away a trailing separator, so `harlequin -o exports.old/` for a folder that does not exist yet reads as a file. Every other case is unaffected, and a profile's `output` keeps its separator because it does not go through click.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the IDE's option list gains `-o/--output`, the default directory or file path for the Data Exporter (and the `output` profile key it shares with hsql); hsql's `-o` reference gains that a directory takes one file per result set, which is also how a format that holds one result set writes several.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfJPtrKZXnyYHLbvPyWTDq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfJPtrKZXnyYHLbvPyWTDq)_