### PR TITLE
Add the query editor's own symbols to autocompletion (#872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children, the correctly-quoted name to paste into a query, and the database's own name for the object's type (`DECIMAL(18,2)`, `BASE TABLE`, `schema`), and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
+- Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Adapter API Changes
 

--- a/src/harlequin/autocomplete/__init__.py
+++ b/src/harlequin/autocomplete/__init__.py
@@ -4,10 +4,14 @@ from harlequin.autocomplete.completers import (
     completer_factory,
 )
 from harlequin.autocomplete.completion import HarlequinCompletion
+from harlequin.autocomplete.symbols import NO_SYMBOLS, BufferSymbols, find_symbols
 
 __all__ = [
+    "NO_SYMBOLS",
+    "BufferSymbols",
     "HarlequinCompletion",
     "MemberCompleter",
     "WordCompleter",
     "completer_factory",
+    "find_symbols",
 ]

--- a/src/harlequin/autocomplete/completers.py
+++ b/src/harlequin/autocomplete/completers.py
@@ -7,10 +7,14 @@ from typing import Iterable
 
 from harlequin.autocomplete.completion import HarlequinCompletion
 from harlequin.autocomplete.constants import get_functions, get_keywords
+from harlequin.autocomplete.symbols import NO_SYMBOLS, BufferSymbols
 from harlequin.catalog import Catalog, CatalogItem
 
 SEPARATOR_PROG = re.compile(r"\.|::?")
 ANY_QUOTE_PROG = re.compile(r"\"|'|`")
+
+BUFFER_TYPE_LABEL = "buf"
+BUFFER_PRIORITY = 400
 
 
 class WordCompleter:
@@ -25,6 +29,10 @@ class WordCompleter:
         self._function_completions = function_completions
         self._catalog_completions = catalog_completions
         self._extra_completions = extra_completions or []
+        self._buffer_symbols = NO_SYMBOLS
+        self._buffer_symbol_values: frozenset[str] = frozenset()
+        self._buffer_completions: list[HarlequinCompletion] = []
+        self._known_keys: set[object] = set()
         self.completions: list[HarlequinCompletion] = []
         self.merge()
 
@@ -37,24 +45,22 @@ class WordCompleter:
             return (c.label, c.type_label)
 
         match_val = prefix.lower()
-        matches: list[tuple[tuple[str, str], str]] = []
+        candidates = self._candidates(match_val)
 
-        # Add exact matches
-        matches.extend(
-            (_label(c), c.value) for c in self.completions if c.match_val == match_val
-        )
-        # Add prefix matches
-        matches.extend(
-            (_label(c), c.value)
-            for c in self.completions
-            if c.match_val.startswith(match_val)
-        )
+        exact = [c for c in candidates if c.match_val == match_val]
+        prefixed = [c for c in candidates if c.match_val.startswith(match_val)]
         # Only add fuzzy matches if there are not enough exact matches
-        if len(matches) < 20:
-            matches.extend(
-                (_label(c), c.value)
-                for c in self._fuzzy_match(match_val, self.completions)
-            )
+        fuzzy = (
+            self._fuzzy_match(match_val, candidates)
+            if len(exact) + len(prefixed) < 20
+            else []
+        )
+
+        matches = [
+            (_label(c), c.value)
+            for group in (exact, prefixed, fuzzy)
+            for c in self._rank(group)
+        ]
 
         return self._dedupe_labels(matches)
 
@@ -75,6 +81,17 @@ class WordCompleter:
         if not defer_merge:
             self.merge()
 
