### PR TITLE
Add `CatalogItem.type_name`, and a `type` column to `hsql --catalog` (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children, the database's own name for the object's type (`DECIMAL(18,2)`, `BASE TABLE`, `schema`), and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
+
+### Adapter API Changes
+
+- Adds `CatalogItem.type_name`, the database's own name for an object's type, like `DECIMAL(18,2)`. It defaults to `None`, and `hsql --catalog` prints it in its `type` column, beside the short `type_label`. It is a new dataclass field appended after `children`, so subclasses that add their own fields should be constructed with keyword arguments.
 
 ## [2.10.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children, the database's own name for the object's type (`DECIMAL(18,2)`, `BASE TABLE`, `schema`), and the correctly-quoted name to paste into a query, and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
+- Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children, the correctly-quoted name to paste into a query, and the database's own name for the object's type (`DECIMAL(18,2)`, `BASE TABLE`, `schema`), and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
 

--- a/src/harlequin/catalog.py
+++ b/src/harlequin/catalog.py
@@ -30,6 +30,9 @@ class CatalogItem:
             a list of columns if this is a table.). If the list is empty and
             a CatalogItem subclass implements the `fetch_children()` method,
             Harlequin will attempt to call that method to lazy-load children.
+        type_name (str | None): The full type of this object, spelled the way
+            this database spells it, e.g. "DECIMAL(18,2)" for a column or
+            "BASE TABLE" for a table. None if the adapter does not know it.
     """
 
     qualified_identifier: str
@@ -37,6 +40,7 @@ class CatalogItem:
     label: str
     type_label: str
     children: list["CatalogItem"] = field(default_factory=list)
+    type_name: str | None = None
 
 
 TCatalogItem_contra = TypeVar(

--- a/src/harlequin/hsql/modes/catalog.py
+++ b/src/harlequin/hsql/modes/catalog.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from harlequin.navigate import CatalogPath
     from harlequin.query import ResultSet
 
-COLUMNS = ("path", "name", "type", "type_label", "query_name")
+COLUMNS = ("path", "name", "query_name", "type", "type_label")
 """Both type columns: `type` is the database's own name for what this object is,
 and `type_label` is the short label, which an adapter always populates."""
 
@@ -44,9 +44,9 @@ def report(
         (
             spell([*path.segments, item.label]),
             item.label,
+            item.query_name,
             item.type_name,
             item.type_label,
-            item.query_name,
         )
         for item in listing.items
     ]

--- a/src/harlequin/hsql/modes/catalog.py
+++ b/src/harlequin/hsql/modes/catalog.py
@@ -10,7 +10,9 @@ if TYPE_CHECKING:
     from harlequin.navigate import CatalogPath
     from harlequin.query import ResultSet
 
-COLUMNS = ("path", "name", "type_label", "query_name")
+COLUMNS = ("path", "name", "type", "type_label", "query_name")
+"""Both type columns: `type` is the database's own name for what this object is,
+and `type_label` is the short label, which an adapter always populates."""
 
 
 def report(
@@ -42,6 +44,7 @@ def report(
         (
             spell([*path.segments, item.label]),
             item.label,
+            item.type_name,
             item.type_label,
             item.query_name,
         )

--- a/src/harlequin_duckdb/catalog.py
+++ b/src/harlequin_duckdb/catalog.py
@@ -32,6 +32,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
         parent: "RelationCatalogItem",
         label: str,
         type_label: str,
+        type_name: str,
     ) -> "ColumnCatalogItem":
         column_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
         column_query_name = f'"{label}"'
@@ -40,6 +41,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
             query_name=column_query_name,
             label=label,
             type_label=type_label,
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
             loaded=True,
@@ -67,6 +69,7 @@ class RelationCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
                 parent=self,
                 label=column_name,
                 type_label=self.connection._short_column_type(column_type),
+                type_name=column_type,
             )
             for column_name, column_type in result
         ]
@@ -83,6 +86,7 @@ class ViewCatalogItem(RelationCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str,
     ) -> "ViewCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -91,6 +95,7 @@ class ViewCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="v",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -107,6 +112,7 @@ class TableCatalogItem(RelationCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str,
     ) -> "TableCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -115,6 +121,7 @@ class TableCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="t",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -131,6 +138,7 @@ class TempTableCatalogItem(TableCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str,
     ) -> "TempTableCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -139,6 +147,7 @@ class TempTableCatalogItem(TableCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="tmp",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -164,6 +173,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
             query_name=schema_identifier,
             label=label,
             type_label="sch",
+            type_name="schema",
             connection=parent.connection,
             parent=parent,
         )
@@ -179,6 +189,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
                     ViewCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             elif table_type == "LOCAL TEMPORARY":
@@ -186,6 +197,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
                     TempTableCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             else:
@@ -193,6 +205,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
                     TableCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
 
@@ -215,6 +228,7 @@ class DatabaseCatalogItem(InteractiveCatalogItem["DuckDbConnection"]):
             query_name=database_identifier,
             label=label,
             type_label="db",
+            type_name="database",
             connection=connection,
         )
 

--- a/src/harlequin_sqlite/catalog.py
+++ b/src/harlequin_sqlite/catalog.py
@@ -27,6 +27,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
         parent: "RelationCatalogItem",
         label: str,
         type_label: str,
+        type_name: str | None,
     ) -> "ColumnCatalogItem":
         column_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
         column_query_name = f'"{label}"'
@@ -35,6 +36,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
             query_name=column_query_name,
             label=label,
             type_label=type_label,
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
             loaded=True,
@@ -60,6 +62,9 @@ class RelationCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
                 parent=self,
                 label=column_name,
                 type_label=self.connection._short_column_type(column_type),
+                # a column can be declared without a type, and an empty string
+                # is not one
+                type_name=column_type or None,
             )
             for _, column_name, column_type, *_ in result
         ]
@@ -75,6 +80,7 @@ class ViewCatalogItem(RelationCatalogItem):
         cls,
         parent: "DatabaseCatalogItem",
         label: str,
+        type_name: str,
     ) -> "ViewCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -83,6 +89,7 @@ class ViewCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="v",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -98,6 +105,7 @@ class TableCatalogItem(RelationCatalogItem):
         cls,
         parent: "DatabaseCatalogItem",
         label: str,
+        type_name: str,
     ) -> "TableCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -106,6 +114,7 @@ class TableCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="t",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -124,6 +133,7 @@ class DatabaseCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
             query_name=database_identifier,
             label=label,
             type_label="db",
+            type_name="database",
             connection=connection,
         )
 
@@ -138,6 +148,7 @@ class DatabaseCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
                     ViewCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             else:
@@ -145,6 +156,7 @@ class DatabaseCatalogItem(InteractiveCatalogItem["HarlequinSqliteConnection"]):
                     TableCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
 

--- a/tests/adapter_tests/test_duckdb.py
+++ b/tests/adapter_tests/test_duckdb.py
@@ -257,6 +257,34 @@ def test_get_catalog(tiny_duck: Path, small_duck: Path) -> None:
                 ]
 
 
+def test_catalog_items_carry_duckdbs_own_type_names(tmp_path: Path) -> None:
+    """`type_name` is the full type duckdb spells, which a 1-3 character
+    `type_label` cannot carry."""
+    conn = DuckDbAdapter([str(tmp_path / "types.db")], no_init=True).connect()
+    conn.execute("create table t (id bigint, total decimal(18,2))")
+    conn.execute("create view v as select 1 as n")
+
+    (database_item,) = conn.get_catalog().items
+    assert isinstance(database_item, InteractiveCatalogItem)
+    assert database_item.type_name == "database"
+    (schema_item,) = database_item.fetch_children()
+    assert isinstance(schema_item, InteractiveCatalogItem)
+    assert schema_item.type_name == "schema"
+
+    relation_items = schema_item.fetch_children()
+    assert [(item.label, item.type_name) for item in relation_items] == [
+        ("t", "BASE TABLE"),
+        ("v", "VIEW"),
+    ]
+
+    table_item = relation_items[0]
+    assert isinstance(table_item, InteractiveCatalogItem)
+    assert [
+        (item.label, item.type_label, item.type_name)
+        for item in table_item.fetch_children()
+    ] == [("id", "##", "BIGINT"), ("total", "#.#", "DECIMAL(18,2)")]
+
+
 def test_init_script(tiny_duck: Path, tmp_path: Path) -> None:
     script = (
         f".bail on\nselect \n1;\n.bail off\n.open {tiny_duck}\n"

--- a/tests/adapter_tests/test_sqlite.py
+++ b/tests/adapter_tests/test_sqlite.py
@@ -208,6 +208,35 @@ def test_get_catalog(tiny_sqlite: Path, small_sqlite: Path) -> None:
                 ]
 
 
+def test_catalog_items_carry_sqlites_own_type_names(tmp_path: Path) -> None:
+    """The declared type, which sqlite keeps verbatim -- and None for a column
+    declared without one, since an empty string is not a type."""
+    conn = HarlequinSqliteAdapter([str(tmp_path / "types.sqlite")]).connect()
+    conn.execute("create table t (id bigint, note, total decimal(18,2))")
+    conn.execute("create view v as select 1 as n")
+
+    (database_item,) = conn.get_catalog().items
+    assert isinstance(database_item, InteractiveCatalogItem)
+    assert database_item.type_name == "database"
+
+    relation_items = database_item.fetch_children()
+    assert [(item.label, item.type_name) for item in relation_items] == [
+        ("t", "table"),
+        ("v", "view"),
+    ]
+
+    table_item = relation_items[0]
+    assert isinstance(table_item, InteractiveCatalogItem)
+    assert [
+        (item.label, item.type_label, item.type_name)
+        for item in table_item.fetch_children()
+    ] == [
+        ("id", "##", "bigint"),
+        ("note", "#.#", None),
+        ("total", "#.#", "decimal(18,2)"),
+    ]
+
+
 def test_init_script(tiny_sqlite: Path, tmp_path: Path) -> None:
     script = (
         f".bail on\nselect \n1;\n.bail off\n.open {tiny_sqlite}\n"

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -2697,7 +2697,7 @@ def catalog_db(hsql: Hsql, tmp_path: Path) -> list[str]:
 def test_catalog_lists_the_top_level(hsql: Hsql, catalog_db: list[str]) -> None:
     res = hsql(*catalog_db, "--catalog", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|db|"cat"\n'
+    assert res.stdout == 'cat|cat|database|db|"cat"\n'
 
 
 def test_catalog_lists_one_level_below_path(hsql: Hsql, catalog_db: list[str]) -> None:
@@ -2720,9 +2720,105 @@ def test_catalog_describes_a_relation_by_listing_it(
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics.orders", "-tA")
     assert res.exit_code == ExitCode.OK
     assert cells(res.stdout) == [
-        ["cat.analytics.orders.customer_id", "customer_id", "##", '"customer_id"'],
-        ["cat.analytics.orders.id", "id", "##", '"id"'],
-        ["cat.analytics.orders.total", "total", "#.#", '"total"'],
+        [
+            "cat.analytics.orders.customer_id",
+            "customer_id",
+            "BIGINT",
+            "##",
+            '"customer_id"',
+        ],
+        ["cat.analytics.orders.id", "id", "BIGINT", "##", '"id"'],
+        ["cat.analytics.orders.total", "total", "DECIMAL(18,2)", "#.#", '"total"'],
+    ]
+
+
+def test_every_level_reports_the_type_its_database_calls_it(
+    hsql: Hsql, catalog_db: list[str]
+) -> None:
+    """`type` is the adapter's own vocabulary, not one core invented for it."""
+    res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert [(row[1], row[2]) for row in cells(res.stdout)] == [
+        ("order_summary", "VIEW"),
+        ("orders", "BASE TABLE"),
+    ]
+
+    res = hsql(*catalog_db, "--catalog", "--path", "cat", "-tA")
+    assert res.exit_code == ExitCode.OK
+    assert {row[2] for row in cells(res.stdout)} == {"schema"}
+
+
+def test_an_item_with_no_type_keeps_its_short_label(tmp_path: Path) -> None:
+    """The degradation path, which no in-tree adapter takes: `type` is beside
+    `type_label` rather than instead of it, so a listing still says what these
+    things are."""
+    from harlequin.adapter import HarlequinConnection
+    from harlequin.catalog import Catalog, CatalogItem
+    from harlequin.hsql.modes import catalog as catalog_mode
+    from harlequin.layout import LayoutOptions
+    from harlequin.navigate import CatalogPath
+
+    class UntypedConnection:
+        def get_catalog(self) -> Catalog:
+            return Catalog(
+                items=[
+                    CatalogItem(
+                        qualified_identifier='"t"',
+                        query_name='"t"',
+                        label="t",
+                        type_label="t",
+                    )
+                ]
+            )
+
+    destination = tmp_path / "listing.csv"
+    with destination.open("wb") as out:
+        catalog_mode.report(
+            out,
+            connection=cast("HarlequinConnection", UntypedConnection()),
+            path=CatalogPath(),
+            format_name="csv",
+            layout_options=LayoutOptions(),
+            file_options={},
+        )
+    assert destination.read_text(encoding="utf-8").splitlines() == [
+        "path,name,type,type_label,query_name",
+        't,t,,t,"""t"""',
+    ]
+
+
+@pytest.mark.parametrize(
+    ("adapter", "levels", "type_names"),
+    [
+        ("duckdb", ["main", "t"], ["BIGINT", "VARCHAR"]),
+        ("sqlite", ["t"], ["bigint", "varchar"]),
+    ],
+)
+def test_type_answers_for_every_bundled_adapter(
+    hsql: Hsql,
+    tmp_path: Path,
+    adapter: str,
+    levels: list[str],
+    type_names: list[str],
+) -> None:
+    """Both in-tree adapters populate it, out of introspection they already do.
+
+    Each spells a type its own way, which is the point of carrying the
+    database's own name for it rather than a normalized one.
+    """
+    argv = ["-a", adapter, "--no-init", str(tmp_path / f"{adapter}.db")]
+    res = hsql(*argv, "--format", "none", "-c", "create table t (n bigint, s varchar)")
+    assert res.exit_code == ExitCode.OK, res.stderr
+
+    res = hsql(*argv, "--catalog", "-tA")
+    assert res.exit_code == ExitCode.OK
+    database_path = cells(res.stdout)[0][0]
+
+    res = hsql(*argv, "--catalog", "--path", ".".join([database_path, *levels]), "-tA")
+    assert res.exit_code == ExitCode.OK, res.stderr
+    assert [(row[1], row[2]) for row in cells(res.stdout)] == [
+        ("n", type_names[0]),
+        ("s", type_names[1]),
     ]
 
 