+    def update_buffer_symbols(self, symbols: BufferSymbols) -> None:
+        """
+        Offer the symbols a user has typed but nothing else knows about, and rank
+        every completion the buffer mentions above the ones it does not. This runs
+        on every edit of the buffer, so it stays O(n) in the number of symbols by
+        matching against the index merge() built.
+        """
+        self._buffer_symbols = symbols
+        self._buffer_symbol_values = frozenset(name.lower() for name in symbols.names)
+        self._buffer_completions = self._build_buffer_completions(symbols)
+
     def merge(self) -> None:
         """
         Rebuild the merged, sorted completions list. This is O(n log n) in the
@@ -89,6 +106,55 @@ class WordCompleter:
             self._catalog_completions,
             self._extra_completions,
         )
+        self._known_keys = self._build_known_keys()
+        self._buffer_completions = self._build_buffer_completions(self._buffer_symbols)
+
+    def _candidates(self, match_val: str) -> list[HarlequinCompletion]:
+        """
+        The completions to match against: the merged list, plus the buffer's own
+        symbols. A buffer symbol identical to what the user has typed would
+        complete to itself, so it is dropped.
+        """
+        if not self._buffer_completions:
+            return self.completions
+        return [
+            *(c for c in self._buffer_completions if c.match_val != match_val),
+            *self.completions,
+        ]
+
+    def _rank(self, matches: list[HarlequinCompletion]) -> list[HarlequinCompletion]:
+        """
+        Order one group of matches by its relationship to the buffer, keeping the
+        (priority, label) order of the merged list within each rank.
+        """
+        if not self._buffer_symbol_values:
+            return matches
+        return sorted(matches, key=self._buffer_rank)
+
+    def _buffer_rank(self, completion: HarlequinCompletion) -> int:
+        if completion.match_val in self._buffer_symbol_values:
+            return 0
+        if completion.match_context in self._buffer_symbol_values:
+            return 1
+        return 2
+
+    def _build_known_keys(self) -> set[object]:
+        """Index the merged completions, so a symbol already offered is not repeated."""
+        return {c.match_val for c in self.completions}
+
+    def _build_buffer_completions(
+        self, symbols: BufferSymbols
+    ) -> list[HarlequinCompletion]:
+        return [
+            HarlequinCompletion(
+                label=name,
+                type_label=BUFFER_TYPE_LABEL,
+                value=name,
+                priority=BUFFER_PRIORITY,
+            )
+            for name in symbols.names
+            if name.lower() not in self._known_keys
+        ]
 
     @staticmethod
     def _fuzzy_match(
@@ -157,30 +223,23 @@ class MemberCompleter(WordCompleter):
         )
 
         context_completions = [
-            c for c in self.completions if c.context == match_context
+            c for c in self._candidates(match_val) if c.context == match_context
         ]
 
-        matches: list[tuple[tuple[str, str], str]] = []
-        # Add exact matches
-        matches.extend(
-            self.format_completion(c, quote_char, value_prefix, _label)
-            for c in context_completions
-            if c.match_val == match_val
-        )
-
-        # Add prefix matches
-        matches.extend(
-            self.format_completion(c, quote_char, value_prefix, _label)
-            for c in context_completions
-            if c.match_val.startswith(match_val)
-        )
-
+        exact = [c for c in context_completions if c.match_val == match_val]
+        prefixed = [c for c in context_completions if c.match_val.startswith(match_val)]
         # Only add fuzzy matches if there are not enough exact matches
-        if len(matches) < 20:
-            matches.extend(
-                self.format_completion(c, quote_char, value_prefix, _label)
-                for c in self._fuzzy_match(match_val, context_completions)
-            )
+        fuzzy = (
+            self._fuzzy_match(match_val, context_completions)
+            if len(exact) + len(prefixed) < 20
+            else []
+        )
+
+        matches = [
+            self.format_completion(c, quote_char, value_prefix, _label)
+            for group in (exact, prefixed, fuzzy)
+            for c in self._rank(group)
+        ]
 
         return self._dedupe_labels(matches)
 
@@ -195,6 +254,28 @@ class MemberCompleter(WordCompleter):
             label_fn(completion, value_prefix, quote_char),
             f"{value_prefix}{quote_char}{completion.value}",
         )
+
+    def _build_known_keys(self) -> set[object]:
+        return {(c.match_context, c.match_val) for c in self.completions}
+
+    def _build_buffer_completions(
+        self, symbols: BufferSymbols
+    ) -> list[HarlequinCompletion]:
+        """
+        A buffer's `context.name` pairs, which is how an alias or a CTE gets
+        members at all -- neither is in the catalog.
+        """
+        return [
+            HarlequinCompletion(
+                label=name,
+                type_label=BUFFER_TYPE_LABEL,
+                value=name,
+                priority=BUFFER_PRIORITY,
+                context=context.lower(),
+            )
+            for context, name in symbols.members
+            if (context.lower(), name.lower()) not in self._known_keys
+        ]
 
     @staticmethod
     def _merge_completions(

--- a/src/harlequin/autocomplete/completers.py
+++ b/src/harlequin/autocomplete/completers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import re
 from collections.abc import Callable
-from typing import Iterable
+from typing import Iterable, Iterator
 
 from harlequin.autocomplete.completion import HarlequinCompletion
 from harlequin.autocomplete.constants import get_functions, get_keywords
@@ -44,14 +44,15 @@ class WordCompleter:
         def _label(c: HarlequinCompletion) -> tuple[str, str]:
             return (c.label, c.type_label)
 
-        match_val = prefix.lower()
-        candidates = self._candidates(match_val)
+        match_val = prefix.casefold()
 
-        exact = [c for c in candidates if c.match_val == match_val]
-        prefixed = [c for c in candidates if c.match_val.startswith(match_val)]
+        exact = [c for c in self._candidates(match_val) if c.match_val == match_val]
+        prefixed = [
+            c for c in self._candidates(match_val) if c.match_val.startswith(match_val)
+        ]
         # Only add fuzzy matches if there are not enough exact matches
         fuzzy = (
-            self._fuzzy_match(match_val, candidates)
+            self._fuzzy_match(match_val, self._candidates(match_val))
             if len(exact) + len(prefixed) < 20
             else []
         )
@@ -83,13 +84,17 @@ class WordCompleter:
 
     def update_buffer_symbols(self, symbols: BufferSymbols) -> None:
         """
-        Offer the symbols a user has typed but nothing else knows about, and rank
-        every completion the buffer mentions above the ones it does not. This runs
-        on every edit of the buffer, so it stays O(n) in the number of symbols by
-        matching against the index merge() built.
+        Replace the buffer state -- the symbols, the values matches are ranked
+        against, and the completions built from the symbols nothing else offers.
+
+        The Query Editor calls this on every edit, so it is O(n) in the number of
+        symbols rather than the number of completions: the index it deduplicates
+        against is the one merge() built.
         """
         self._buffer_symbols = symbols
-        self._buffer_symbol_values = frozenset(name.lower() for name in symbols.names)
+        self._buffer_symbol_values = frozenset(
+            name.casefold() for name in symbols.names
+        )
         self._buffer_completions = self._build_buffer_completions(symbols)
 
     def merge(self) -> None:
@@ -109,18 +114,20 @@ class WordCompleter:
         self._known_keys = self._build_known_keys()
         self._buffer_completions = self._build_buffer_completions(self._buffer_symbols)
 
-    def _candidates(self, match_val: str) -> list[HarlequinCompletion]:
+    def _candidates(self, match_val: str) -> Iterator[HarlequinCompletion]:
         """
-        The completions to match against: the merged list, plus the buffer's own
-        symbols. A buffer symbol identical to what the user has typed would
-        complete to itself, so it is dropped.
+        Everything to match against: the buffer's own completions, then the merged
+        list. A buffer symbol identical to what the user has typed would complete
+        to itself, so it is dropped.
+
+        This is an iterator, and each pass over the candidates gets its own -- the
+        merged list is the whole catalog, and a copy of it per keystroke is a copy
+        nothing reads twice.
         """
-        if not self._buffer_completions:
-            return self.completions
-        return [
-            *(c for c in self._buffer_completions if c.match_val != match_val),
-            *self.completions,
-        ]
+        return itertools.chain(
+            (c for c in self._buffer_completions if c.match_val != match_val),
+            self.completions,
+        )
 
     def _rank(self, matches: list[HarlequinCompletion]) -> list[HarlequinCompletion]:
         """
@@ -153,12 +160,12 @@ class WordCompleter:
                 priority=BUFFER_PRIORITY,
             )
             for name in symbols.names
-            if name.lower() not in self._known_keys
+            if name.casefold() not in self._known_keys
         ]
 
     @staticmethod
     def _fuzzy_match(
-        match_val: str, completions: list[HarlequinCompletion]
+        match_val: str, completions: Iterable[HarlequinCompletion]
     ) -> list[HarlequinCompletion]:
         regex_base = ".{0,2}?".join(f"({re.escape(c)})" for c in match_val)
         regex = "^.*" + regex_base + ".*$"
@@ -212,11 +219,11 @@ class MemberCompleter(WordCompleter):
             quote_match = ANY_QUOTE_PROG.match(item_prefix)
             if quote_match is not None:
                 quote_char = quote_match.group(0)
-                match_val = item_prefix[1:].lower()
+                match_val = item_prefix[1:].casefold()
             else:
                 quote_char = ""
-                match_val = item_prefix.lower()
-            match_context = context.strip("'`\"").lower()
+                match_val = item_prefix.casefold()
+            match_context = context.strip("'`\"").casefold()
             separators = SEPARATOR_PROG.findall(prefix)
         value_prefix = "".join(
             f"{w}{sep}" for w, sep in zip([*others, context], separators, strict=False)
@@ -271,10 +278,10 @@ class MemberCompleter(WordCompleter):
                 type_label=BUFFER_TYPE_LABEL,
                 value=name,
                 priority=BUFFER_PRIORITY,
-                context=context.lower(),
+                context=context.casefold(),
             )
             for context, name in symbols.members
-            if (context.lower(), name.lower()) not in self._known_keys
+            if (context.casefold(), name.casefold()) not in self._known_keys
         ]
 
     @staticmethod

--- a/src/harlequin/autocomplete/completion.py
+++ b/src/harlequin/autocomplete/completion.py
@@ -15,7 +15,9 @@ class HarlequinCompletion:
     priority (lowest first). Harlequin gives reserved keywords a priority of 100,
     Catalog items a priority of 500, and functions a priority of 1000. Completions
     can have a context, which will cause them to be shown as member completions after
-    the user types the context followed by a `.` or `:`.
+    the user types the context followed by a `.` or `:`. Completions whose label
+    or context appears in the Query Editor are ranked above those that do not,
+    and a symbol found only in the editor gets a priority of 400.
 
     Args:
         label (str): The text shown to the user in the autocomplete menu.
@@ -49,3 +51,8 @@ class HarlequinCompletion:
     @cached_property
     def match_val(self) -> str:
         return self.label.lower()
+
+    @cached_property
+    def match_context(self) -> str:
+        """The context, folded for comparison; the empty string if there is none."""
+        return self.context.lower() if self.context is not None else ""

--- a/src/harlequin/autocomplete/completion.py
+++ b/src/harlequin/autocomplete/completion.py
@@ -50,9 +50,9 @@ class HarlequinCompletion:
 
     @cached_property
     def match_val(self) -> str:
-        return self.label.lower()
+        return self.label.casefold()
 
     @cached_property
     def match_context(self) -> str:
         """The context, folded for comparison; the empty string if there is none."""
-        return self.context.lower() if self.context is not None else ""
+        return self.context.casefold() if self.context is not None else ""

--- a/src/harlequin/autocomplete/symbols.py
+++ b/src/harlequin/autocomplete/symbols.py
@@ -44,8 +44,7 @@ NO_SYMBOLS = BufferSymbols()
 def find_symbols(text: str) -> BufferSymbols:
     """Extract every identifier in `text`, and each `context.name` pair among them.
 
-    Names are deduplicated case-insensitively, keeping the spelling that appears
-    first.
+    Names are deduplicated caselessly, keeping the spelling that appears first.
     """
     if not text.strip():
         return NO_SYMBOLS
@@ -60,13 +59,13 @@ def find_symbols(text: str) -> BufferSymbols:
     for node in sorted(matched.get("identifier", []), key=lambda n: n.start_byte):
         name = _identifier(node)
         if name:
-            names.setdefault(name.lower(), name)
+            names.setdefault(name.casefold(), name)
 
     members: dict[tuple[str, str], tuple[str, str]] = {}
     for node in sorted(matched.get("reference", []), key=lambda n: n.start_byte):
         parts = _dotted_parts(node)
         for context, name in pairwise(parts):
-            members.setdefault((context.lower(), name.lower()), (context, name))
+            members.setdefault((context.casefold(), name.casefold()), (context, name))
 
     return BufferSymbols(names=tuple(names.values()), members=tuple(members.values()))
 