@@ -2811,7 +2907,7 @@ def test_catalog_takes_every_format_a_result_set_does(
     """A listing is rows, so it inherits the output layer rather than adding one."""
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--csv")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout.splitlines()[0] == "path,name,type_label,query_name"
+    assert res.stdout.splitlines()[0] == "path,name,type,type_label,query_name"
 
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--json")
     assert res.exit_code == ExitCode.OK
@@ -2911,7 +3007,7 @@ def test_catalog_carries_the_adapters_options(
     """
     res = hsql(*catalog_db, "--catalog", "--force-install-extensions", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|db|"cat"\n'
+    assert res.stdout == 'cat|cat|database|db|"cat"\n'
 
 
 def test_catalog_reads_the_profile_a_run_would(
@@ -2928,7 +3024,7 @@ def test_catalog_reads_the_profile_a_run_would(
     )
     res = hsql("--config-path", str(config_file), "-P", "cat", "--catalog", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|db|"cat"\n'
+    assert res.stdout == 'cat|cat|database|db|"cat"\n'
 
 
 def test_catalog_answers_for_every_bundled_adapter(

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -2697,7 +2697,7 @@ def catalog_db(hsql: Hsql, tmp_path: Path) -> list[str]:
 def test_catalog_lists_the_top_level(hsql: Hsql, catalog_db: list[str]) -> None:
     res = hsql(*catalog_db, "--catalog", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|database|db|"cat"\n'
+    assert res.stdout == 'cat|cat|"cat"|database|db\n'
 
 
 def test_catalog_lists_one_level_below_path(hsql: Hsql, catalog_db: list[str]) -> None:
@@ -2723,12 +2723,12 @@ def test_catalog_describes_a_relation_by_listing_it(
         [
             "cat.analytics.orders.customer_id",
             "customer_id",
+            '"customer_id"',
             "BIGINT",
             "##",
-            '"customer_id"',
         ],
-        ["cat.analytics.orders.id", "id", "BIGINT", "##", '"id"'],
-        ["cat.analytics.orders.total", "total", "DECIMAL(18,2)", "#.#", '"total"'],
+        ["cat.analytics.orders.id", "id", '"id"', "BIGINT", "##"],
+        ["cat.analytics.orders.total", "total", '"total"', "DECIMAL(18,2)", "#.#"],
     ]
 
 
@@ -2738,14 +2738,14 @@ def test_every_level_reports_the_type_its_database_calls_it(
     """`type` is the adapter's own vocabulary, not one core invented for it."""
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert [(row[1], row[2]) for row in cells(res.stdout)] == [
+    assert [(row[1], row[3]) for row in cells(res.stdout)] == [
         ("order_summary", "VIEW"),
         ("orders", "BASE TABLE"),
     ]
 
     res = hsql(*catalog_db, "--catalog", "--path", "cat", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert {row[2] for row in cells(res.stdout)} == {"schema"}
+    assert {row[3] for row in cells(res.stdout)} == {"schema"}
 
 
 def test_an_item_with_no_type_keeps_its_short_label(tmp_path: Path) -> None:
@@ -2782,8 +2782,8 @@ def test_an_item_with_no_type_keeps_its_short_label(tmp_path: Path) -> None:
             file_options={},
         )
     assert destination.read_text(encoding="utf-8").splitlines() == [
-        "path,name,type,type_label,query_name",
-        't,t,,t,"""t"""',
+        "path,name,query_name,type,type_label",
+        't,t,"""t""",,t',
     ]
 
 
@@ -2816,7 +2816,7 @@ def test_type_answers_for_every_bundled_adapter(
 
     res = hsql(*argv, "--catalog", "--path", ".".join([database_path, *levels]), "-tA")
     assert res.exit_code == ExitCode.OK, res.stderr
-    assert [(row[1], row[2]) for row in cells(res.stdout)] == [
+    assert [(row[1], row[3]) for row in cells(res.stdout)] == [
         ("n", type_names[0]),
         ("s", type_names[1]),
     ]
@@ -2907,7 +2907,7 @@ def test_catalog_takes_every_format_a_result_set_does(
     """A listing is rows, so it inherits the output layer rather than adding one."""
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--csv")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout.splitlines()[0] == "path,name,type,type_label,query_name"
+    assert res.stdout.splitlines()[0] == "path,name,query_name,type,type_label"
 
     res = hsql(*catalog_db, "--catalog", "--path", "cat.analytics", "--json")
     assert res.exit_code == ExitCode.OK
@@ -3007,7 +3007,7 @@ def test_catalog_carries_the_adapters_options(
     """
     res = hsql(*catalog_db, "--catalog", "--force-install-extensions", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|database|db|"cat"\n'
+    assert res.stdout == 'cat|cat|"cat"|database|db\n'
 
 
 def test_catalog_reads_the_profile_a_run_would(
@@ -3024,7 +3024,7 @@ def test_catalog_reads_the_profile_a_run_would(
     )
     res = hsql("--config-path", str(config_file), "-P", "cat", "--catalog", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout == 'cat|cat|database|db|"cat"\n'
+    assert res.stdout == 'cat|cat|"cat"|database|db\n'
 
 
 def test_catalog_answers_for_every_bundled_adapter(
@@ -3033,7 +3033,7 @@ def test_catalog_answers_for_every_bundled_adapter(
     """Every adapter names its levels differently, and every one has a top."""
     res = hsql(*both_adapters, "--catalog", "-tA")
     assert res.exit_code == ExitCode.OK
-    assert res.stdout.count("|db|") == 1
+    assert [row[4] for row in cells(res.stdout)] == ["db"]
 
 
 def test_catalog_is_in_the_help(hsql: Hsql) -> None:


### PR DESCRIPTION
Part of #524 — PR 10 of M2, per `docs/plans/m2-hsql-technical-plan.md` §3.2.

**What** are the key elements of this solution?

- `CatalogItem.type_name: str | None = None` on the adapter contract: the database's own name for what an object is.
- Both in-tree adapters populate it, out of introspection they already ran and discarded:

  | | columns | relations | schemas / databases |
  |---|---|---|---|
  | DuckDB | `information_schema.columns.data_type` → `DECIMAL(18,2)` | `table_type` → `BASE TABLE`, `VIEW`, `LOCAL TEMPORARY` | `schema`, `database` |
  | SQLite | the declared type from `pragma table_info`, `None` for a column declared without one | `sqlite_schema.type` → `table`, `view` | `database` |

- `hsql --catalog`'s columns become `path, name, query_name, type, type_label` — the two identifiers a caller copies out of a listing together, then the two type columns:

  ```
   path                       | name  | query_name | type          | type_label
  ----------------------------+-------+------------+---------------+------------
   cat.analytics.orders.id    | id    | "id"       | BIGINT        | ##
   cat.analytics.orders.total | total | "total"    | DECIMAL(18,2) | #.#
  ```

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

`CatalogItem` carries a 1–3 character `type_label`, so the type an agent actually needs was not in the contract at all — `total #.#` does not tell you the precision, and `id ##` does not tell you `BIGINT` from `HUGEINT`. The field is the plan's answer to the `--format compact` idea it replaced.

Three choices worth naming:

- **The full type sits beside the short label, not instead of it.** `type_name` defaults to `None`, so an adapter that never adopts it degrades to today's listing rather than to a blank column. `type_label` also stays what the IDE's Data Catalog renders.
- **The value is the adapter's own vocabulary, un-normalized.** DuckDB says `BASE TABLE` and SQLite says `table`; core does not reconcile them. Normalizing would mean core owning a type taxonomy for every database, and the string an agent wants to paste back into DDL is the one its database uses.
- **The relation type is threaded down from `fetch_children()`** rather than hardcoded per subclass, so DuckDB's fallback branch reports whatever `table_type` it actually saw instead of asserting `BASE TABLE` for a type it did not recognize.

The one tradeoff: `type_name` is a new dataclass field, so it shifts the positional argument order of any `CatalogItem` subclass's own fields. It is appended after `children`, which leaves the base class's own positional order untouched; every in-tree call site and the adapter template already pass keywords. The `CHANGELOG.md` entry says so under Adapter API Changes.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the Catalog & Introspection page needs the `type` column in its description of a `--catalog` listing, and the adapter-author page needs `type_name`. The plan puts both in PR 12, with the rest of the M2 catalog docs.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

- `tests/unit_tests/test_hsql.py`: every level reports the type its database calls it; both bundled adapters answer, each spelling a type its own way; and the degradation path — `report()` against a stub connection holding a plain `CatalogItem`, asserting an empty `type` with `type_label` intact. No bundled adapter takes that path any more, which is why it is driven directly rather than through a fixture.
- `tests/adapter_tests/`: one test per adapter walking its catalog tree, including a SQLite column declared with no type coming back `None`.

Full suite green on the rebased branch: 1107 passed, 6 skipped, 1 xfailed, 148 snapshots passed; `mypy`, `ruff` and all four import-linter contracts clean.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