--- a/src/harlequin/autocomplete/symbols.py
+++ b/src/harlequin/autocomplete/symbols.py
@@ -1,0 +1,95 @@
+"""The identifiers a user has typed into a buffer, for the autocompleters.
+
+A buffer names things the catalog does not -- a CTE, an alias, a column of a
+table that has not been created yet -- and the things it does name are the ones
+the user is most likely to want next. `find_symbols()` reads both out of the
+tree-sitter parse, so a mid-edit buffer full of syntax errors still yields the
+identifiers around the error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+SYMBOL_QUERY = """
+(identifier) @identifier
+[(object_reference) (field)] @reference
+"""
+"""Capture every identifier, and every dotted reference that relates two of them.
+
+Keywords are their own node types, so `select` and `from` are not identifiers;
+function names are, and are deduped against the function completions.
+"""
+
+QUOTE_CHARS = "\"'`[]"
+
+
+@dataclass(frozen=True)
+class BufferSymbols:
+    """The identifiers in a buffer, in the order they first appear."""
+
+    names: tuple[str, ...] = ()
+    members: tuple[tuple[str, str], ...] = ()
+    """One `(context, name)` pair per `context.name` written in the buffer."""
+
+
+NO_SYMBOLS = BufferSymbols()
+
+
+def find_symbols(text: str) -> BufferSymbols:
+    """Extract every identifier in `text`, and each `context.name` pair among them.
+
+    Names are deduplicated case-insensitively, keeping the spelling that appears
+    first.
+    """
+    if not text.strip():
+        return NO_SYMBOLS
+
+    # deferred: every adapter imports this package, and only the Query Editor
+    # ever parses SQL with it.
+    from harlequin.statements import captures
+
+    matched = captures(text, SYMBOL_QUERY)
+
+    names: dict[str, str] = {}
+    for node in sorted(matched.get("identifier", []), key=lambda n: n.start_byte):
+        name = _identifier(node)
+        if name:
+            names.setdefault(name.lower(), name)
+
+    members: dict[tuple[str, str], tuple[str, str]] = {}
+    for node in sorted(matched.get("reference", []), key=lambda n: n.start_byte):
+        parts = _dotted_parts(node)
+        for context, name in pairwise(parts):
+            members.setdefault((context.lower(), name.lower()), (context, name))
+
+    return BufferSymbols(names=tuple(names.values()), members=tuple(members.values()))
+
+
+def _identifier(node: Node) -> str:
+    """The text of an identifier node, without whatever quoted it."""
+    if node.text is None:
+        return ""
+    return node.text.decode("utf-8").strip(QUOTE_CHARS)
+
+
+def _dotted_parts(node: Node) -> list[str]:
+    """The identifiers of a dotted reference, left to right.
+
+    A three-part reference nests: `db.sch.tbl` is an `object_reference` holding
+    `db` and `sch` inside the one holding `tbl`.
+    """
+    parts: list[str] = []
+    for child in node.children:
+        if child.type == "identifier":
+            name = _identifier(child)
+            if name:
+                parts.append(name)
+        elif child.type == "object_reference":
+            parts.extend(_dotted_parts(child))
+    return parts

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -82,7 +82,6 @@ class CodeEditor(TextEditor, inherit_bindings=False):
             )
 
     def _scan_for_symbols(self) -> None:
-        # the text is read here, on the main thread, and parsed on a worker.
         self._symbol_scan_timer = None
         self.read_symbols(self.text)
 

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -5,20 +5,31 @@ from typing import List, Union
 
 from sqlfmt.api import Mode, format_string
 from sqlfmt.exception import SqlfmtError
+from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.geometry import Offset
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import Tab, Tabs
+from textual.timer import Timer
+from textual.widgets import Tab, Tabs, TextArea
 from textual.widgets.text_area import EditHistory, Location, Selection
 from textual_textarea import TextAreaSaved, TextEditor
 
-from harlequin.autocomplete import MemberCompleter, WordCompleter
+from harlequin.autocomplete import (
+    NO_SYMBOLS,
+    BufferSymbols,
+    MemberCompleter,
+    WordCompleter,
+    find_symbols,
+)
 from harlequin.components.text_modal import ErrorModal
 from harlequin.editor_cache import BufferState, load_cache
 from harlequin.messages import WidgetMounted
 from harlequin.statements import find_separators
+
+SYMBOL_SCAN_INTERVAL = 0.3
+"""Seconds an edit waits before the buffer is re-read for symbols."""
 
 
 @dataclass
@@ -52,6 +63,32 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         def __init__(self, text: str) -> None:
             super().__init__()
             self.text = text
+
+    class SymbolsFound(Message):
+        """Posted when the loaded buffer's identifiers have been re-read."""
+
+        def __init__(self, symbols: BufferSymbols) -> None:
+            super().__init__()
+            self.symbols = symbols
+
+    _symbol_scan_timer: Union[Timer, None] = None
+
+    @on(TextArea.Changed)
+    def schedule_symbol_scan(self, message: TextArea.Changed) -> None:
+        """Re-read the buffer's symbols, at most once per scan interval."""
+        if self._symbol_scan_timer is None:
+            self._symbol_scan_timer = self.set_timer(
+                SYMBOL_SCAN_INTERVAL, self._scan_for_symbols
+            )
+
+    def _scan_for_symbols(self) -> None:
+        # the text is read here, on the main thread, and parsed on a worker.
+        self._symbol_scan_timer = None
+        self.read_symbols(self.text)
+
+    @work(thread=True, exclusive=True, group="symbol_scanners")
+    def read_symbols(self, text: str) -> None:
+        self.post_message(self.SymbolsFound(symbols=find_symbols(text)))
 
     def selected_queries(self) -> list[str]:
         """
@@ -228,6 +265,7 @@ class EditorCollection(Vertical):
         self.counter = 0
         self._word_completer: WordCompleter | None = None
         self._member_completer: MemberCompleter | None = None
+        self._buffer_symbols: BufferSymbols = NO_SYMBOLS
         self.startup_cache = load_cache()
         self.buffer_states: dict[str, EditorState] = {}
         self.loaded_buffer_id: str | None = None
@@ -276,6 +314,7 @@ class EditorCollection(Vertical):
     @member_completer.setter
     def member_completer(self, new_completer: MemberCompleter) -> None:
         self._member_completer = new_completer
+        new_completer.update_buffer_symbols(self._buffer_symbols)
         self.editor.member_completer = new_completer
 
     @property
@@ -285,7 +324,21 @@ class EditorCollection(Vertical):
     @word_completer.setter
     def word_completer(self, new_completer: WordCompleter) -> None:
         self._word_completer = new_completer
+        new_completer.update_buffer_symbols(self._buffer_symbols)
         self.editor.word_completer = new_completer
+
+    @on(CodeEditor.SymbolsFound)
+    def update_completer_symbols(self, message: CodeEditor.SymbolsFound) -> None:
+        """Hand the loaded buffer's symbols to the completers.
+
+        They are kept here as well, since the app swaps in whole new completers
+        every time it rebuilds them from the catalog.
+        """
+        message.stop()
+        self._buffer_symbols = message.symbols
+        for completer in (self._word_completer, self._member_completer):
+            if completer is not None:
+                completer.update_buffer_symbols(message.symbols)
 
     async def on_mount(self) -> None:
         if self.startup_cache is not None and self.startup_cache.buffers:

--- a/src/harlequin/statements.py
+++ b/src/harlequin/statements.py
@@ -5,6 +5,10 @@ the same one-line query the Query Editor has always used, so a script run with
 `-f` and the same script in the editor cannot disagree about where a statement
 ends.
 
+This module also owns the grammar itself: `captures()` runs a tree-sitter query
+over parsed SQL, so the grammar is loaded and each query compiled exactly once,
+however many things ask questions of a buffer.
+
 Tree-sitter reports positions as **byte** offsets. Everything this module
 returns is in **characters**, because that is what both callers slice with:
 `str` for `split()`, and Textual's `Document.get_text_range()` for
@@ -19,7 +23,7 @@ from bisect import bisect_right
 from dataclasses import dataclass
 
 import tree_sitter_sql
-from tree_sitter import Language, Parser, Query, QueryCursor
+from tree_sitter import Language, Node, Parser, Query, QueryCursor
 
 SEMICOLON_QUERY = '(";" @semicolon)'
 """Capture every semicolon the grammar considers a statement separator.
@@ -42,22 +46,36 @@ class Statement:
 
 
 _LANGUAGE: Language | None = None
-_QUERY: Query | None = None
+_QUERIES: dict[str, Query] = {}
 
 
-def _grammar() -> tuple[Language, Query]:
-    """Load the grammar and prepare the query once, on first use.
+def _grammar(pattern: str) -> tuple[Language, Query]:
+    """Load the grammar and compile `pattern` once, on first use.
 
-    Together they cost ~16ms, which nothing that never splits SQL should pay --
-    `hsql --help` being the case that matters. The `Query` is reused across
-    calls, as tree-sitter intends; the `Parser` is not, since it holds the tree
-    it last produced.
+    The grammar and one query cost ~16ms together, which nothing that never
+    parses SQL should pay -- `hsql --help` being the case that matters. Each
+    `Query` is reused across calls, as tree-sitter intends; the `Parser` is not,
+    since it holds the tree it last produced.
     """
-    global _LANGUAGE, _QUERY
-    if _LANGUAGE is None or _QUERY is None:
+    global _LANGUAGE
+    if _LANGUAGE is None:
         _LANGUAGE = Language(tree_sitter_sql.language())
-        _QUERY = Query(_LANGUAGE, SEMICOLON_QUERY)
-    return _LANGUAGE, _QUERY
+    query = _QUERIES.get(pattern)
+    if query is None:
+        query = _QUERIES[pattern] = Query(_LANGUAGE, pattern)
+    return _LANGUAGE, query
+
+
+def captures(text: str, pattern: str) -> dict[str, list[Node]]:
+    """Parse `text` and return the nodes each capture in `pattern` matched.
+
+    Nodes keep their tree alive, so they stay valid after this returns. They
+    arrive in the order tree-sitter's patterns matched them, which is not the
+    order they appear in the buffer; sort on a byte offset to recover that.
+    """
+    language, query = _grammar(pattern)
+    tree = Parser(language).parse(text.encode("utf-8"))
+    return QueryCursor(query).captures(tree.root_node)
 
 
 def _separator_offsets(text: str) -> list[int]:
@@ -66,19 +84,15 @@ def _separator_offsets(text: str) -> list[int]:
         # cheap, and the common case for a single statement.
         return []
 
-    language, query = _grammar()
-    encoded = text.encode("utf-8")
-    tree = Parser(language).parse(encoded)
-    captures = QueryCursor(query).captures(tree.root_node)
-    # tree-sitter captures nodes in the order its patterns match them, which is
-    # not the order they appear in the buffer.
-    byte_offsets = sorted(node.end_byte for node in captures.get("semicolon", []))
+    matched = captures(text, SEMICOLON_QUERY)
+    byte_offsets = sorted(node.end_byte for node in matched.get("semicolon", []))
 
     if text.isascii():
         return byte_offsets
 
     # decode the gaps between offsets rather than the prefix of each, so a
     # script with thousands of statements stays linear in its length.
+    encoded = text.encode("utf-8")
     offsets: list[int] = []
     byte_cursor = 0
     char_cursor = 0

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -467,7 +467,10 @@ async def test_buffer_symbols_reach_the_completers(
         assert word_completer("my_c")[0] == (("my_cte", "buf"), "my_cte")
         assert member_completer("t.my_c") == [(("t.my_col", "buf"), "t.my_col")]
 
-        # symbols belong to the buffer they were read from
+        # symbols belong to the buffer they were read from, so switching tabs
+        # away from that query drops them, and switching back brings them back.
+        first_buffer_id = app.editor_collection.active
+        assert first_buffer_id is not None
         await app.editor_collection.action_new_buffer()
         for _ in range(20):
             if not word_completer("my_c"):
@@ -475,3 +478,11 @@ async def test_buffer_symbols_reach_the_completers(
             await pilot.pause(0.1)
 
         assert not word_completer("my_c")
+
+        app.editor_collection.tabs.active = first_buffer_id
+        for _ in range(20):
+            if word_completer("my_c"):
+                break
+            await pilot.pause(0.1)
+
+        assert word_completer("my_c")[0] == (("my_cte", "buf"), "my_cte")

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -436,3 +436,42 @@ async def test_selected_queries_split_on_character_columns(
         app.editor.selection = Selection((0, 0), (0, 22))
         assert app.editor.selected_queries() == ["select '日本語';", "select 2"]
         assert app.editor.selected_queries() == [s.sql for s in split(app.editor.text)]
+
+
+@pytest.mark.asyncio
+async def test_buffer_symbols_reach_the_completers(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None or app.editor_collection.word_completer is None:
+            await pilot.pause()
+        word_completer = app.editor_collection.word_completer
+        member_completer = app.editor_collection.member_completer
+        assert member_completer is not None
+
+        assert not word_completer("my_c")
+        assert not member_completer("t.my_c")
+
+        app.editor.text = (
+            "with my_cte as (select 1 as my_col) select t.my_col from my_cte t"
+        )
+
+        # the editor re-reads the buffer on a timer
+        for _ in range(20):
+            if word_completer("my_c"):
+                break
+            await pilot.pause(0.1)
+
+        assert word_completer("my_c")[0] == (("my_cte", "buf"), "my_cte")
+        assert member_completer("t.my_c") == [(("t.my_col", "buf"), "t.my_col")]
+
+        # symbols belong to the buffer they were read from
+        await app.editor_collection.action_new_buffer()
+        for _ in range(20):
+            if not word_completer("my_c"):
+                break
+            await pilot.pause(0.1)
+
+        assert not word_completer("my_c")

--- a/tests/unit_tests/test_completers.py
+++ b/tests/unit_tests/test_completers.py
@@ -3,9 +3,14 @@ from pathlib import Path
 
 import pytest
 
-from harlequin.autocomplete.completers import WordCompleter
+from harlequin.autocomplete.completers import (
+    MemberCompleter,
+    WordCompleter,
+    completer_factory,
+)
 from harlequin.autocomplete.completion import HarlequinCompletion
-from harlequin.catalog import CatalogItem
+from harlequin.autocomplete.symbols import BufferSymbols
+from harlequin.catalog import Catalog, CatalogItem
 
 
 @pytest.fixture
@@ -66,3 +71,108 @@ def test_extend_catalog_defer_merge(parent_item: CatalogItem) -> None:
     assert not any(c.label == "bar" for c in completer.completions)
     completer.merge()
     assert any(c.label == "bar" for c in completer.completions)
+
+
+@pytest.fixture
+def catalog() -> Catalog:
+    def _table(label: str, columns: list[str]) -> CatalogItem:
+        return CatalogItem(
+            qualified_identifier=f'"{label}"',
+            query_name=f'"{label}"',
+            label=label,
+            type_label="t",
+            children=[
+                CatalogItem(
+                    qualified_identifier=f'"{label}"."{column}"',
+                    query_name=f'"{column}"',
+                    label=column,
+                    type_label="#",
+                )
+                for column in columns
+            ],
+        )
+
+    return Catalog(
+        items=[
+            _table("alpha", ["col_a", "shared"]),
+            _table("beta", ["col_b", "shared"]),
+        ]
+    )
+
+
+@pytest.fixture
+def word_completer(catalog: Catalog) -> WordCompleter:
+    word, _ = completer_factory(catalog=catalog)
+    return word
+
+
+@pytest.fixture
+def member_completer(catalog: Catalog) -> MemberCompleter:
+    _, member = completer_factory(catalog=catalog)
+    return member
+
+
+def test_buffer_symbol_is_offered(word_completer: WordCompleter) -> None:
+    assert not any(label == "my_cte" for (label, _), _ in word_completer("my_c"))
+    word_completer.update_buffer_symbols(BufferSymbols(names=("my_cte",)))
+    assert word_completer("my_c")[0] == (("my_cte", "buf"), "my_cte")
+
+
+def test_buffer_symbol_does_not_complete_to_itself(
+    word_completer: WordCompleter,
+) -> None:
+    word_completer.update_buffer_symbols(BufferSymbols(names=("my_cte", "my_cte_2")))
+    labels = {label for (label, _), _ in word_completer("my_cte")}
+    assert "my_cte" not in labels
+    assert "my_cte_2" in labels
+
+
+def test_buffer_symbol_is_not_duplicated(word_completer: WordCompleter) -> None:
+    word_completer.update_buffer_symbols(BufferSymbols(names=("alpha",)))
+    assert [label for label, _ in word_completer("alpha")] == [("alpha", "t")]
+
+
+def test_catalog_item_in_buffer_ranks_first(word_completer: WordCompleter) -> None:
+    assert word_completer("al")[0][0] != ("alpha", "t")
+    word_completer.update_buffer_symbols(BufferSymbols(names=("alpha",)))
+    assert word_completer("al")[0][0] == ("alpha", "t")
+
+
+def test_completion_whose_context_is_in_buffer_ranks_higher(
+    word_completer: WordCompleter,
+) -> None:
+    def _rank_of(label: str) -> int:
+        return [x[0][0] for x in word_completer("col")].index(label)
+
+    assert _rank_of("col_a") < _rank_of("col_b")
+    word_completer.update_buffer_symbols(BufferSymbols(names=("beta",)))
+    assert _rank_of("col_b") < _rank_of("col_a")
+
+
+def test_member_completions_come_from_the_buffer(
+    member_completer: MemberCompleter,
+) -> None:
+    assert member_completer("t.") == []
+    member_completer.update_buffer_symbols(
+        BufferSymbols(names=("alpha", "t", "extra_col"), members=(("t", "extra_col"),))
+    )
+    assert member_completer("t.") == [(("t.extra_col", "buf"), "t.extra_col")]
+
+
+def test_member_completions_from_the_buffer_are_not_duplicated(
+    member_completer: MemberCompleter,
+) -> None:
+    member_completer.update_buffer_symbols(
+        BufferSymbols(names=("alpha", "col_a"), members=(("alpha", "col_a"),))
+    )
+    assert [label for label, _ in member_completer("alpha.col_a")] == [
+        ("alpha.col_a", "#")
+    ]
+
+
+def test_buffer_symbols_survive_a_catalog_update(
+    word_completer: WordCompleter, catalog: Catalog
+) -> None:
+    word_completer.update_buffer_symbols(BufferSymbols(names=("my_cte",)))
+    word_completer.update_catalog(catalog)
+    assert word_completer("my_c")[0] == (("my_cte", "buf"), "my_cte")

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -63,6 +63,23 @@ def test_headless_imports_do_not_load_the_tui(
     assert not leaked, f"{statement!r} imported {leaked}"
 
 
+def test_importing_the_completers_does_not_parse_sql(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """Every adapter imports the completers; only the Query Editor parses SQL.
+
+    `find_symbols()` defers `harlequin.statements`, so loading the grammar stays
+    off the path of everything that never reads a buffer.
+    """
+    proc = run_python(
+        "import harlequin.autocomplete\n"
+        "import sys\n"
+        "print(','.join(m for m in ('tree_sitter', 'tree_sitter_sql') "
+        "if m in sys.modules))\n"
+    )
+    assert not proc.stdout.strip(), f"importing the completers loaded {proc.stdout}"
+
+
 @pytest.mark.parametrize("argv", [["--help"], ["--version"]])
 def test_building_the_hsql_command_imports_no_adapter(
     argv: list[str], run_python: Callable[[str], subprocess.CompletedProcess[str]]

--- a/tests/unit_tests/test_symbols.py
+++ b/tests/unit_tests/test_symbols.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from harlequin.autocomplete import BufferSymbols, find_symbols
+
+# (name, sql, expected names, expected members). The name is the pytest id.
+CORPUS: list[tuple[str, str, list[str], list[tuple[str, str]]]] = [
+    ("empty", "", [], []),
+    ("whitespace only", "  \n\t ", [], []),
+    ("keywords only", "select 1", [], []),
+    ("one table", "select * from my_table", ["my_table"], []),
+    (
+        "columns and aliases",
+        "select foo as bar, baz from t",
+        ["foo", "bar", "baz", "t"],
+        [],
+    ),
+    (
+        "qualified table",
+        "select * from my_db.my_schema.my_table",
+        ["my_db", "my_schema", "my_table"],
+        [("my_db", "my_schema"), ("my_schema", "my_table")],
+    ),
+    (
+        "aliased columns",
+        "select t.a, t.b from my_table t",
+        ["t", "a", "b", "my_table"],
+        [("t", "a"), ("t", "b")],
+    ),
+    (
+        "cte",
+        "with my_cte as (select 1 as n) select my_cte.n from my_cte",
+        ["my_cte", "n"],
+        [("my_cte", "n")],
+    ),
+    (
+        "quoted identifiers",
+        'select t."Mixed Case" from "My Table" t',
+        ["t", "Mixed Case", "My Table"],
+        [("t", "Mixed Case")],
+    ),
+    # the user is mid-edit far more often than not, so the parse has to keep
+    # going past whatever they have not finished typing.
+    ("unterminated member", "select * from my_table t where t.", ["my_table", "t"], []),
+    (
+        "half-typed clause",
+        "select a, from my_table",
+        ["a", "from", "my_table"],
+        [],
+    ),
+    (
+        "several statements",
+        "select a from one; select b from two",
+        ["a", "one", "b", "two"],
+        [],
+    ),
+    # a symbol is worth offering once, under the spelling it first appeared in.
+    (
+        "repeated, in mixed case",
+        "select FOO from t union all select foo from t",
+        ["FOO", "t"],
+        [],
+    ),
+    # semicolons and words inside these belong to one node, so nothing in them
+    # is an identifier.
+    ("string literal", "select 'not_a_symbol' from t", ["t"], []),
+    ("comment", "select a from t -- not_a_symbol\n", ["a", "t"], []),
+]
+
+
+@pytest.mark.parametrize(
+    "sql,expected_names,expected_members",
+    [pytest.param(*case[1:], id=case[0]) for case in CORPUS],
+)
+def test_find_symbols(
+    sql: str, expected_names: list[str], expected_members: list[tuple[str, str]]
+) -> None:
+    assert find_symbols(sql) == BufferSymbols(
+        names=tuple(expected_names), members=tuple(expected_members)
+    )


### PR DESCRIPTION
Closes #872

**What** are the key elements of this solution?

A buffer names things the catalog does not — a CTE, an alias, a column of a table that does not exist yet — and the things it does name are the ones a user is most likely to want next.

- **`autocomplete/symbols.py`** — `find_symbols()` runs one tree-sitter query over the buffer and returns a `BufferSymbols`: every `identifier` in first-appearance order, plus every `(context, name)` pair from a dotted reference. It works on mid-edit SQL, so `select * from my_table t where t.` still yields `my_table` and `t`.
- **`CodeEditor`** re-reads the loaded buffer on a 0.3s throttle after `TextArea.Changed`, parses on a worker thread, and posts `SymbolsFound`. `EditorCollection` keeps the latest symbols and pushes them into both completers — including into whatever new completers the app swaps in when it rebuilds them from the catalog, which would otherwise drop them.
- **The completers** use the symbols two ways, which is the issue's three points:
  1. A symbol nothing else offers becomes a completion of its own (`buf` type label, priority 400), so a CTE or an alias completes. For the member completer, the `(context, name)` pairs are how an alias gets members at all — typing `t.` offers the columns the query uses through `t`.
  2. & 3. Every match is ranked by its relationship to the buffer: label in the buffer (0) → context in the buffer (1) → neither (2).
- **`statements.captures()`** now owns the grammar for everything that asks a question of parsed SQL, so it is loaded and each query compiled once rather than per-caller.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**Ranking is a second sort key applied to matches, not a change to `priority`.** The obvious alternative — bake a boost into `priority` and re-`merge()` — means an O(n log n) sort of the whole catalog every time the buffer changes (~13ms against a 20k-completion catalog, on the main thread, every 0.3s while typing). Instead `_rank()` stable-sorts each of the exact/prefix/fuzzy groups by a 0/1/2 rank, which preserves the `(priority, label)` order inside each rank and only touches the matches. A completion object is shared between both completers, so mutating its priority was never on the table anyway.

**Buffer completions are kept in their own list, not merged in,** for the same reason. `update_buffer_symbols()` is therefore O(number of symbols), not O(number of completions) — it dedupes against an index `merge()` builds on the worker thread. Measured at **5µs** against a 20k-completion catalog, which is what makes it fine on the main thread. Both attributes it touches are rebound rather than mutated, so a completer call running on textual-textarea's worker at the same instant can at worst see a one-keystroke-stale ranking, the same way `merge()` already swaps `self.completions` underneath one.

**A buffer symbol identical to what the user has typed is dropped** — it would complete to itself, which is the one case where offering a buffer symbol is worse than not.

**`captures()` is a refactor rather than a second grammar load.** Symbol extraction is an autocomplete concern, but the `Language` costs ~16ms and nothing should pay for it twice. `find_symbols()` defers its `harlequin.statements` import, because every adapter imports `harlequin.autocomplete` and `scripts/cold_start.py` showed +24 modules / +8ms on the adapter path without the deferral.

**Two things I decided against.** Caching symbols per-buffer in `EditorState`: a tab switch already re-scans (Textual's `load_text` posts `Changed`), so it would only close a sub-300ms window in which the completers hold the previous buffer's symbols — in exchange for a second source of truth for derived state that is itself only fresh to within one scan interval. And a size cap on the scan: `find_symbols` takes ~270ms on a pathological 192KB / 2000-statement buffer, but it is off the UI thread and throttled, and a cap would silently stop completing in exactly the large scripts where it helps most.

**One incidental change:** `match_val` and `match_context` fold with `casefold()` rather than `lower()`, along with every value compared against them. ASCII casefolds identically, so nothing about the completions a user sees today changes.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: wherever autocompletion is described, it now draws on the query editor's own text as well as the catalog — CTEs, aliases and not-yet-created columns complete, `alias.` offers that alias's columns, and anything the query already mentions sorts to the top.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`tests/unit_tests/test_symbols.py` is a 15-case corpus over `find_symbols`, including the mid-edit and string/comment cases. `tests/unit_tests/test_completers.py` gains 8 tests for the two uses and their dedupe rules. `tests/functional_tests/test_query_editor.py::test_buffer_symbols_reach_the_completers` drives the real app and asserts the symbols reach both completers, that switching tabs away from a query drops its symbols, and that switching back restores them. `tests/unit_tests/test_import_hygiene.py` gains a run-time guard that importing the completers loads no tree-sitter.

Full check green on this branch: 1132 passed / 6 skipped / 1 xfailed, 148 snapshots unchanged, py12 subset passing, mypy clean, 4/4 import-linter contracts kept.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvhDwzb9f9JRdiK8M3cGev

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvhDwzb9f9JRdiK8M3cGev)_