### PR TITLE
Add a design for SSH tunnels (#545)

### DIFF
--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -168,15 +168,39 @@ the only thing the contract says.
 
 ### 4.2 The same cluster, with nothing in `~/.ssh/config`
 
+The §4.1 `Host` block, translated flag for flag — every line of it, so that what the five
+options can and cannot say is visible:
+
 ```bash
-hsql -a postgres --host localhost --port 15439 --dbname prod \
-     --ssh-host tco@web-1 \
-     --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
-     -c "select 1"
+harlequin -a postgres \
+  --host localhost --port 15439 --dbname prod --user tco \
+  --ssh-host tco@web-1 \
+  --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
+  --ssh-option ServerAliveInterval=60 \
+  --ssh-option ServerAliveCountMax=3
 ```
 
-The docs' advice will be to write the `Host` block instead and go back to 4.1 — but this
-works, and it is what an agent or a CI job with no dotfiles has to do.
+```toml
+[profiles.redshift-no-dotfiles]
+adapter = "postgres"
+host = "localhost"
+port = 15439
+dbname = "prod"
+user = "tco"
+ssh_host = "tco@web-1"
+ssh_forward = ["15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439"]
+ssh_option = ["ServerAliveInterval=60", "ServerAliveCountMax=3"]
+```
+
+Line by line: `HostName web-1` and `User tco` are `--ssh-host tco@web-1`; `LocalForward`
+is `--ssh-forward`, the same text with the space turned into a colon; and the two keepalive
+settings are the **only** lines that need `--ssh-option`. Note the two unrelated users, which
+happen to share a name here: `--user` is Redshift's, `tco@` is the SSH host's.
+
+Compare §4.1, which is the same connection in one key. This is the shape for a CI job or an
+agent with no dotfiles, and the docs' advice is to write the `Host` block instead.
+
+**What this example is really for** is §14.1: `--ssh-option` exists for those last two lines.
 
 ### 4.3 Postgres running on the bastion itself
 
@@ -563,7 +587,17 @@ client where one exists.
 
 ## 14. Open questions for review
 
-1. **Does `--ssh-option` earn its place at all?** It is the only option that needs a
-   deny-list, and everything it can express a `Host` block can express better. Dropping it
-   would take v1 to four flags and delete §6.1 outright. Keeping it is the answer for a CI job
-   or an agent with no dotfiles, which is the same audience `--ssh-forward` exists for.
+1. **Does `--ssh-option` earn its place?** §4.2 is the evidence: translating a real `Host`
+   block, four of its five lines land on `--ssh-host` and `--ssh-forward`, and only the
+   keepalives need `--ssh-option`. Three ways to go, and the recommendation is the second:
+
+   | | |
+   |---|---|
+   | **Keep it, with the §6.1 deny-list** | The full escape hatch. Costs a deny-list against a program that keeps adding keywords — `KnownHostsCommand` arrived in OpenSSH 8.5, so the list is a standing obligation, and a keyword we miss is a hole. |
+   | **Drop it — four flags, no §6.1** ← | A setup these four cannot express goes in a `Host` block, which `--ssh-host` names. Closed by construction rather than by a list we maintain. The CI job this would strand can write four lines of ssh config beside the key it already had to write. |
+   | **Replace it with `--ssh-keepalive SECONDS`** | `-o ServerAliveInterval=N -o ServerAliveCountMax=3`, which is exactly what §4.2 needed and nothing else. One narrow option, no arbitrary keywords, no deny-list. A good follow-up if dropping `--ssh-option` turns out to sting. |
+
+   Related and rejected either way: **`--ssh-config PATH`** (point `ssh -F` at another config
+   file). It looks safer than `--ssh-option` — a path, not a keyword — but the file it names
+   can hold a `ProxyCommand`, and a repo-local Harlequin config naming a repo-local ssh config
+   is the §6.1 threat with an extra step and no deny-list possible.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -81,16 +81,23 @@ backwards. So `--ssh-forward` is optional, and §4.1 is the case where it is not
    --ssh-host redshift_prod    ───────►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
                                          (the -L comes from ~/.ssh/config)
 
-   -a postgres                           adapter dials 127.0.0.1:5439
-   "postgresql://me@localhost:5439/prod" which is the far side's redshift.internal:5439
+   -a postgres                            adapter dials 127.0.0.1:15439
+   "postgresql://tco@localhost:15439/prod" the local end of `LocalForward 15439 …:5439`
 ```
 
-Two rules, and they are the whole contract:
+One rule, and it is the whole contract:
 
-1. **Connection details are read from the SSH host's side.** `localhost` means the SSH
-   host's localhost; `redshift.internal` means whatever the SSH host resolves that to.
-2. **A forward binds the same port locally by default**, so the address the user typed is the
-   address that now works here.
+**The connection details name the local end of the forward.** Harlequin runs the tunnel and
+touches nothing else.
+
+That is it. In the config behind that example (§4.1) the forward is `LocalForward 15439 <redshift>:5439`, so the
+local end is `localhost:15439` and that is what the profile says — the ports differ, and
+nothing in Harlequin needs to know or care. The far side's address appears once, in the ssh
+config, where it already was.
+
+"Give the address as the SSH host sees it" is a useful mnemonic for the `--ssh-forward 5432`
+shorthand below, where the local and remote ports match. It is not the rule. The rule is the
+local end.
 
 Nothing is rewritten. `conn_str` and every adapter option reach the adapter exactly as the
 user wrote them, and the adapter is never told a tunnel exists.
@@ -102,11 +109,16 @@ The forward can come from either place, and Harlequin does not care which:
 | `~/.ssh/config` | a `LocalForward` line in the `Host` block. Harlequin passes no `-L`. |
 | Harlequin | `--ssh-forward`, repeatable, in one of three forms below |
 
-| `--ssh-forward` | becomes |
-|---|---|
-| `5432` | `-L 127.0.0.1:5432:localhost:5432` — the database runs on the SSH host |
-| `db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` — the SSH host is a jump host |
-| `15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` — something local already has 5432 |
+| `--ssh-forward` | becomes | |
+|---|---|---|
+| `15439:db.internal:5439` | `-L 127.0.0.1:15439:db.internal:5439` | the general form, and the one to recommend |
+| `db.internal:5439` | `-L 127.0.0.1:5439:db.internal:5439` | shorthand: same port on both ends |
+| `5432` | `-L 127.0.0.1:5432:localhost:5432` | shorthand: the database runs on the SSH host |
+
+**The docs should recommend a distinct local port**, as the config above does with `15439`.
+It sidesteps the collision case entirely, and it is most of the mitigation for the hazard
+below: nothing else on a developer's laptop is listening on 15439, so a profile run without
+its tunnel fails to connect instead of quietly reaching a local database on 5432.
 
 ### What this model gives up, and what it buys
 
@@ -129,8 +141,9 @@ What it buys, beyond not guessing:
 ### The hazard this model does have
 
 A profile that says `host = "localhost"` is only correct with the tunnel up. Run it without
-`ssh_host` and it connects to whatever is on **your** 5439 — which on a developer's laptop may
-well be a database, just the wrong one.
+`ssh_host` and it connects to whatever is on **your** machine at that port — which, if the
+forward uses the database's own port number, may well be a database, just the wrong one. A
+distinct local port makes this a connection refused instead.
 
 The `ssh_*` keys live in the same profile as the connection details, so they travel together
 and the failure needs someone to have deliberately overridden one; the start-up notice (§6)
@@ -141,38 +154,43 @@ refuse to connect without one. Not proposed for v1.
 
 ### 4.1 A Redshift cluster behind a bastion, with the forward already in `~/.ssh/config`
 
+The motivating case — a real config, from this repo's author:
+
 ```
 Host redshift_prod
-    HostName bastion.example.com
-    User ted
-    IdentityFile ~/.ssh/id_ed25519
-    LocalForward 5439 redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439
+  HostName web-1
+  User tco
+  LocalForward 15439 data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
 ```
 
-Today: `ssh -fN redshift_prod`, then `harlequin -a postgres --host localhost --port 5439 …`,
+Today: `ssh -fN redshift_prod`, then `harlequin -a postgres --host localhost --port 15439 …`,
 then remember to kill the ssh later.
 
 ```toml
 [profiles.redshift]
 adapter = "postgres"
 host = "localhost"
-port = 5439
+port = 15439
 dbname = "prod"
-user = "ted"
 ssh_host = "redshift_prod"
 ```
 
-`harlequin -P redshift`, and `hsql -P redshift -c "select 1"`. **No `--ssh-forward`, no
-`--ssh-user`, no `--ssh-identity`** — the ssh config already says all of it, and Harlequin
-runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`. The connection details are unchanged
-from what works today, because `localhost:5439` was already the far side's address.
+`harlequin -P redshift`, and `hsql -P redshift -c "select 1"`. **One key.** No
+`--ssh-forward`, no `--ssh-user`, no `--ssh-identity`, no keepalive settings — the `Host`
+block says all of it, and Harlequin runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`.
+The connection details are exactly the ones that work today.
+
+Note the ports: local `15439`, remote `5439`. The profile names the **local** end, which is
+the only thing the contract says.
 
 ### 4.2 The same cluster, with nothing in `~/.ssh/config`
 
 ```bash
-hsql -a postgres --host localhost --port 5439 --dbname prod \
-     --ssh-host ted@bastion.example.com \
-     --ssh-forward 5439:redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439 \
+hsql -a postgres --host localhost --port 15439 --dbname prod \
+     --ssh-host tco@web-1 \
+     --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
      -c "select 1"
 ```
 
@@ -233,8 +251,8 @@ Also `kubectl port-forward svc/pg 5432:5432`, `aws ssm start-session … localPo
 
 ```
 $ hsql -P redshift -c "select count(*) from events"
-Enter passphrase for key '/home/ted/.ssh/id_ed25519':
-tunnel: 127.0.0.1:5439 -> redshift-prod…:5439 via ssh redshift_prod
+Enter passphrase for key '/home/tco/.ssh/id_ed25519':
+tunnel: 127.0.0.1:15439 -> data-analytics…:5439 via ssh redshift_prod
 ```
 
 The prompt is `ssh`'s, on the real terminal, because the child is started before Textual (in
@@ -280,8 +298,16 @@ One implementation, `SubprocessTunnel`. The SSH options build an argv; `--tunnel
   check against, and the fallback has to be good enough on its own.
 - **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
   `tui.run()` and the `hsql` run, plus an `atexit` backstop.
-- `-o ServerAliveInterval=30`. No reconnect in v1: a dead tunnel surfaces as the adapter's own
-  connection error, already an error modal in the IDE and exit 3 in `hsql`.
+- **The only `-o` Harlequin imposes is `ExitOnForwardFailure=yes`**, and only because a
+  forward that silently did not happen is the one failure the user cannot diagnose. Notably
+  *not* imposed: `ServerAliveInterval`. A command-line `-o` beats the user's config file, and
+  keepalives are exactly the sort of thing a working `Host` block already sets — overriding
+  them would be Harlequin quietly retuning a connection someone else configured. The docs say
+  to set them in the `Host` block; `--ssh-option` is there for anyone who wants to anyway.
+- **No reconnect in v1, but the IDE says when the tunnel dies.** A thread waiting on the
+  child posts a notification when it exits, so a session whose forward dropped shows
+  `tunnel closed: <ssh's last line>` rather than an unexplained wall of query errors. `hsql`
+  is short-lived enough that the adapter's own connection error is the whole story.
 
 ## 6. The CLI and config surface
 
@@ -321,7 +347,7 @@ know of none that claims one.
 IDE as a notification and on the debug screen:
 
 ```
-tunnel: 127.0.0.1:5439 -> redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439 via ssh redshift_prod
+tunnel: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 via ssh redshift_prod
 ```
 
 One line, and it is what tells a user which database they are actually looking at.
@@ -464,7 +490,8 @@ client where one exists.
 
 1. **Should an already-listening local port mean "the tunnel is already up"?** Today's answer
    is a hard error from `ExitOnForwardFailure`, which means a user who still runs
-   `ssh -fN redshift_prod` by hand gets a bind failure from every Harlequin start. Skipping the
+   `ssh -fN redshift_prod` by hand gets `bind: Address already in use` on 15439 from every
+   Harlequin start. Skipping the
    child when every known local port already accepts connections would fix that, at the cost
    of connecting to *something* on that port without knowing it is the right tunnel. Leaning
    toward skip-with-a-notice.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -161,7 +161,8 @@ class SshTunnel:
 
     def stop(self) -> None: ...
     def __enter__(self) -> SshTunnel: ...
-    def __exit__(self, *exc: Any) -> None: self.stop()
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
 ```
 
 ```

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -289,15 +289,71 @@ One implementation, `SubprocessTunnel`. The SSH options build an argv; `--tunnel
 - **Readiness** is a connect-poll against each known local port until `--tunnel-timeout`
   (default 10s), which also notices the child exiting early. On failure the error quotes the
   child's stderr verbatim, because `ssh`'s diagnostics are better than any we would write.
-- **Ports we do not know**: in the 4.1 shape the forward is in `ssh_config`, so Harlequin has
-  no port to poll. Two ways out, and the first needs verifying: `ssh -G <host>` prints the
-  resolved config and *may* include `localforward` lines, in which case the poll is exact and
-  free; otherwise Harlequin skips the poll, waits for the child to survive a short grace
-  period, and lets the adapter's own connection be the test. **Confirm `-G` behavior on the
-  OpenSSH versions we care about before relying on it** — this container has no `ssh` to
-  check against, and the fallback has to be good enough on its own.
+- **Which ports to poll comes from `ssh -G`**, §5.1.
 - **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
   `tui.run()` and the `hsql` run, plus an `atexit` backstop.
+
+### 5.1 Asking `ssh` what it is about to forward
+
+In the 4.1 shape the forward lives in `ssh_config`, so Harlequin does not know the port it
+should be polling. `ssh -G` answers that: it applies every `Host` and `Match` block, prints
+the resolved configuration, and connects to nothing. Confirmed against the motivating config:
+
+```
+$ ssh -G redshift_prod | grep -i forward
+localforward 15439 [data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com]:5439
+```
+
+**Probe with the argv we are about to run**, not with the destination alone — `ssh -G` echoes
+back command-line `-L` and `-o` flags along with the config's, so
+
+```python
+forwards = _parse_forwards(run([*argv_without_N, "-G"]))
+```
+
+gives one list whether the forward came from `--ssh-forward`, from a `Host` block, or from
+both. There is no "config forwards" path and "flag forwards" path to keep in agreement,
+because `ssh` merges them before we look.
+
+Parsing is two whitespace-separated fields after the keyword, each `port`, `[host]:port`, or a
+unix socket path; brackets are how it writes a host, and they make IPv6 unambiguous. A
+`localforward` whose listen side is a socket path counts as a forward but is not polled.
+`dynamicforward` (SOCKS) and `remoteforward` are not forwards this feature can use — see the
+error below.
+
+Three things now have an exact answer instead of a guess:
+
+- **The readiness poll** watches the real local ports.
+- **`--ssh-host` that forwards nothing** is a usage error, and it can say what it found:
+  `redshift_prod resolves no LocalForward; add one to your Host block or pass --ssh-forward`
+  — with a distinct message when the config has a `DynamicForward` instead, since that is a
+  working SOCKS proxy the adapter cannot use.
+- **The notice and the cache key** can name the far side even when Harlequin never saw it.
+
+`ssh -G` costs one subprocess (~10-30ms, no network) on invocations that tunnel, and nothing
+on the ones that do not. If it exits non-zero or prints something this cannot parse,
+Harlequin degrades rather than fails: no poll, no forwards-nothing error, a short grace
+period, and the adapter's own connection is the test.
+
+### 5.2 A local port that is already bound
+
+The default is to **fail**: `ExitOnForwardFailure=yes` means `ssh` exits with
+`bind: Address already in use`, and Harlequin reports it. A port that is already answering is
+not evidence that the right tunnel is behind it, and connecting to the wrong database because
+something else happened to be on 15439 is worse than an error at start-up.
+
+`--tunnel-reuse` (`tunnel_reuse = true`) opts into the other behavior, for the person who
+keeps a `ssh -fN redshift_prod` running all day and does not want Harlequin fighting it: if
+**every** local port `ssh -G` reported is already accepting connections, skip the child
+entirely and say so.
+
+```
+tunnel: 127.0.0.1:15439 already listening; reusing (--tunnel-reuse)
+```
+
+If only some of them answer, that is a half-open state nobody meant, and it is an error
+naming the ports either way.
+
 - **The only `-o` Harlequin imposes is `ExitOnForwardFailure=yes`**, and only because a
   forward that silently did not happen is the one failure the user cannot diagnose. Notably
   *not* imposed: `ServerAliveInterval`. A command-line `-o` beats the user's config file, and
@@ -322,6 +378,7 @@ most: a cron job or an agent cannot ask a human to run `ssh -fN` in another term
 | `--tunnel-command TEXT` | §4.7; mutually exclusive with `--ssh-host` |
 | `--tunnel-port INT` | repeatable; ports the readiness poll waits for |
 | `--tunnel-timeout FLOAT` | seconds to wait (default 10) |
+| `--tunnel-reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
 
 Three SSH flags, not nine. An earlier draft had `--ssh-user`, `--ssh-port`, `--ssh-identity`
 and more; every one of them is `ssh_config` or `-o` spelled twice, and the docs' advice is to
@@ -330,9 +387,8 @@ certificate and `Match` rules already live.
 
 `--ssh-host` with neither `--ssh-forward` nor a `LocalForward` in its resolved config is a
 usage error naming both places — a tunnel that forwards nothing is always a mistake, and it is
-better caught before an SSH handshake than after one. (This is the second thing that depends
-on `ssh -G`; without it, this check degrades to "no `--ssh-forward` and no way to know", and
-should then not fire at all rather than fire wrongly.)
+better caught before an SSH handshake than after one. `ssh -G` is what makes the check real
+(§5.1).
 
 No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
 for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
@@ -448,7 +504,14 @@ child is dead once the command exits. Runs on all three OSes and needs no secret
 | `--ssh-forward 15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` |
 | `--ssh-forward` repeated | one child, two `-L` |
 | `--ssh-host` alone, `-G` reports a `localforward` | argv has no `-L`, poll watches that port |
+| `-G` output `localforward 15439 [host]:5439` | parsed as local 15439, remote host:5439 |
+| `-G` output with a bind address, IPv6, a socket path | parsed; the socket path is not polled |
+| `-G` reports only `dynamicforward` | usage error, distinct message |
+| `-G` exits non-zero or prints garbage | no poll, no forwards-nothing error, still starts |
 | `--ssh-host` alone, no forward anywhere | usage error naming both places |
+| port bound, no `--tunnel-reuse` | ssh's `bind: Address already in use`, exit 3 |
+| port bound, `--tunnel-reuse` | no child started, notice printed, adapter connects |
+| two ports, one bound, `--tunnel-reuse` | error naming both |
 | `--ssh-host` and `--tunnel-command` | usage error, exit 2 |
 | a garbage forward spec | usage error naming the three forms |
 | `tunnel_command` from a cwd-discovered config | config error naming the file (§6.1) |
@@ -486,23 +549,22 @@ client where one exists.
 | **paramiko directly, in v1** | A `cryptography` dependency on every install, and it reimplements the part of `~/.ssh/config` users already have working. Kept as the v2 backend, §9. |
 | **Tell users to run `ssh -fN` themselves** | It works, and it is what people do today — including the author of this repo. It also means a second terminal, an orphaned tunnel to remember to kill, and a profile that only connects if a human ran something first, which is exactly what `hsql` in a cron job or an agent loop cannot do. |
 
-## 13. Open questions for review
+## 13. Settled in review
 
-1. **Should an already-listening local port mean "the tunnel is already up"?** Today's answer
-   is a hard error from `ExitOnForwardFailure`, which means a user who still runs
-   `ssh -fN redshift_prod` by hand gets `bind: Address already in use` on 15439 from every
-   Harlequin start. Skipping the
-   child when every known local port already accepts connections would fix that, at the cost
-   of connecting to *something* on that port without knowing it is the right tunnel. Leaning
-   toward skip-with-a-notice.
-2. **How much do we lean on `ssh -G`?** It is what makes the 4.1 shape fully checkable — the
-   readiness poll and the "you forwarded nothing" error both want it. It needs verifying
-   against real OpenSSH versions (including Windows) before either depends on it.
-3. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
+- **`ssh -G` reports `localforward`**, verified against the config in §4.1:
+  `localforward 15439 [data-analytics.…:5439`. The readiness poll, the forwards-nothing
+  error and the notice all lean on it, with a documented degradation for output it cannot
+  parse (§5.1).
+- **A bound local port fails.** `--tunnel-reuse` is the opt-in for reusing a tunnel someone
+  else started (§5.2).
+
+## 14. Open questions for review
+
+1. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
    `0.0.0.0` would expose the far side's database to the user's network, which seems like a
    thing to make people ask for.
-4. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait for
-   someone to be bitten?
-5. **Naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one splits
-   `--tunnel-timeout` away from its siblings. Alternative: `--ssh-*` everywhere plus
-   `--tunnel-command`, with `--ssh-timeout` covering both.
+2. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait
+   for someone to be bitten?
+3. **Naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one splits
+   `--tunnel-timeout` and `--tunnel-reuse` away from their siblings. Alternative: `--ssh-*`
+   everywhere plus `--tunnel-command`, with `--ssh-timeout` and `--ssh-reuse` covering both.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -13,8 +13,9 @@ out-of-tree ones that are never changed.** Nothing here is implemented yet.
   `ssh` verbatim. Anything they cannot say goes in a `Host` block, which `--ssh-host` names.
 - **No new dependencies** — the blocker on the issue since 2025 — and the user's whole
   `~/.ssh/config` comes for free: `LocalForward`, `ProxyJump`, agent, certificates, `Match`.
-- **The tunnel starts before Textual**, so a passphrase or 2FA prompt reaches a human. It is a
-  child process, not `ssh -f`, so it dies with the session instead of outliving it.
+- **The tunnel starts before Textual**, so a passphrase or 2FA prompt reaches a human — or
+  `--ssh-no-prompt` refuses to prompt at all, for scripts and agents. It is a child process,
+  not `ssh -f`, so it dies with the session instead of outliving it.
 
 ## 1. Ten seconds of SSH
 
@@ -25,6 +26,7 @@ out-of-tree ones that are never changed.** Nothing here is implemented yet.
 | `-N` | run no remote command; I am here for the forwards |
 | `-f` | fork to the background once the forwards are up |
 | `-o ExitOnForwardFailure=yes` | exit if a forward cannot be set up, rather than connecting anyway |
+| `-o BatchMode=yes` | never prompt for a passphrase, password or host key; fail instead |
 | `ssh -G host` | print the resolved config — `Host`/`Match` blocks plus this command line's flags — and connect to nothing |
 
 `ssh -fN redshift_prod` and `ssh -L …` are not alternatives. `-f` and `-N` say *how to run*;
@@ -91,7 +93,8 @@ end, which is all the contract says.
 ```bash
 harlequin -a postgres --host localhost --port 15439 --dbname prod --user tco \
   --ssh-host tco@web-1 \
-  --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439
+  --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
+  --ssh-no-prompt
 ```
 
 `HostName` + `User` → `--ssh-host tco@web-1`. `LocalForward` → `--ssh-forward`, the same text
@@ -119,6 +122,7 @@ cannot ask a human to run `ssh -fN` first.
 |---|---|---|
 | `--ssh-host TEXT` | `ssh_host` | the destination, verbatim to `ssh`: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
 | `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, verbatim. Omit when `ssh_config` has it |
+| `--ssh-no-prompt` | `ssh_no_prompt` | `-o BatchMode=yes`: fail rather than ask for a passphrase, password or host key (§5.2) |
 | `--ssh-allow-reuse` | `ssh_allow_reuse` | on a bind collision, warn and connect anyway instead of failing (§5.3) |
 | `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
@@ -172,7 +176,7 @@ first_pass -> click parses -> profile merge -> SshTunnel.start()   <-- prompts h
 - **Foreground, not `-f`.** The child keeps the terminal, so prompts work, and we keep the
   handle, so it can be killed. Teardown is `terminate()` then `kill()` from a
   `contextlib.ExitStack` around `tui.run()` and the `hsql` run, plus an `atexit` backstop.
-- **`ExitOnForwardFailure=yes` is the only `-o` Harlequin imposes**, because a forward that
+- **`ExitOnForwardFailure=yes` is the only `-o` Harlequin imposes on its own**, because a forward that
   silently did not happen is the one failure a user cannot diagnose. Notably not imposed:
   `ServerAliveInterval`. A command-line `-o` beats the config file, and §3.1 already sets
   keepalives — overriding them would be Harlequin retuning someone else's connection.
@@ -196,11 +200,21 @@ socket path (which counts as a forward but is not polled). It costs one subproce
 no network. If `-G` fails or prints something unparseable, Harlequin degrades: no poll, no
 forwards-nothing error, a short grace period, and the adapter's connection is the test.
 
-### 5.2 Readiness
+### 5.2 Readiness, and prompts
 
 Connect-poll each local port `-G` reported until `--ssh-timeout` (default 10s), noticing the
 child exiting early. On failure, the error quotes ssh's stderr verbatim — its diagnostics are
 better than any we would write.
+
+**A prompt nobody answers is what the timeout catches**, and catching it late is not good
+enough for a script: `ssh` asks for a passphrase, a password, or confirmation of an unknown
+host key, and an unattended caller waits out the whole timeout and then reports something
+vague. `--ssh-no-prompt` passes `-o BatchMode=yes`, so `ssh` fails immediately and says which
+credential it wanted. An agent, a cron job and CI should all set it.
+
+Without the flag the timeout is still the backstop, so nothing hangs forever — and when it
+fires with the child still running, the error names the flag, because waiting on input is the
+likeliest reason a live `ssh` never opened its forwards.
 
 ### 5.3 A local port that is already bound
 
@@ -253,8 +267,9 @@ No SSH server, no `online` marker.
 - **Unit**: `--ssh-forward` reaches argv unchanged and repeats in order; `--ssh-host` is
   unparsed; `-G` lines with a bind address, IPv6 and a socket path parse; `-G` returning only
   `dynamicforward` is a usage error; `-G` garbage degrades; no forward anywhere is a usage
-  error; the argv carries `ExitOnForwardFailure` and no other `-o`; `-o` still means
-  `--output`; profile round trip; two ssh hosts hash differently.
+  error; the argv carries `ExitOnForwardFailure` and, with `--ssh-no-prompt`, `BatchMode=yes` and
+  nothing else; `-o` still means `--output`; a timeout with the child alive names
+  `--ssh-no-prompt`; profile round trip; two ssh hosts hash differently.
 - One test runs `ssh -V` and skips if absent, proving the argv is accepted by a real client.
 
 Phasing: **(1)** `harlequin/ssh.py` — argv, `-G` probe and parser, poll, reuse,
@@ -292,6 +307,7 @@ contract, and the `Host` block as the recommended setup — plus a `CHANGELOG.md
 | `--tunnel-command` for non-SSH proxies | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, with an answer to the code-execution problem above |
 | a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary |
 | reconnect after a drop | the death notification proves not to be enough |
+| `--ssh-no-prompt` on by default in `hsql` | interactive `hsql` users turn out to be rarer than scripted ones. Default-off is the same behavior in both commands today, which is easier to explain |
 
 Each is additive: the flags are namespaced, one class has no ABC to satisfy, and no adapter is
 involved in any of it.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -16,6 +16,8 @@ out-of-tree ones that are never changed.** Nothing here is implemented yet.
 - **The tunnel starts before Textual**, so a passphrase or 2FA prompt reaches a human — or
   `--ssh-batch-mode` refuses to prompt at all, for scripts and agents. It is a child process,
   not `ssh -f`, so it dies with the session instead of outliving it.
+- **It stays up, and comes back if it drops** (§5.4): keepalives when the user's config sets
+  none, and a lazy restart-and-reconnect in the IDE on the next thing that needs the database.
 
 ## 1. Ten seconds of SSH
 
@@ -196,9 +198,15 @@ along with the config's, so one call returns one list whether the forward came f
 `--ssh-forward`, a `Host` block, or both — there are not two sources to keep in agreement.
 
 Parsing is two whitespace-separated fields after the keyword, each `port`, `[host]:port`, or a
-socket path (which counts as a forward but is not polled). It costs one subprocess, ~10–30ms,
-no network. If `-G` fails or prints something unparseable, Harlequin degrades: no poll, no
-forwards-nothing error, a short grace period, and the adapter's connection is the test.
+socket path (which counts as a forward but is not polled). The same output answers one more
+question — `serveraliveinterval`, for §5.4. It costs one subprocess, ~10–30ms, no network. If
+`-G` fails or prints something unparseable, Harlequin degrades: no poll, no forwards-nothing
+error, no imposed keepalive, a short grace period, and the adapter's connection is the test.
+
+**Why this step exists at all**: it is the only way to know which local port to wait on before
+the adapter connects, and in §3.1 — the motivating case — Harlequin never saw a port number.
+`ssh -f` would signal readiness by exiting, but the surviving process would not be our child
+and could not be killed at exit, which is the orphaned tunnel this feature removes.
 
 ### 5.2 Readiness, and prompts
 
@@ -239,11 +247,57 @@ Failing by default is the safe direction: a port that answers is not proof the r
 behind it. `--ssh-allow-reuse` is for the person who keeps `ssh -fN redshift_prod` running all
 day and does not want Harlequin fighting it.
 
+### 5.4 Keeping it open, and getting it back
+
+A tunnel that drops after lunch is the difference between a feature people trust and one they
+work around. Three layers, cheapest first.
+
+**Keep it alive.** `ssh` sends no keepalives by default, so an idle forward behind a NAT or a
+corporate firewall is reaped silently. The `-G` probe already reports the resolved
+`serveraliveinterval`: if it is `0`, Harlequin passes `-o ServerAliveInterval=30`; if the user
+set one — §3.1 sets 60 — it is left alone. No flag, no override, and the common case stops
+dropping. Not configurable: a keepalive interval is not a thing anyone should have to tune,
+and the one person who wants to has a `Host` block.
+
+**Say so immediately.** A thread waiting on the child posts `tunnel closed: <ssh's last line>`
+when it exits unexpectedly, so a dead forward is not an unexplained wall of query errors.
+
+**Recover on next use.** Restarting `ssh` is not enough on its own: the adapter's TCP
+connection ran *through* the old forward, so it died with it. Recovery is both halves,
+together, and it happens lazily — before the next thing that needs the database (a query, a
+catalog refresh), not on a background timer:
+
+1. the tunnel is marked down when the monitor sees the child exit;
+2. the next database action restarts `ssh` and re-runs the readiness poll;
+3. then re-runs `adapter.connect()`, replacing `self.connection`;
+4. then does what the user asked.
+
+Three things this has to get right:
+
+- **Restarts are always `BatchMode=yes`**, whatever the flag said at start-up. Textual owns
+  the terminal now, so a passphrase prompt has nowhere to go. If the restart needs a
+  credential we cannot supply, it fails once with that message and does not retry — the user
+  restarts Harlequin, having been told why.
+- **Say what was lost.** A reconnect is a new session: open transactions are gone, so are temp
+  tables and anything set with `SET`. The notification says so rather than letting a user
+  believe they are still inside a `BEGIN`.
+- **One attempt per action, no loop.** The user retries by running their query again. A
+  background retry storm against a bastion that is down is how an account gets locked.
+
+**`hsql` does none of this.** It is short-lived, its statements are not idempotent, and an
+unattended caller that loses its connection should fail loudly: the statement errors, and the
+run exits 3 (or continues, per `--on-error`). Only the keepalive applies to both commands.
+
+Reconnecting the adapter is useful beyond tunnels — a server restart or an idle timeout kills
+a connection the same way — but v1 triggers it only from a tunnel that went down, because
+that is the case it can detect without guessing.
+
 ## 6. What this touches
 
 **No public API change.** Nothing in `HarlequinAdapter`, `HarlequinConnection`,
 `HarlequinCursor`, `AbstractOption`, `catalog.py` or `driver.py`. One new
-`HarlequinSshError(HarlequinError)`, one new module.
+`HarlequinSshError(HarlequinError)`, one new module, and — for §5.4 only — a reconnect path in
+`app.py` that re-runs `adapter.connect()` on the existing connect worker.
 
 **No dependency**: `subprocess`, `socket`. `harlequin/ssh.py` imports no Textual and no
 adapter, joins the "adapter API is reachable without the TUI" contract, and is imported only
@@ -271,12 +325,17 @@ No SSH server, no `online` marker.
   error; the argv carries `ExitOnForwardFailure` and, with `--ssh-batch-mode`, `BatchMode=yes` and
   nothing else; `-o` still means `--output`; a timeout with the child alive names
   `--ssh-batch-mode`; profile round trip; two ssh hosts hash differently.
+- **Recovery**: `-G` reporting `serveraliveinterval 0` adds `-o ServerAliveInterval=30`, a
+  non-zero one does not; killing the child marks the tunnel down and notifies; the next action
+  restarts it in batch mode, reconnects, and warns about lost session state; a restart that
+  fails does not retry.
 - One test runs `ssh -V` and skips if absent, proving the argv is accepted by a real client.
 
 Phasing: **(1)** `harlequin/ssh.py` — argv, `-G` probe and parser, poll, reuse,
 `HarlequinSshError`; unit and lifecycle tests, no CLI. **(2)** the four options, the
-`ExitStack`, the notice, the cache key, the end-to-end test. **(3)** `--info` and debug-screen
-reporting, the death notification, regenerated schema. **(4)** docs in `harlequin-web` — the
+`ExitStack`, the notice, the cache key, the end-to-end test. **(3)** the keepalive default, the death
+notification, `--info` and debug-screen reporting, regenerated schema. **(4)** lazy
+restart-and-reconnect in the IDE (§5.4), which is the one step that touches `app.py`. **(5)** docs in `harlequin-web` — the
 contract, and the `Host` block as the recommended setup — plus a `CHANGELOG.md` entry under
 `[Unreleased]` → Features citing [#545](https://github.com/tconbeer/harlequin/issues/545).
 
@@ -307,7 +366,7 @@ contract, and the `Host` block as the recommended setup — plus a `CHANGELOG.md
 | `--ssh-keepalive SECONDS` | someone runs an all-day IDE session with no `~/.ssh/config` and gets dropped (§3.2) |
 | `--tunnel-command` for non-SSH proxies | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, with an answer to the code-execution problem above |
 | a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary |
-| reconnect after a drop | the death notification proves not to be enough |
+| reconnecting a database connection that dropped with the tunnel up | a server restart or idle timeout should recover the same way §5.4 does; v1 only detects the tunnel case |
 | `--ssh-batch-mode` on by default in `hsql` | interactive `hsql` users turn out to be rarer than scripted ones. Default-off is the same behavior in both commands today, which is easier to explain |
 
 Each is additive: the flags are namespaced, one class has no ABC to satisfy, and no adapter is

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -1,0 +1,430 @@
+# Tunnels — a design for [#545](https://github.com/tconbeer/harlequin/issues/545)
+
+A proposal for connecting Harlequin and `hsql` to a database that is only reachable through
+an SSH bastion, **with any adapter, including out-of-tree ones that are never changed**.
+
+Nothing here is implemented. This is the design to argue with before the first PR.
+
+---
+
+## Bottom line up front
+
+1. **The tunnel belongs to core, not to adapters.** Every adapter that talks to a network
+   database needs the same thing, and the ones that need it most are the ones this repo
+   does not own. An adapter-by-adapter implementation is N implementations, N spellings,
+   and N adapters that never get around to it.
+2. **A tunnel is two mechanisms, and they are separable**: something that makes a remote
+   endpoint reachable at `127.0.0.1:<port>`, and a **rewrite** that gets the adapter to
+   dial that address instead of the real one. The second is the hard part and the one that
+   has to work for an adapter core knows nothing about.
+3. **Ship the forwarder as a subprocess, not as a library.** `ssh -L`, plus a generic
+   `--tunnel-command` for everything that is not SSH (`cloud-sql-proxy`, `aws ssm`,
+   `kubectl port-forward`, `teleport`). This answers the four-year-old blocker on the issue
+   — sshtunnel is unmaintained, paramiko is a real dependency — with **zero new
+   dependencies**, and it inherits the user's entire `~/.ssh/config`: `ProxyJump`, agent,
+   certificates, hardware keys, `Match` blocks, 2FA. A paramiko backend stays possible
+   behind the same ABC and an extra (`harlequin[ssh]`); §9 says what would trigger it.
+4. **Rewriting is layered, and the bottom layer works with every adapter shipped today**:
+   an option's declared role (new, precise, opt-in for adapters), a name backstop for
+   `host`/`port` (the same move `harlequin.redact` already makes for passwords), and a DSN
+   rewrite inside `conn_str`. Whatever it does, it says so out loud.
+5. **The tunnel comes up before Textual does.** That is not an implementation detail: it is
+   the only way an SSH password, a key passphrase or a 2FA prompt can reach a human.
+
+Scope of v1: **one hop, one forwarded endpoint, for the life of one invocation.**
+
+---
+
+## 1. What the issue asks for
+
+> Need to think through whether this is an adapter feature or a harlequin feature. Maybe
+> it's a library that adapters can use. Would be nice to provide CLI options for
+> configuring an ssh tunnel, and then intercept/rewrite the host/port/etc options passed
+> through to the adapter.
+
+Two later comments matter:
+
+- The maintainer's blocker (Feb 2025): `sshtunnel` looks perfect and has not shipped in
+  four years. paramiko was offered in reply as the maintained thing underneath it.
+- A request for **Cloud SQL** (Google's connector), which is not SSH at all. It is the
+  reason the abstraction below is "a thing that makes a remote endpoint reachable
+  locally", with SSH as one instance, rather than an SSH feature with a config file.
+
+## 2. Where the code sits today
+
+Both commands build a config dict, instantiate one adapter with it, and connect:
+
+| | IDE | headless |
+|---|---|---|
+| adapter constructed | `cli.py:548`, `adapter_cls(conn_str=conn_str, **config)` | `hsql/cli.py:_connect()` |
+| connection opened | `app.py:_connect()`, on a worker thread, after `tui.run()` | `hsql/cli.py:_connect()`, inline |
+| connection closed | `app.py:action_quit()` | never explicitly; the process exits |
+| cache key | `adapter.connection_id` or `get_connection_hash(conn_str, config)` (`cli.py:553`) | n/a |
+
+Four existing facts the design leans on:
+
+- **One invocation, one adapter.** `first_pass()` already settles which one, before click
+  parses anything, and `attach_adapter_options()` puts only that adapter's options on the
+  command. So at the moment the rewrite has to happen, the adapter class is in hand and its
+  `ADAPTER_OPTIONS` can be inspected.
+- **A command's own click params are what claim a profile key.** `parse_profile_options()`
+  takes `command_options` from `{param.name for param in cmd.params}`; anything else in the
+  profile must be a declared option of the adapter. New `--ssh-*` options on both commands
+  therefore become valid profile keys and JSON-schema keys with no further plumbing.
+- **`AbstractOption` already carries semantics core acts on.** `secret=True` is the
+  precedent: core cannot enumerate what is sensitive across every adapter, so the adapter
+  declares it and one module acts on it.
+- **`harlequin.redact` already parses DSNs**, for the password inside them, with a
+  name-based backstop for the adapters that predate the declaration. The endpoint rewrite
+  needs the same two moves against the same strings.
+
+## 3. The shape
+
+```
+                    spec (CLI + profile)
+                            |
+             harlequin.tunnel.resolve()  ──► RewritePlan   (pure; no I/O)
+                            |                    │
+                 Tunnel.start()  ──► Endpoint    │  what to dial, and where it is written
+                            |                    ▼
+                            └────────► rewritten conn_str + options
+                                                 |
+                                    adapter_cls(conn_str, **options)
+```
+
+Three pieces, in a new `harlequin/tunnel.py` (plus `harlequin/dsn.py`, §5.3):
+
+```python
+@dataclass(frozen=True)
+class Endpoint:
+    host: str
+    port: int
+
+class Tunnel(ABC):
+    """Something that makes one remote endpoint reachable on localhost."""
+
+    @abstractmethod
+    def start(self, remote: Endpoint) -> Endpoint:
+        """Bring the forward up and return the local endpoint. Blocks until it
+        is accepting connections. Raises HarlequinTunnelError."""
+
+    def stop(self) -> None:
+        return None
+
+    def __enter__(self) -> Tunnel: ...
+    def __exit__(self, *exc: Any) -> None: self.stop()
+```
+
+`resolve()` is pure and is where all the interesting behavior is; the backends are small.
+
+## 4. The forwarder
+
+### 4.1 `SubprocessTunnel` — the only backend in v1
+
+```
+ssh -N -T -o ExitOnForwardFailure=yes -L 127.0.0.1:54321:db.internal:5432 bastion
+```
+
+- The local port is chosen by binding `127.0.0.1:0`, reading the port, and closing the
+  socket, then handing that number to `ssh`. There is a race; it is the race every tool
+  that does this has, and `ExitOnForwardFailure=yes` turns losing it into a clean error
+  rather than a silent no-forward. `--ssh-local-port` pins it for anyone who cares.
+- The child stays in the **foreground** (no `-f`) with the terminal attached, so
+  `Enter passphrase for key ...` and a 2FA prompt reach the human. Readiness is a
+  connect-poll against the local port with `--tunnel-timeout` (default 10s), which also
+  notices the child exiting; on failure, the child's stderr is what the error message
+  quotes, verbatim.
+- Teardown is `terminate()` then `kill()`, from a `contextlib.ExitStack` that wraps
+  `tui.run()` and the `hsql` run, plus an `atexit` backstop.
+
+The user's `~/.ssh/config` is read by `ssh` itself. `--ssh bastion` gets `HostName`, `User`,
+`Port`, `IdentityFile`, `ProxyJump`, `Match` — all of it, correct, for free, and matching
+whatever the user already tests with `ssh bastion`. This is the single strongest argument
+for the subprocess: **the configuration surface is not ours to reimplement or to document.**
+
+### 4.2 `--tunnel-command` — the same backend, for everything that is not SSH
+
+```bash
+hsql --tunnel-command 'cloud-sql-proxy --port {local_port} my-proj:us-central1:pg' -a postgres
+hsql --tunnel-command 'aws ssm start-session --target i-0abc --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host={remote_host},portNumber={remote_port},localPortNumber={local_port}'
+hsql --tunnel-command 'kubectl port-forward svc/pg {local_port}:{remote_port}'
+```
+
+Placeholders: `{local_port}`, `{remote_host}`, `{remote_port}`. Same lifecycle, same
+readiness poll, same teardown; `--ssh` is sugar over it with an argv we build.
+
+This is ~40 lines on top of the SSH backend and it covers the Cloud SQL request on the
+issue, every corporate access proxy, and the next one nobody has heard of yet. It is also
+what makes the whole feature **testable in CI without an SSH server** (§10).
+
+### 4.3 What v1 does not do
+
+One hop and one endpoint. Multiple forwards over one `ssh` connection is a one-line
+extension (`-L` repeats) and can wait for someone who wants it. No reconnect: `ssh` gets
+`-o ServerAliveInterval=30`, and a dead tunnel surfaces as the adapter's own connection
+error, which is already an error modal in the IDE and exit 3 in `hsql`.
+
+## 5. The rewrite — the part that has to work with any adapter
+
+`resolve()` answers two questions with no I/O: **what remote endpoint is this invocation
+about to dial**, and **where do I write the local one so the adapter uses it**. It returns
+a plan, which the CLI applies after `Tunnel.start()`:
+
+```python
+@dataclass(frozen=True)
+class RewritePlan:
+    remote: Endpoint
+    sites: tuple[Site, ...]      # option pair, or a span inside a conn_str
+    described: str               # "--host/--port", "conn_str[0]" -- what we print
+```
+
+Three sources, in precedence order. All of them are consulted; if two name **different**
+remote endpoints, that is an error naming both, resolved by `--tunnel-remote HOST:PORT`.
+
+### 5.1 Declared roles (new, precise, opt-in)
+
+An additive keyword on `AbstractOption`, exactly parallel to `secret=`:
+
+```python
+TextOption(name="host", ..., role="host")
+TextOption(name="port", ..., role="port")
+```
+
+- `role: ClassVar[str] = ""` as a class attribute and a ctor kwarg, so a third-party
+  subclass that predates it still answers (the `getattr` move `to_dict()` already makes).
+- Reported by `to_dict()`, so it shows up in `hsql --spec` and the generated config schema.
+- Nothing in core requires it. It is how an adapter with an unguessable spelling
+  (`--server`, `--endpoint`, `--bootstrap-servers`) opts into being tunneled correctly, and
+  the in-tree adapters have nothing to declare.
+
+### 5.2 The name backstop (works with every adapter installed today)
+
+When no option declares a role, core matches option names — `host`, `hostname`, `server`,
+`address` paired with `port` — the same way `redact._SECRET_NAME` matches password-ish keys,
+and for exactly the same reason: **every adapter's options predate the declaration**, and an
+adapter the user installed last year is the whole point of the feature.
+
+This is a guess, so it is guarded three ways:
+
+1. It only runs when the user asked for a tunnel. Nothing changes for anyone else.
+2. It only matches options **the invocation actually set** (CLI or profile). An unset option
+   is not evidence of anything.
+3. **It prints what it did.** `hsql` on stderr, the IDE as a notification and on the debug
+   screen:
+   ```
+   tunnel: forwarding db.internal:5432 -> 127.0.0.1:54321 (ssh bastion); rewrote --host, --port
+   ```
+   Visibility is the mitigation for a wrong guess, and it is also the thing that tells a
+   user their adapter needs `role=` upstream.
+
+### 5.3 Inside `conn_str`
+
+Adapters that take a DSN (`postgres://user:pw@db.internal:5432/app`) carry the endpoint
+positionally, where no option describes it. Core rewrites the host and port **in place** for
+two forms:
+
+- URI-shaped: `scheme://[user[:pass]@]host[:port][/...]`
+- libpq keyword-shaped: `host=db.internal port=5432 dbname=app`
+
+Anything else is refused with a message pointing at `--tunnel-remote` and the adapter's own
+host option. `redact.py` already has regexes for the second thing it finds in these strings;
+this proposes lifting the parse into `harlequin/dsn.py` and having both callers use it, so
+"where is the host in a DSN" and "where is the password in a DSN" cannot drift apart. (The
+existing precedent for two implementations of one string question is
+`export._deduplicate_column_names()`, and AGENTS.md is not fond of it.)
+
+### 5.4 When there is nothing to rewrite
+
+DuckDB, SQLite, and any adapter with no network endpoint: `resolve()` finds no site, and the
+invocation **fails** with a usage error rather than silently connecting around the tunnel.
+
+```
+hsql: no host to forward for adapter 'duckdb'.
+      This adapter declares no host option and the connection string names no host.
+      Use --tunnel-remote HOST:PORT if you meant to forward something else.
+```
+
+Failing loudly matters: the silent version connects straight to a database the user believed
+was reachable only through a bastion.
+
+## 6. The CLI and config surface
+
+New options on **both** commands (a profile serves both, and `hsql` is where an agent or a
+cron job needs this most). All are `ssh_*`/`tunnel_*` profile keys with the same spelling.
+
+| option | meaning |
+|---|---|
+| `--ssh [user@]host[:port]` | the jump host, as `ssh` would take it; also an alias from `~/.ssh/config` |
+| `--ssh-identity PATH` | `-i` |
+| `--ssh-option KEY=VALUE` | repeatable `-o` passthrough; the escape hatch for everything not listed |
+| `--tunnel-command TEXT` | §4.2; mutually exclusive with `--ssh` |
+| `--tunnel-remote HOST:PORT` | name the remote endpoint instead of discovering it |
+| `--tunnel-local-port INT` | pin the local port (default: ephemeral) |
+| `--tunnel-timeout FLOAT` | seconds to wait for the forward (default 10) |
+
+Seven spellings, namespaced. `hsql`'s flags are the frozen part of its API, so these join the
+reserved set in `first_pass.attach_adapter_options()`: an adapter that declares `--ssh-host`
+today loses that spelling and keeps the option under its profile key, visibly, in `--help`.
+(Worth a survey of published adapters before merging; I know of none that claims one.)
+
+No password flags. `--ssh-password` would be a credential in `ps` output and in shell
+history for a case `ssh` already handles better with keys, an agent, or its own prompt. If
+one is added later it is `secret=True` and `redact._SECRET_NAME` grows `passphrase`, which it
+is missing today.
+
+In a config file, unremarkably:
+
+```toml
+[profiles.prod]
+adapter = "postgres"
+host = "db.internal"
+port = 5432
+dbname = "app"
+ssh = "bastion.example.com"
+```
+
+Both commands pick this up through the existing profile merge; `config_schema.py` generates
+the keys from click params, so `schemas/config-v1.json` regenerates with
+`scripts/write_config_schema.py` and the schema test keeps them honest.
+
+## 7. Ordering, and why the tunnel comes up before Textual
+
+```
+first_pass -> click parses -> profile merge -> resolve()  [pure]
+                                                  |
+                                            Tunnel.start()      <-- prompts happen HERE
+                                                  |
+                                            apply the plan
+                                                  |
+                              adapter_cls(...) -> tui.run() / hsql runs
+```
+
+The IDE opens its database on a worker thread after the app is running, which is right for a
+database and wrong for a tunnel: once Textual owns the terminal, `ssh` cannot ask for a
+passphrase, and a 2FA push has nowhere to print "check your phone". Starting the tunnel in
+the click callback also means one error path for both commands —
+`pretty_print_error` / `diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) —
+before a single widget is mounted.
+
+The cost is that `harlequin --ssh ...` authenticates before showing a UI, which is what every
+CLI that tunnels does, and is what the user expects from having typed an SSH flag.
+
+## 8. Two things that break quietly if we forget them
+
+**Cache keys.** `get_connection_hash(conn_str, config)` is computed from the config dict, and
+`adapter.connection_id` is usually a hydrated connection string. Hash the **pre-rewrite**
+values, or an ephemeral local port changes the key on every run and the user silently loses
+query history and the catalog cache. Concretely: compute the hash in `cli.py` before applying
+the plan, and when a tunnel is active prefer it over `adapter.connection_id` (which will have
+`127.0.0.1:54321` baked into it). The ssh destination joins the hashed material, so two
+bastions to two databases do not collide.
+
+**TLS.** An adapter told to connect to `127.0.0.1` will fail certificate hostname
+verification under `sslmode=verify-full` and friends. Core cannot fix this generically —
+libpq has `host`/`hostaddr` for exactly this, other drivers have nothing — so it is
+documented, and the rewrite notice is the place a user finds out why their `verify-full`
+connection started failing.
+
+## 9. Dependencies, imports, packaging
+
+**v1 adds no dependency at all.** `subprocess`, `socket`, `shlex`.
+
+`harlequin/tunnel.py` and `harlequin/dsn.py` import no Textual and no adapter; both join the
+"adapter API is reachable without the TUI" import-linter contract, and `harlequin.tunnel` is
+imported from the CLI callbacks only when a tunnel was asked for, so an invocation without
+one pays nothing (`scripts/cold_start.py` should show no change).
+
+**When paramiko would earn its place** — as `harlequin[ssh]`, a second `Tunnel`
+implementation, no change anywhere else:
+
+- Windows users without OpenSSH (it ships with Windows 10+, but is removable and absent from
+  many CI images).
+- Containers: this repo's own dev container has no `ssh` binary, and neither does the
+  `python:3.x-slim` image most people build on.
+- Anything needing in-process sockets rather than a listener — which is also the shape the
+  Google Cloud SQL *connector* (as opposed to its proxy binary) wants, and the one thing
+  `--tunnel-command` genuinely cannot express.
+
+Until one of those has a user asking, the argument on the issue stands: an unmaintained
+wrapper is not worth taking, and a maintained one is still a cryptography dependency for
+every Harlequin install to solve a problem `ssh` already solves on the same machine.
+
+## 10. Testing
+
+**Unit, no network** — `resolve()` is a pure function and gets the table:
+
+| adapter shape | conn_str | options set | expected |
+|---|---|---|---|
+| declares `role="host"`/`"port"` | — | `--server`, `--port` | rewrites both |
+| `host`/`port` names only | — | `--host`, `--port` | rewrites both, with a notice |
+| DSN, URI form | `postgres://u@db:5432/app` | — | rewrites the span |
+| DSN, libpq form | `host=db port=5432` | — | rewrites both keys |
+| both, agreeing | DSN + `--host` | | rewrites both sites |
+| both, disagreeing | | | `HarlequinTunnelError`, names both |
+| duckdb / sqlite | file path | | usage error, §5.4 |
+| DSN we cannot parse | `weird::thing` | | usage error naming `--tunnel-remote` |
+
+**End to end, no SSH server.** `--tunnel-command` makes the whole path testable with a
+python subprocess as the forwarder:
+
+```python
+--tunnel-command "{sys.executable} -m tests.tcp_forward {local_port} {remote_host} {remote_port}"
+```
+
+A ~30-line loopback TCP forwarder in `tests/`, a real SQLite-over-TCP or a stub server on the
+far side, and the test asserts the adapter actually reached through it, that the local port
+was substituted, and that the child is dead after the command exits. Runs on all three OSes,
+needs no `online` marker, no secrets, no `ssh`.
+
+**The SSH argv** is asserted as data (`_ssh_argv(spec, remote, local) == [...]`) rather than
+by running it. One test does run `ssh -V` and skips if absent, to prove the built argv is at
+least accepted by a real client where one exists.
+
+## 11. Public API impact
+
+Additive only; every out-of-tree adapter keeps working untouched:
+
+- `AbstractOption.role` — new class attribute + ctor kwarg + `to_dict()` key. Adapters that
+  never set it are handled by §5.2.
+- `HarlequinTunnelError(HarlequinError)` in `exception.py`.
+- No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`, `catalog.py` or
+  `driver.py`. **An adapter does not know it is tunneled**, which is the property that makes
+  this work for adapters nobody in this org maintains.
+
+## 12. Alternatives considered
+
+| | why not |
+|---|---|
+| **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings; the adapters that need it most are out-of-tree. Exactly the "workaround here is a permanent tax" case AGENTS.md warns about — except the tax is paid N times, by other people. |
+| **A library adapters call (`harlequin-tunnel`)** | Adapters must opt in, so "works with any adapter" becomes "works with adapters that adopted it". Reasonable *in addition*, for an adapter that wants a tunnel inside its own connection (Cloud SQL connector); not a substitute. |
+| **`sshtunnel`** | The blocker on the issue. Four years without a release, and it is a wrapper over paramiko that we would be depending on for ~150 lines of behavior. |
+| **paramiko directly, in v1** | A real dependency (cryptography) on every install, and it reimplements the part of `~/.ssh/config` users already have working — `paramiko.SSHConfig` handles some of it, not `Match`, not certificates, not the agent story on Windows. Kept as the v2 backend, §9. |
+| **Tell users to run `ssh -L` themselves** | It works, and it is what people do today. It also means two terminals, a remembered port, and a profile that only works if a human ran something first — which is precisely what `hsql` in a cron job or an agent loop cannot do. |
+| **A nested `[profiles.x.ssh]` config table** | Prettier in TOML, but the CLI merge is flat by name (`merge_profile_with_cli`), so it would need a second mapping between flag names and config keys. Not worth it for seven keys. |
+
+## 13. Phasing
+
+1. **`harlequin/dsn.py`** — lift the DSN parse out of `redact.py`, no behavior change, tests
+   pin the existing redaction. Small, mergeable alone.
+2. **`harlequin/tunnel.py`: `resolve()` + `RewritePlan`** — pure, plus `AbstractOption.role`
+   and the `to_dict()` key. The §10 table is the whole test suite. No CLI yet.
+3. **`SubprocessTunnel` + `--tunnel-command`** on both commands, with the lifecycle, the
+   notice, the cache-key fix, and the loopback end-to-end test.
+4. **`--ssh` and friends** — argv construction over PR 3, reserved spellings in
+   `attach_adapter_options()`, `--info` / debug-screen reporting, regenerated config schema.
+5. **Docs** in `tconbeer/harlequin-web`, and a `CHANGELOG.md` entry under `[Unreleased]`
+   → Features, referencing [#545](https://github.com/tconbeer/harlequin/issues/545).
+
+## 14. Open questions for review
+
+1. **Is the name backstop (§5.2) acceptable?** It is what makes the feature work with the
+   adapters people have installed right now, and it is a guess that prints itself. The strict
+   alternative is `role=` only, which means the feature does nothing useful until every
+   adapter ships a release.
+2. **`--ssh` sugar in v1, or `--tunnel-command` alone?** The generic one is strictly more
+   powerful and half the code; the sugar is what makes the feature discoverable and is what
+   the issue asks for.
+3. **Should `harlequin` (the IDE) offer to keep the tunnel across a reconnect** if a
+   reconnect action is ever added? Nothing needs it today.
+4. **Multiple `conn_str`s** are supported by the IDE. v1 forwards one endpoint and errors on
+   two distinct ones. Is anyone attaching two remote databases through one bastion?

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -11,24 +11,26 @@ Nothing here is implemented. This is the design to argue with before the first P
 
 1. **Harlequin manages a tunnel; it does not touch connection details.** The user gives the
    adapter the address the database has **from the SSH host's side**, and the tunnel makes
-   that address true on this machine. `--ssh-forward 5432` binds `127.0.0.1:5432` here and
-   forwards it there, so a conn_str of `postgresql://user@localhost:5432/app` needs no
-   rewriting — it is already pointing at the tunnel.
-2. **That is what makes it work with any adapter.** Core never has to know which of an
-   adapter's options is the host, never parses a DSN, and adds nothing to the adapter API.
-   An adapter cannot tell it is tunneled, and one published four years ago works today.
-3. **The forwarder is a subprocess, not a library.** `ssh -L`, plus a generic
+   that address true on this machine. A conn_str of `postgresql://me@localhost:5439/prod`
+   needs no rewriting — it is already pointing at the tunnel.
+2. **That is what makes it work with any adapter.** Core never learns which of an adapter's
+   options is the host, never parses a DSN, and adds nothing to the adapter API. An adapter
+   cannot tell it is tunneled, and one published four years ago works today.
+3. **The forwarder is a subprocess, not a library.** `ssh`, plus a generic
    `--tunnel-command` for what is not SSH (`cloud-sql-proxy`, `aws ssm`,
    `kubectl port-forward`, Teleport). **Zero new dependencies** — which answers the
    four-year-old blocker on the issue — and it inherits the user's whole `~/.ssh/config`:
-   `ProxyJump`, agent, certificates, hardware keys, `Match` blocks, 2FA. A paramiko backend
-   stays possible behind the same ABC and an extra (`harlequin[ssh]`); §8 says what would
-   trigger it.
-4. **The tunnel comes up before Textual does.** Not an implementation detail: it is the only
-   way an SSH password, a key passphrase, or a 2FA prompt can reach a human.
+   `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match` blocks, 2FA.
+4. **SSH is a special case of `--tunnel-command` and still earns its own flags** — three of
+   them, not nine. The deciding argument is not ergonomics: `ssh_host = "redshift_prod"` in
+   a profile is a *name*, while `tunnel_command = "…"` is a shell command, and a
+   `pyproject.toml` in a cloned repository must not be able to run one (§6.1).
+5. **The tunnel comes up before Textual does**, so an SSH password, a key passphrase or a
+   2FA prompt can reach a human — and it is a child process, not `ssh -f`, so it dies with
+   the session instead of outliving it.
 
-What core owns is the **lifecycle** — bring the forward up before anything connects, report
-what went wrong in the two commands' own error paths, tear it down on exit — and that is the
+What core owns is the **lifecycle**: bring the forward up before anything connects, report
+what went wrong in the two commands' own error paths, tear it down on exit. That is the
 whole of the feature.
 
 ---
@@ -47,94 +49,204 @@ Two later comments matter:
 - A request for **Cloud SQL**, which is not SSH at all. It is the reason the abstraction here
   is "a subprocess that makes a remote endpoint reachable locally", with SSH as one instance.
 
-**The rewrite half of the issue is what this design drops.** §11 has the reasoning; the short
+**The rewrite half of the issue is what this design drops.** §12 has the reasoning; the short
 version is that intercepting connection details means core guessing which of an adapter's
-options is a host, and guessing wrong quietly. Binding the local end to the port the user
-already typed reaches the same place with none of that.
+options is a host, and guessing wrong quietly.
 
-## 2. Where the code sits today
+## 2. Ten seconds of SSH, for the rest of this document
 
-Both commands build a config dict, instantiate one adapter with it, and connect:
+| | |
+|---|---|
+| `-L 5439:redshift.internal:5439` | **local forward.** Listen on `127.0.0.1:5439` here; anything that connects is carried over the SSH connection and delivered to `redshift.internal:5439` **as resolved by the SSH host**. |
+| `LocalForward 5439 redshift.internal:5439` | The same thing, written in `~/.ssh/config` under a `Host` block instead of on the command line. |
+| `-N` | Don't run a remote command. "I am here for the forwards." |
+| `-f` | Fork into the background once the forwards are up. |
+| `-J`, `ProxyJump` | Reach the destination through another SSH host first. Chains. |
+| `-o KEY=VALUE` | Set any `ssh_config` keyword for this invocation. |
+| `-o ExitOnForwardFailure=yes` | If a forward can't be set up (port already in use, remote refuses), exit instead of connecting anyway. |
+| `ssh -G host` | Print the resolved config for `host` — every `Host`/`Match` block applied — and connect to nothing. |
 
-| | IDE | headless |
-|---|---|---|
-| adapter constructed | `cli.py:548`, `adapter_cls(conn_str=conn_str, **config)` | `hsql/cli.py:_connect()` |
-| connection opened | `app.py:_connect()`, on a worker thread, after `tui.run()` | `hsql/cli.py:_connect()`, inline |
-| connection closed | `app.py:action_quit()` | never explicitly; the process exits |
-| cache key | `adapter.connection_id` or `get_connection_hash(conn_str, config)` (`cli.py:553`) | n/a |
+**`ssh -fN redshift_prod` and `ssh -L …` are not alternatives.** The forward in that command
+is real, it is just written down somewhere else: a `Host redshift_prod` block in
+`~/.ssh/config` with a `LocalForward` line in it. `-f` and `-N` say *how to run*; `-L` and
+`LocalForward` say *what to forward*, and they are the same directive in two places.
 
-Two existing facts the design leans on:
-
-- **A command's own click params are what claim a profile key.** `parse_profile_options()`
-  takes `command_options` from `{param.name for param in cmd.params}`; anything else in a
-  profile must be a declared option of the adapter. New `--ssh-*` options on both commands
-  therefore become valid profile keys and JSON-schema keys with no further plumbing.
-- **`first_pass()` settles the adapter before click parses anything**, so nothing here
-  changes the start-up cost of an invocation that does not tunnel.
+This matters for the design: **a user who already tunnels probably has the forward in their
+ssh config**, and asking them to repeat it on Harlequin's command line would be a step
+backwards. So `--ssh-forward` is optional, and §4.1 is the case where it is not used at all.
 
 ## 3. The model
 
 ```
-   --ssh-host bastion                        ssh -N -T \
-   --ssh-forward 5432          ───────►        -o ExitOnForwardFailure=yes \
-                                               -L 127.0.0.1:5432:localhost:5432 bastion
+   --ssh-host redshift_prod    ───────►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
+                                         (the -L comes from ~/.ssh/config)
 
-   -a postgres                               adapter dials 127.0.0.1:5432
-   "postgresql://me@localhost:5432/app"  ──► which is the far side's localhost:5432
+   -a postgres                           adapter dials 127.0.0.1:5439
+   "postgresql://me@localhost:5439/prod" which is the far side's redshift.internal:5439
 ```
 
 Two rules, and they are the whole contract:
 
-1. **Connection details are read from the SSH host's side.** `localhost` means the bastion's
-   localhost. `db.internal` means whatever the bastion resolves that to.
-2. **`--ssh-forward` binds the same port locally by default**, so the address the user typed
-   is the address that now works here. `--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`.
+1. **Connection details are read from the SSH host's side.** `localhost` means the SSH
+   host's localhost; `redshift.internal` means whatever the SSH host resolves that to.
+2. **A forward binds the same port locally by default**, so the address the user typed is the
+   address that now works here.
 
-Nothing rewrites anything. `conn_str` and every adapter option reach the adapter exactly as
-the user wrote them, and the adapter is never told a tunnel exists.
+Nothing is rewritten. `conn_str` and every adapter option reach the adapter exactly as the
+user wrote them, and the adapter is never told a tunnel exists.
 
-Three spellings of `--ssh-forward`, matching `ssh -L` from the right:
+The forward can come from either place, and Harlequin does not care which:
 
-| written | means |
+| where | how |
 |---|---|
-| `5432` | `-L 127.0.0.1:5432:localhost:5432` — the database runs on the bastion |
-| `db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` — the bastion is a jump host |
-| `15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` — something local already has 5432 |
+| `~/.ssh/config` | a `LocalForward` line in the `Host` block. Harlequin passes no `-L`. |
+| Harlequin | `--ssh-forward`, repeatable, in one of three forms below |
 
-Repeatable, because one `ssh` connection carries as many forwards as you like, and the IDE
-takes several `CONN_STR`s.
+| `--ssh-forward` | becomes |
+|---|---|
+| `5432` | `-L 127.0.0.1:5432:localhost:5432` — the database runs on the SSH host |
+| `db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` — the SSH host is a jump host |
+| `15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` — something local already has 5432 |
 
 ### What this model gives up, and what it buys
 
-A local port collision is a **hard error**, not a workaround: `ExitOnForwardFailure=yes`
-means `ssh` exits and says `bind: Address already in use`, and the user picks a local port
-with the three-part form. That is the honest failure, and the alternative — quietly binding
-somewhere else — is the failure mode that makes people distrust the feature.
+A local port collision is a **hard error**, not a workaround: `ExitOnForwardFailure=yes` means
+`ssh` exits saying `bind: Address already in use`, and the user picks a local port with the
+three-part form. That is the honest failure; quietly binding somewhere else is the failure
+mode that makes people distrust the feature. (§13 asks whether an already-listening port
+should instead be taken as "the tunnel is already up" — it is the one case where this bites a
+user who does what our own reader did for years.)
 
 What it buys, beyond not guessing:
 
-- **TLS still works the way the user asked for it.** Nothing silently changes the hostname
-  the driver validates against; whatever they typed is what gets verified.
-- **`connection_id` and the catalog cache key stay stable across runs** (§7), because there
-  is no ephemeral port in the config the hash is taken over.
+- **TLS still works the way the user asked for it.** Nothing silently changes the hostname the
+  driver validates against.
+- **`connection_id` and the catalog cache key stay stable across runs** (§7), because no
+  ephemeral port lands in the config the hash is taken over.
 - **DuckDB and SQLite need no special case.** They ignore the tunnel; a duckdb `ATTACH` of
   `postgres://localhost:5432/app` goes through it like anything else.
 
 ### The hazard this model does have
 
 A profile that says `host = "localhost"` is only correct with the tunnel up. Run it without
-`--ssh-host` and it connects to whatever is on **your** 5432 — which on a developer's laptop
-may well be a database, just the wrong one.
+`ssh_host` and it connects to whatever is on **your** 5439 — which on a developer's laptop may
+well be a database, just the wrong one.
 
-Mitigation, in order of how much they cost: the `ssh_*` keys live in the same profile as the
-connection details, so they travel together and the failure needs someone to have deliberately
-overridden one of them; the start-up notice (§6) says on stderr what was forwarded; and if
-this proves to bite in practice, a `require_tunnel = true` profile key can refuse to connect
-without one. Not proposed for v1.
+The `ssh_*` keys live in the same profile as the connection details, so they travel together
+and the failure needs someone to have deliberately overridden one; the start-up notice (§6)
+says what was forwarded. If it proves to bite, a `require_tunnel = true` profile key can
+refuse to connect without one. Not proposed for v1.
 
-## 4. The forwarder
+## 4. Worked examples
 
-### 4.1 `SubprocessTunnel` — the only backend in v1
+### 4.1 A Redshift cluster behind a bastion, with the forward already in `~/.ssh/config`
+
+```
+Host redshift_prod
+    HostName bastion.example.com
+    User ted
+    IdentityFile ~/.ssh/id_ed25519
+    LocalForward 5439 redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439
+```
+
+Today: `ssh -fN redshift_prod`, then `harlequin -a postgres --host localhost --port 5439 …`,
+then remember to kill the ssh later.
+
+```toml
+[profiles.redshift]
+adapter = "postgres"
+host = "localhost"
+port = 5439
+dbname = "prod"
+user = "ted"
+ssh_host = "redshift_prod"
+```
+
+`harlequin -P redshift`, and `hsql -P redshift -c "select 1"`. **No `--ssh-forward`, no
+`--ssh-user`, no `--ssh-identity`** — the ssh config already says all of it, and Harlequin
+runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`. The connection details are unchanged
+from what works today, because `localhost:5439` was already the far side's address.
+
+### 4.2 The same cluster, with nothing in `~/.ssh/config`
+
+```bash
+hsql -a postgres --host localhost --port 5439 --dbname prod \
+     --ssh-host ted@bastion.example.com \
+     --ssh-forward 5439:redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439 \
+     -c "select 1"
+```
+
+The advice in the docs will be to write the `Host` block instead and go back to 4.1 — but
+this works, and it is what an agent or a CI job with no dotfiles has to do.
+
+### 4.3 Postgres running on the bastion itself
+
+```bash
+harlequin -a postgres --host localhost --port 5432 --ssh-host bastion --ssh-forward 5432
+```
+
+`--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`: the short form exists because
+this is the most common shape.
+
+### 4.4 You already run a local Postgres on 5432
+
+```bash
+harlequin -a postgres --host localhost --port 15432 \
+          --ssh-host bastion --ssh-forward 15432:db.internal:5432
+```
+
+The two ports agree because the user wrote both. Nothing infers anything.
+
+### 4.5 Two databases through one bastion
+
+```bash
+harlequin -a postgres --ssh-host bastion \
+          --ssh-forward 5432:pg.internal:5432 \
+          --ssh-forward 15432:analytics.internal:5432 \
+          "postgresql://me@localhost:5432/app" "postgresql://me@localhost:15432/analytics"
+```
+
+One `ssh` child, two `-L`s.
+
+### 4.6 A jump host in front of the bastion
+
+Nothing new. `ProxyJump jump.example.com` in the `Host` block, or
+`--ssh-option ProxyJump=jump.example.com`. Chains of three work because `ssh` does them, not
+because we do.
+
+### 4.7 Cloud SQL — the request from the issue thread
+
+```toml
+[profiles.cloudsql]
+adapter = "mysql"
+host = "127.0.0.1"
+port = 3306
+database = "app"
+tunnel_command = "cloud-sql-proxy --port 3306 my-proj:us-central1:my-instance"
+tunnel_port = [3306]
+```
+
+Also `kubectl port-forward svc/pg 5432:5432`, `aws ssm start-session … localPortNumber=5432`,
+`tsh proxy db --port 5432 …`. Same lifecycle, same readiness poll, same teardown.
+
+### 4.8 A key with a passphrase, or 2FA
+
+```
+$ hsql -P redshift -c "select count(*) from events"
+Enter passphrase for key '/home/ted/.ssh/id_ed25519':
+tunnel: 127.0.0.1:5439 -> redshift-prod…:5439 via ssh redshift_prod
+```
+
+The prompt is `ssh`'s, on the real terminal, because the child is started before Textual (in
+the IDE) and before any output (in `hsql`). An agent running `hsql` unattended uses a key
+with no passphrase or an agent, exactly as it would for `ssh` itself.
+
+### 4.9 Something that is not tunneled
+
+`harlequin my.db`, `hsql -a postgres --host prod.example.com …`. No `ssh_host`, no
+`tunnel_command`, no `harlequin.tunnel` import, no cost.
+
+## 5. The forwarder
 
 ```python
 class Tunnel(ABC):
@@ -150,71 +262,51 @@ class Tunnel(ABC):
     def __exit__(self, *exc: Any) -> None: self.stop()
 ```
 
-- The child stays in the **foreground** (no `-f`) with the terminal attached, so
-  `Enter passphrase for key ...` and a 2FA prompt reach the human. Readiness is a
-  connect-poll against each forwarded local port with `--tunnel-timeout` (default 10s),
-  which also notices the child exiting early; on failure the error quotes the child's stderr
-  verbatim, because `ssh`'s diagnostics are better than any we would write.
-- Teardown is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping `tui.run()`
-  and the `hsql` run, plus an `atexit` backstop.
+One implementation, `SubprocessTunnel`. The SSH options build an argv; `--tunnel-command` is
+`shlex.split()` of what the user wrote. Everything after that is shared.
+
+- **Foreground, not `-f`.** The child keeps the terminal, so prompts reach the human, and we
+  keep the handle, so it can be killed. `ssh -fN` backgrounds itself and outlives the
+  session — which is why the manual workflow needs a `kill` afterwards and this does not.
+- **Readiness** is a connect-poll against each known local port until `--tunnel-timeout`
+  (default 10s), which also notices the child exiting early. On failure the error quotes the
+  child's stderr verbatim, because `ssh`'s diagnostics are better than any we would write.
+- **Ports we do not know**: in the 4.1 shape the forward is in `ssh_config`, so Harlequin has
+  no port to poll. Two ways out, and the first needs verifying: `ssh -G <host>` prints the
+  resolved config and *may* include `localforward` lines, in which case the poll is exact and
+  free; otherwise Harlequin skips the poll, waits for the child to survive a short grace
+  period, and lets the adapter's own connection be the test. **Confirm `-G` behavior on the
+  OpenSSH versions we care about before relying on it** — this container has no `ssh` to
+  check against, and the fallback has to be good enough on its own.
+- **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
+  `tui.run()` and the `hsql` run, plus an `atexit` backstop.
 - `-o ServerAliveInterval=30`. No reconnect in v1: a dead tunnel surfaces as the adapter's own
-  connection error, which is already an error modal in the IDE and exit 3 in `hsql`.
-
-The user's `~/.ssh/config` is read by `ssh` itself, so `--ssh-host bastion` picks up
-`HostName`, `User`, `Port`, `IdentityFile` and `ProxyJump` from a `Host bastion` block — all
-of it, correct, and matching whatever the user already tests with `ssh bastion`. This is the
-strongest argument for the subprocess: **that configuration surface is not ours to
-reimplement or to document.**
-
-### 4.2 `--tunnel-command` — the same lifecycle, for what is not SSH
-
-```bash
-hsql --tunnel-command 'cloud-sql-proxy --port 5432 my-proj:us-central1:pg' --tunnel-port 5432
-hsql --tunnel-command 'kubectl port-forward svc/pg 5432:5432' --tunnel-port 5432
-```
-
-The command binds whatever port the user's connection details name — the same contract as
-§3, so there is nothing to substitute. `--tunnel-port` (repeatable) is what the readiness
-poll watches; omit it and Harlequin starts the child and carries on.
-
-Roughly 30 lines on top of the SSH backend. It covers the Cloud SQL request on the issue,
-every corporate access proxy, and the next one nobody has heard of yet — and it is what makes
-the whole feature **testable in CI without an SSH server** (§9).
-
-### 4.3 Not in v1
-
-Reconnect, and `ssh` control-socket multiplexing (which would let a second Harlequin reuse a
-live connection, and which Windows OpenSSH does not support anyway).
-
-## 5. Public API impact
-
-**None.** No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`,
-`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinTunnelError(HarlequinError)`
-in `exception.py`, and one new module, `harlequin/tunnel.py`.
-
-That an adapter cannot tell it is tunneled is not an accident of the design — it is the
-property being bought, and it is why this works for adapters nobody in this org maintains.
+  connection error, already an error modal in the IDE and exit 3 in `hsql`.
 
 ## 6. The CLI and config surface
 
 New options on **both** commands. A profile serves both, and `hsql` is where this matters
-most: a cron job or an agent cannot ask a human to run `ssh -L` in another terminal first.
+most: a cron job or an agent cannot ask a human to run `ssh -fN` in another terminal first.
 
 | option | meaning |
 |---|---|
-| `--ssh-host TEXT` | the jump host, or a `Host` alias from `~/.ssh/config` |
-| `--ssh-user TEXT` | `ssh -l`; defaults to whatever ssh_config or the local user says |
-| `--ssh-port INT` | the SSH port, if not 22 |
-| `--ssh-identity PATH` | `ssh -i` |
-| `--ssh-forward TEXT` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT` (§3) |
-| `--ssh-option KEY=VALUE` | repeatable `-o` passthrough; the escape hatch for the rest |
-| `--tunnel-command TEXT` | §4.2; mutually exclusive with `--ssh-host` |
+| `--ssh-host TEXT` | `[user@]host[:port]`, or a `Host` alias from `~/.ssh/config` |
+| `--ssh-forward TEXT` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT`. Omit when `ssh_config` has it |
+| `--ssh-option KEY=VALUE` | repeatable `-o`; `IdentityFile`, `ProxyJump`, `User`, anything |
+| `--tunnel-command TEXT` | §4.7; mutually exclusive with `--ssh-host` |
 | `--tunnel-port INT` | repeatable; ports the readiness poll waits for |
 | `--tunnel-timeout FLOAT` | seconds to wait (default 10) |
 
-`--ssh-host` with no `--ssh-forward` is a usage error naming the three spellings: a tunnel
-that forwards nothing is always a mistake, and it is better caught before an SSH handshake
-than after one.
+Three SSH flags, not nine. An earlier draft had `--ssh-user`, `--ssh-port`, `--ssh-identity`
+and more; every one of them is `ssh_config` or `-o` spelled twice, and the docs' advice is to
+write a `Host` block, which is reusable outside Harlequin and is where a user's `ProxyJump`,
+certificate and `Match` rules already live.
+
+`--ssh-host` with neither `--ssh-forward` nor a `LocalForward` in its resolved config is a
+usage error naming both places — a tunnel that forwards nothing is always a mistake, and it is
+better caught before an SSH handshake than after one. (This is the second thing that depends
+on `ssh -G`; without it, this check degrades to "no `--ssh-forward` and no way to know", and
+should then not fire at all rather than fire wrongly.)
 
 No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
 for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
@@ -222,34 +314,34 @@ ever added it is `secret=True`, and `redact._SECRET_NAME` grows `passphrase`, wh
 missing today.
 
 `hsql`'s flags are the frozen part of its API, so these join the reserved spellings in
-`first_pass.attach_adapter_options()`: an adapter that declares `--ssh-host` today would lose
-that spelling, visibly, in `--help`, and keep the option under its profile key. Worth a survey
-of published adapters before merging; I know of none that claims one.
-
-In a config file, unremarkably — and note that the connection details are the far side's:
-
-```toml
-[profiles.prod]
-adapter = "postgres"
-host = "localhost"
-port = 5432
-dbname = "app"
-ssh_host = "bastion.example.com"
-ssh_forward = ["5432"]
-```
-
-Both commands pick this up through the existing profile merge. `config_schema.py` generates
-its keys from click params, so `schemas/config-v1.json` regenerates with
-`scripts/write_config_schema.py`, and the schema test keeps them honest.
+`first_pass.attach_adapter_options()`. Worth a survey of published adapters before merging; I
+know of none that claims one.
 
 **The start-up notice.** `hsql` on stderr (never stdout — that belongs to query output), the
 IDE as a notification and on the debug screen:
 
 ```
-tunnel: 127.0.0.1:5432 -> localhost:5432 via ssh bastion.example.com
+tunnel: 127.0.0.1:5439 -> redshift-prod.abc123.us-east-1.redshift.amazonaws.com:5439 via ssh redshift_prod
 ```
 
 One line, and it is what tells a user which database they are actually looking at.
+
+### 6.1 A config file must not be able to run a command
+
+This is the one place the feature can make Harlequin *less* safe, and it is why SSH keeps its
+own flags rather than collapsing into `--tunnel-command`.
+
+Config files are discovered in the **working directory**, including `pyproject.toml`. Clone a
+repository, run `harlequin` in it, and today the worst a hostile config can do is name a
+database. With `tunnel_command`, it would run a shell command. The same is true of
+`ssh_option`, because `ProxyCommand=…` is a command.
+
+Proposed rule: **`tunnel_command` and `ssh_option` are honored only from the user's own
+config** — an explicit `--config-path`, the user config dir, or `$HOME` — and from the command
+line. A profile supplied by a file found in the working directory that sets either one is a
+config error naming the file. `config.py` already tracks which file supplied each profile
+(`Provenance`), so the check has the information it needs. `ssh_host` and `ssh_forward` are
+names and ports, not commands, and stay allowed everywhere.
 
 ## 7. Ordering, cache keys, and the two commands
 
@@ -267,22 +359,31 @@ passphrase and a 2FA push has nowhere to print "check your phone". Starting the 
 click callback also means one error path for both commands — `pretty_print_error` /
 `diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) — before a widget is mounted.
 
-The cost is that `harlequin --ssh-host …` authenticates before showing a UI, which is what
-every CLI that tunnels does and what a user who typed an SSH flag expects.
+The cost is that `harlequin -P redshift` authenticates before showing a UI, which is what
+every CLI that tunnels does and what a user who configured one expects.
 
 **Cache keys need one small change.** Nothing is rewritten, so `get_connection_hash()` and
 `adapter.connection_id` are already stable across runs — but two bastions fronting two
-databases both look like `localhost:5432`, and would share a catalog cache and a query
-history. The ssh destination (and the forward specs) join the hashed material.
+databases both look like `localhost:5439`, and would share a catalog cache and a query
+history. The ssh destination and the forward specs join the hashed material.
 
-## 8. Dependencies, imports, packaging
+## 8. Public API impact
+
+**None.** No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`,
+`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinTunnelError(HarlequinError)`
+in `exception.py`, and one new module, `harlequin/tunnel.py`.
+
+That an adapter cannot tell it is tunneled is not an accident — it is the property being
+bought, and it is why this works for adapters nobody in this org maintains.
+
+## 9. Dependencies, imports, packaging
 
 **v1 adds no dependency at all**: `subprocess`, `socket`, `shlex`.
 
 `harlequin/tunnel.py` imports no Textual and no adapter, and joins the "adapter API is
 reachable without the TUI" import-linter contract. It is imported from the CLI callbacks only
-when a tunnel was asked for, so an invocation without one pays nothing —
-`scripts/cold_start.py` should show no change.
+when a tunnel was asked for, so 4.9 pays nothing — `scripts/cold_start.py` should show no
+change.
 
 **When paramiko would earn its place** — as `harlequin[ssh]`, a second `Tunnel`
 implementation, nothing else changing:
@@ -290,15 +391,15 @@ implementation, nothing else changing:
 - Windows users without OpenSSH. It ships with Windows 10+, but is removable.
 - Containers: this repo's own dev container has no `ssh` binary, and neither does the
   `python:3.x-slim` image most people build on.
-- Anything wanting in-process sockets rather than a listener — which is the shape Google's
-  Cloud SQL *connector* (as opposed to its proxy binary) wants, and the one thing
-  `--tunnel-command` cannot express.
+- Anything wanting in-process sockets rather than a listener — the shape Google's Cloud SQL
+  *connector* (as opposed to its proxy binary) wants, and the one thing `--tunnel-command`
+  cannot express.
 
 Until one of those has a user asking, the argument on the issue stands: an unmaintained
 wrapper is not worth taking, and a maintained one is still a `cryptography` dependency on
 every Harlequin install, to solve a problem `ssh` already solves on the same machine.
 
-## 9. Testing
+## 10. Testing
 
 **End to end, no SSH server, no `online` marker.** `--tunnel-command` makes the whole
 lifecycle testable with a Python child as the forwarder:
@@ -320,9 +421,11 @@ child is dead once the command exits. Runs on all three OSes and needs no secret
 | `--ssh-forward db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` |
 | `--ssh-forward 15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` |
 | `--ssh-forward` repeated | one child, two `-L` |
-| `--ssh-host` with no `--ssh-forward` | usage error, exit 2 |
+| `--ssh-host` alone, `-G` reports a `localforward` | argv has no `-L`, poll watches that port |
+| `--ssh-host` alone, no forward anywhere | usage error naming both places |
 | `--ssh-host` and `--tunnel-command` | usage error, exit 2 |
 | a garbage forward spec | usage error naming the three forms |
+| `tunnel_command` from a cwd-discovered config | config error naming the file (§6.1) |
 | child exits during the poll | `HarlequinTunnelError` quoting its stderr, exit 3 |
 | poll times out | ditto, naming `--tunnel-timeout` |
 | profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
@@ -331,41 +434,48 @@ child is dead once the command exits. Runs on all three OSes and needs no secret
 One test runs `ssh -V` and skips if absent, to prove the built argv is accepted by a real
 client where one exists.
 
-## 10. Phasing
+## 11. Phasing
 
 1. **`harlequin/tunnel.py`** — the `Tunnel` ABC, `SubprocessTunnel`, argv construction, the
    readiness poll, `HarlequinTunnelError`. Unit tests only; no CLI. Mergeable alone.
 2. **Wire it into both commands** — the options, the `ExitStack`, the notice, the cache-key
-   change, and the loopback end-to-end test.
+   change, the §6.1 provenance rule, and the loopback end-to-end test.
 3. **`--tunnel-command`**, `--info` / debug-screen reporting, regenerated config schema.
-4. **Docs** in `tconbeer/harlequin-web` — including the "details are the far side's" contract,
-   which is the whole of what a user has to learn — and a `CHANGELOG.md` entry under
-   `[Unreleased]` → Features, referencing
+4. **Docs** in `tconbeer/harlequin-web`: the "details are the far side's" contract, and the
+   `Host` block as the recommended way to configure a tunnel. Plus a `CHANGELOG.md` entry
+   under `[Unreleased]` → Features, referencing
    [#545](https://github.com/tconbeer/harlequin/issues/545).
 
-## 11. Alternatives considered
+## 12. Alternatives considered
 
 | | why not |
 |---|---|
-| **Rewriting the adapter's host/port** (the issue's original sketch, and an earlier draft of this doc) | Core has to know which option is the host. There is no general answer: it would take a new `role=` declaration on `AbstractOption` that no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where `-L 5432:localhost:5432` reaches with none. It also bakes an ephemeral local port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
-| **A `{tunnel_port}` placeholder** the user writes into their conn_str | Fully general and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable without the tunnel rather than merely wrong. Worth revisiting only if the port-collision case turns out to be common. |
+| **Rewriting the adapter's host/port** (the issue's original sketch, and an earlier draft of this doc) | Core has to know which option is the host, and there is no general answer: a new `role=` declaration no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
+| **Only `--tunnel-command`, with SSH as one way to spell it** | Mechanically correct — `--tunnel-command 'ssh -N redshift_prod'` is the whole feature. Rejected for §6.1: a name in a config file is safe and a command is not, and the safety rule is only writable if the two are different keys. The ergonomics are the secondary argument: `ssh_host` needs no quoting, survives a Windows shell, and is what someone looks for in `--help`. |
+| **A `{tunnel_port}` placeholder** the user writes into their conn_str | General and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable *without* the tunnel rather than merely wrong. |
 | **A SOCKS proxy (`ssh -D`) with `socket.socket` patched** | The one design where the driver keeps the real hostname, so TLS verification is untouched. It only works for pure-Python drivers: psycopg2, mysqlclient, ODBC and duckdb's extensions open sockets in C and never see Python's `socket` module. |
 | **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings, and the adapters that need it most are out-of-tree. |
 | **A library adapters call (`harlequin-tunnel`)** | Adapters must opt in, so "works with any adapter" becomes "works with adapters that adopted it". Reasonable *in addition*, for an adapter that wants a tunnel inside its own connection (the Cloud SQL connector); not a substitute. |
 | **`sshtunnel`** | The blocker on the issue: four years without a release, and it is a wrapper over paramiko for behavior we would otherwise get from a binary already on the machine. |
-| **paramiko directly, in v1** | A `cryptography` dependency on every install, and it reimplements the part of `~/.ssh/config` users already have working. Kept as the v2 backend, §8. |
-| **Tell users to run `ssh -L` themselves** | It works, and it is what people do today. It also means two terminals, a remembered port, and a profile that only connects if a human ran something first — which is exactly what `hsql` in a cron job or an agent loop cannot do. |
+| **paramiko directly, in v1** | A `cryptography` dependency on every install, and it reimplements the part of `~/.ssh/config` users already have working. Kept as the v2 backend, §9. |
+| **Tell users to run `ssh -fN` themselves** | It works, and it is what people do today — including the author of this repo. It also means a second terminal, an orphaned tunnel to remember to kill, and a profile that only connects if a human ran something first, which is exactly what `hsql` in a cron job or an agent loop cannot do. |
 
-## 12. Open questions for review
+## 13. Open questions for review
 
-1. **Is `--ssh-forward` required, or can it default to `--ssh-port`-style guessing?** Required
-   is proposed. The alternative is reading the conn_str to find a port, which is the
-   inference this design exists to avoid — but it would make the common case one flag.
-2. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
+1. **Should an already-listening local port mean "the tunnel is already up"?** Today's answer
+   is a hard error from `ExitOnForwardFailure`, which means a user who still runs
+   `ssh -fN redshift_prod` by hand gets a bind failure from every Harlequin start. Skipping the
+   child when every known local port already accepts connections would fix that, at the cost
+   of connecting to *something* on that port without knowing it is the right tunnel. Leaning
+   toward skip-with-a-notice.
+2. **How much do we lean on `ssh -G`?** It is what makes the 4.1 shape fully checkable — the
+   readiness poll and the "you forwarded nothing" error both want it. It needs verifying
+   against real OpenSSH versions (including Windows) before either depends on it.
+3. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
    `0.0.0.0` would expose the far side's database to the user's network, which seems like a
    thing to make people ask for.
-3. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait for
+4. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait for
    someone to be bitten?
-4. **Flag naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one reads
-   well but splits `--tunnel-timeout` away from its siblings. All `--ssh-*` with
-   `--ssh-command`? All `--tunnel-*`?
+5. **Naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one splits
+   `--tunnel-timeout` away from its siblings. Alternative: `--ssh-*` everywhere plus
+   `--tunnel-command`, with `--ssh-timeout` covering both.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -1,7 +1,7 @@
-# Tunnels — a design for [#545](https://github.com/tconbeer/harlequin/issues/545)
+# SSH tunnels — a design for [#545](https://github.com/tconbeer/harlequin/issues/545)
 
 A proposal for connecting Harlequin and `hsql` to a database that is only reachable through
-an SSH bastion, **with any adapter, including out-of-tree ones that are never changed**.
+an SSH host, **with any adapter, including out-of-tree ones that are never changed**.
 
 Nothing here is implemented. This is the design to argue with before the first PR.
 
@@ -9,29 +9,26 @@ Nothing here is implemented. This is the design to argue with before the first P
 
 ## Bottom line up front
 
-1. **Harlequin manages a tunnel; it does not touch connection details.** The user gives the
-   adapter the address the database has **from the SSH host's side**, and the tunnel makes
-   that address true on this machine. A conn_str of `postgresql://me@localhost:5439/prod`
-   needs no rewriting — it is already pointing at the tunnel.
+1. **Harlequin manages a tunnel; it does not touch connection details.** The user's
+   connection details name the local end of a forward, and that is the whole contract. A
+   profile that works today with `ssh -fN redshift_prod` running in another terminal works
+   unchanged, with one key added.
 2. **That is what makes it work with any adapter.** Core never learns which of an adapter's
    options is the host, never parses a DSN, and adds nothing to the adapter API. An adapter
    cannot tell it is tunneled, and one published four years ago works today.
-3. **The forwarder is a subprocess, not a library.** `ssh`, plus a generic
-   `--tunnel-command` for what is not SSH (`cloud-sql-proxy`, `aws ssm`,
-   `kubectl port-forward`, Teleport). **Zero new dependencies** — which answers the
-   four-year-old blocker on the issue — and it inherits the user's whole `~/.ssh/config`:
-   `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match` blocks, 2FA.
-4. **SSH is a special case of `--tunnel-command` and still earns its own flags** — three of
-   them, not nine. The deciding argument is not ergonomics: `ssh_host = "redshift_prod"` in
-   a profile is a *name*, while `tunnel_command = "…"` is a shell command, and a
-   `pyproject.toml` in a cloned repository must not be able to run one (§6.1).
-5. **The tunnel comes up before Textual does**, so an SSH password, a key passphrase or a
-   2FA prompt can reach a human — and it is a child process, not `ssh -f`, so it dies with
-   the session instead of outliving it.
+3. **The forwarder is `ssh`, run as a child process.** **Zero new dependencies** — which
+   answers the four-year-old blocker on the issue — and it inherits the user's whole
+   `~/.ssh/config`: `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match`
+   blocks, 2FA. `ssh -G` tells us what it is about to forward, so nothing is guessed.
+4. **Five flags, all `--ssh-*`.** No generic `--tunnel-command` in v1 (§12), no
+   `--ssh-user`/`--ssh-port`/`--ssh-identity` — those are `ssh_config` spelled twice.
+5. **The tunnel comes up before Textual does**, so a passphrase or 2FA prompt can reach a
+   human — and it is a child process, not `ssh -f`, so it dies with the session instead of
+   outliving it.
 
 What core owns is the **lifecycle**: bring the forward up before anything connects, report
-what went wrong in the two commands' own error paths, tear it down on exit. That is the
-whole of the feature.
+what went wrong in the two commands' own error paths, tear it down on exit. That is the whole
+of the feature.
 
 ---
 
@@ -42,47 +39,43 @@ whole of the feature.
 > configuring an ssh tunnel, and then intercept/rewrite the host/port/etc options passed
 > through to the adapter.
 
-Two later comments matter:
+The maintainer's blocker (Feb 2025) was dependencies: `sshtunnel` looks perfect and has not
+shipped in four years; paramiko was offered in reply as the maintained thing underneath it.
+This design needs neither.
 
-- The maintainer's blocker (Feb 2025): `sshtunnel` looks perfect and has not shipped in four
-  years. paramiko was offered in reply as the maintained thing underneath it.
-- A request for **Cloud SQL**, which is not SSH at all. It is the reason the abstraction here
-  is "a subprocess that makes a remote endpoint reachable locally", with SSH as one instance.
-
-**The rewrite half of the issue is what this design drops.** §12 has the reasoning; the short
-version is that intercepting connection details means core guessing which of an adapter's
-options is a host, and guessing wrong quietly.
+**The rewrite half of the issue is what it drops.** §12 has the reasoning; the short version
+is that intercepting connection details means core guessing which of an adapter's options is
+a host, and guessing wrong quietly.
 
 ## 2. Ten seconds of SSH, for the rest of this document
 
 | | |
 |---|---|
-| `-L 5439:redshift.internal:5439` | **local forward.** Listen on `127.0.0.1:5439` here; anything that connects is carried over the SSH connection and delivered to `redshift.internal:5439` **as resolved by the SSH host**. |
-| `LocalForward 5439 redshift.internal:5439` | The same thing, written in `~/.ssh/config` under a `Host` block instead of on the command line. |
+| `-L 15439:redshift.internal:5439` | **local forward.** Listen on `127.0.0.1:15439` here; anything that connects is carried over the SSH connection and delivered to `redshift.internal:5439` **as resolved by the SSH host**. |
+| `LocalForward 15439 redshift.internal:5439` | The same directive, written in `~/.ssh/config` under a `Host` block instead of on the command line. |
 | `-N` | Don't run a remote command. "I am here for the forwards." |
 | `-f` | Fork into the background once the forwards are up. |
 | `-J`, `ProxyJump` | Reach the destination through another SSH host first. Chains. |
-| `-o KEY=VALUE` | Set any `ssh_config` keyword for this invocation. |
-| `-o ExitOnForwardFailure=yes` | If a forward can't be set up (port already in use, remote refuses), exit instead of connecting anyway. |
-| `ssh -G host` | Print the resolved config for `host` — every `Host`/`Match` block applied — and connect to nothing. |
+| `-o KEY=VALUE` | Set any `ssh_config` keyword for this invocation. Beats the config file. |
+| `-o ExitOnForwardFailure=yes` | If a forward can't be set up, exit instead of connecting anyway. |
+| `ssh -G host` | Print the resolved config — every `Host`/`Match` block applied, plus any flags on this command line — and connect to nothing. |
 
 **`ssh -fN redshift_prod` and `ssh -L …` are not alternatives.** The forward in that command
-is real, it is just written down somewhere else: a `Host redshift_prod` block in
-`~/.ssh/config` with a `LocalForward` line in it. `-f` and `-N` say *how to run*; `-L` and
-`LocalForward` say *what to forward*, and they are the same directive in two places.
+is real; it is just written down somewhere else. `-f` and `-N` say *how to run*; `-L` and
+`LocalForward` say *what to forward*, and they are one directive in two places.
 
-This matters for the design: **a user who already tunnels probably has the forward in their
-ssh config**, and asking them to repeat it on Harlequin's command line would be a step
-backwards. So `--ssh-forward` is optional, and §4.1 is the case where it is not used at all.
+That matters here: **a user who already tunnels has the forward in their ssh config**, and
+asking them to repeat it on Harlequin's command line would be a step backwards. `--ssh-forward`
+is optional, and §4.1 — the motivating case — never uses it.
 
 ## 3. The model
 
 ```
-   --ssh-host redshift_prod    ───────►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
-                                         (the -L comes from ~/.ssh/config)
+   ssh_host = "redshift_prod"    ───────►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
+                                           (the -L comes from ~/.ssh/config)
 
-   -a postgres                            adapter dials 127.0.0.1:15439
-   "postgresql://tco@localhost:15439/prod" the local end of `LocalForward 15439 …:5439`
+   -a postgres                             adapter dials 127.0.0.1:15439
+   host = "localhost", port = 15439        the local end of `LocalForward 15439 …:5439`
 ```
 
 One rule, and it is the whole contract:
@@ -90,24 +83,15 @@ One rule, and it is the whole contract:
 **The connection details name the local end of the forward.** Harlequin runs the tunnel and
 touches nothing else.
 
-That is it. In the config behind that example (§4.1) the forward is `LocalForward 15439 <redshift>:5439`, so the
-local end is `localhost:15439` and that is what the profile says — the ports differ, and
-nothing in Harlequin needs to know or care. The far side's address appears once, in the ssh
-config, where it already was.
-
-"Give the address as the SSH host sees it" is a useful mnemonic for the `--ssh-forward 5432`
-shorthand below, where the local and remote ports match. It is not the rule. The rule is the
-local end.
+In the config behind that example (§4.1) the forward is `LocalForward 15439 <redshift>:5439`,
+so the local end is `localhost:15439` and that is what the profile says. The ports differ,
+and nothing in Harlequin needs to know or care. The far side's address appears once, in the
+ssh config, where it already was.
 
 Nothing is rewritten. `conn_str` and every adapter option reach the adapter exactly as the
 user wrote them, and the adapter is never told a tunnel exists.
 
-The forward can come from either place, and Harlequin does not care which:
-
-| where | how |
-|---|---|
-| `~/.ssh/config` | a `LocalForward` line in the `Host` block. Harlequin passes no `-L`. |
-| Harlequin | `--ssh-forward`, repeatable, in one of three forms below |
+When the forward is *not* already in the ssh config, `--ssh-forward` writes one:
 
 | `--ssh-forward` | becomes | |
 |---|---|---|
@@ -115,40 +99,31 @@ The forward can come from either place, and Harlequin does not care which:
 | `db.internal:5439` | `-L 127.0.0.1:5439:db.internal:5439` | shorthand: same port on both ends |
 | `5432` | `-L 127.0.0.1:5432:localhost:5432` | shorthand: the database runs on the SSH host |
 
-**The docs should recommend a distinct local port**, as the config above does with `15439`.
-It sidesteps the collision case entirely, and it is most of the mitigation for the hazard
-below: nothing else on a developer's laptop is listening on 15439, so a profile run without
-its tunnel fails to connect instead of quietly reaching a local database on 5432.
+**The docs should recommend a distinct local port**, as the config in §4.1 does with `15439`.
+It sidesteps the collision case, and it is most of the mitigation for the hazard below:
+nothing else on a developer's laptop listens on 15439, so a profile run without its tunnel
+fails to connect instead of quietly reaching a local database on 5432.
 
 ### What this model gives up, and what it buys
 
-A local port collision is a **hard error**, not a workaround: `ExitOnForwardFailure=yes` means
-`ssh` exits saying `bind: Address already in use`, and the user picks a local port with the
-three-part form. That is the honest failure; quietly binding somewhere else is the failure
-mode that makes people distrust the feature. (§13 asks whether an already-listening port
-should instead be taken as "the tunnel is already up" — it is the one case where this bites a
-user who does what our own reader did for years.)
+A local port that is already bound is a **hard error** (§5.2), not a workaround.
 
 What it buys, beyond not guessing:
 
 - **TLS still works the way the user asked for it.** Nothing silently changes the hostname the
   driver validates against.
-- **`connection_id` and the catalog cache key stay stable across runs** (§7), because no
-  ephemeral port lands in the config the hash is taken over.
+- **`connection_id` and the catalog cache key stay stable across runs** (§7): no ephemeral
+  port lands in the config the hash is taken over.
 - **DuckDB and SQLite need no special case.** They ignore the tunnel; a duckdb `ATTACH` of
-  `postgres://localhost:5432/app` goes through it like anything else.
+  `postgres://localhost:15439/prod` goes through it like anything else.
 
 ### The hazard this model does have
 
 A profile that says `host = "localhost"` is only correct with the tunnel up. Run it without
-`ssh_host` and it connects to whatever is on **your** machine at that port — which, if the
-forward uses the database's own port number, may well be a database, just the wrong one. A
-distinct local port makes this a connection refused instead.
-
-The `ssh_*` keys live in the same profile as the connection details, so they travel together
-and the failure needs someone to have deliberately overridden one; the start-up notice (§6)
-says what was forwarded. If it proves to bite, a `require_tunnel = true` profile key can
-refuse to connect without one. Not proposed for v1.
+`ssh_host` and it reaches whatever is on your machine at that port — which, if the forward
+uses the database's own port number, may be a database, just the wrong one. A distinct local
+port makes it a connection refused instead, and the `ssh_*` keys live in the same profile as
+the connection details, so they travel together.
 
 ## 4. Worked examples
 
@@ -178,9 +153,9 @@ ssh_host = "redshift_prod"
 ```
 
 `harlequin -P redshift`, and `hsql -P redshift -c "select 1"`. **One key.** No
-`--ssh-forward`, no `--ssh-user`, no `--ssh-identity`, no keepalive settings — the `Host`
-block says all of it, and Harlequin runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`.
-The connection details are exactly the ones that work today.
+`--ssh-forward`, no user, no identity file, no keepalive settings — the `Host` block says all
+of it, and Harlequin runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`. The connection
+details are exactly the ones that work today.
 
 Note the ports: local `15439`, remote `5439`. The profile names the **local** end, which is
 the only thing the contract says.
@@ -194,8 +169,8 @@ hsql -a postgres --host localhost --port 15439 --dbname prod \
      -c "select 1"
 ```
 
-The advice in the docs will be to write the `Host` block instead and go back to 4.1 — but
-this works, and it is what an agent or a CI job with no dotfiles has to do.
+The docs' advice will be to write the `Host` block instead and go back to 4.1 — but this
+works, and it is what an agent or a CI job with no dotfiles has to do.
 
 ### 4.3 Postgres running on the bastion itself
 
@@ -203,8 +178,7 @@ this works, and it is what an agent or a CI job with no dotfiles has to do.
 harlequin -a postgres --host localhost --port 5432 --ssh-host bastion --ssh-forward 5432
 ```
 
-`--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`: the short form exists because
-this is the most common shape.
+`--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`.
 
 ### 4.4 You already run a local Postgres on 5432
 
@@ -219,9 +193,9 @@ The two ports agree because the user wrote both. Nothing infers anything.
 
 ```bash
 harlequin -a postgres --ssh-host bastion \
-          --ssh-forward 5432:pg.internal:5432 \
-          --ssh-forward 15432:analytics.internal:5432 \
-          "postgresql://me@localhost:5432/app" "postgresql://me@localhost:15432/analytics"
+          --ssh-forward 15432:pg.internal:5432 \
+          --ssh-forward 15433:analytics.internal:5432 \
+          "postgresql://me@localhost:15432/app" "postgresql://me@localhost:15433/analytics"
 ```
 
 One `ssh` child, two `-L`s.
@@ -232,72 +206,82 @@ Nothing new. `ProxyJump jump.example.com` in the `Host` block, or
 `--ssh-option ProxyJump=jump.example.com`. Chains of three work because `ssh` does them, not
 because we do.
 
-### 4.7 Cloud SQL — the request from the issue thread
+### 4.7 Cloud SQL and other proxies — works, but Harlequin does not run them
 
-```toml
-[profiles.cloudsql]
-adapter = "mysql"
-host = "127.0.0.1"
-port = 3306
-database = "app"
-tunnel_command = "cloud-sql-proxy --port 3306 my-proj:us-central1:my-instance"
-tunnel_port = [3306]
+The issue thread asks for Cloud SQL, which is not SSH. In v1 the user runs the proxy
+themselves and points at its local port:
+
+```bash
+cloud-sql-proxy --port 3306 my-proj:us-central1:my-instance &
+hsql -a mysql --host 127.0.0.1 --port 3306 --database app -c "select 1"
 ```
 
-Also `kubectl port-forward svc/pg 5432:5432`, `aws ssm start-session … localPortNumber=5432`,
-`tsh proxy db --port 5432 …`. Same lifecycle, same readiness poll, same teardown.
+That already works, and it works *because of* the contract in §3 — the details name a local
+endpoint and Harlequin does not care what is behind it. What v1 does not do is manage that
+process's lifetime the way it manages `ssh`'s. §12 says why that is deferred rather than
+refused.
 
 ### 4.8 A key with a passphrase, or 2FA
 
 ```
 $ hsql -P redshift -c "select count(*) from events"
 Enter passphrase for key '/home/tco/.ssh/id_ed25519':
-tunnel: 127.0.0.1:15439 -> data-analytics…:5439 via ssh redshift_prod
+ssh: 127.0.0.1:15439 -> data-analytics…:5439 via redshift_prod
 ```
 
-The prompt is `ssh`'s, on the real terminal, because the child is started before Textual (in
-the IDE) and before any output (in `hsql`). An agent running `hsql` unattended uses a key
-with no passphrase or an agent, exactly as it would for `ssh` itself.
+The prompt is `ssh`'s, on the real terminal, because the child starts before Textual (in the
+IDE) and before any output (in `hsql`). An agent running `hsql` unattended uses a key with no
+passphrase or an agent, exactly as it would for `ssh` itself.
 
 ### 4.9 Something that is not tunneled
 
 `harlequin my.db`, `hsql -a postgres --host prod.example.com …`. No `ssh_host`, no
-`tunnel_command`, no `harlequin.tunnel` import, no cost.
+`harlequin.ssh` import, no cost.
 
 ## 5. The forwarder
 
-```python
-class Tunnel(ABC):
-    """A child process that makes remote endpoints reachable on localhost."""
+`harlequin/ssh.py`, one class:
 
-    @abstractmethod
+```python
+class SshTunnel:
+    """An `ssh` child process holding one or more local forwards open."""
+
     def start(self) -> None:
         """Start it and block until the forwarded ports accept connections.
-        Raises HarlequinTunnelError, quoting the child's stderr."""
+        Raises HarlequinSshError, quoting ssh's stderr."""
 
     def stop(self) -> None: ...
-    def __enter__(self) -> Tunnel: ...
+    def __enter__(self) -> SshTunnel: ...
     def __exit__(self, *exc: Any) -> None: self.stop()
 ```
-
-One implementation, `SubprocessTunnel`. The SSH options build an argv; `--tunnel-command` is
-`shlex.split()` of what the user wrote. Everything after that is shared.
 
 - **Foreground, not `-f`.** The child keeps the terminal, so prompts reach the human, and we
   keep the handle, so it can be killed. `ssh -fN` backgrounds itself and outlives the
   session — which is why the manual workflow needs a `kill` afterwards and this does not.
-- **Readiness** is a connect-poll against each known local port until `--tunnel-timeout`
-  (default 10s), which also notices the child exiting early. On failure the error quotes the
-  child's stderr verbatim, because `ssh`'s diagnostics are better than any we would write.
-- **Which ports to poll comes from `ssh -G`**, §5.1.
+- **Readiness** is a connect-poll against each local port `ssh -G` reported (§5.1) until
+  `--ssh-timeout` (default 10s), which also notices the child exiting early. On failure the
+  error quotes ssh's stderr verbatim: its diagnostics are better than any we would write.
+- **The only `-o` Harlequin imposes is `ExitOnForwardFailure=yes`**, because a forward that
+  silently did not happen is the one failure a user cannot diagnose. Notably *not* imposed:
+  `ServerAliveInterval`. A command-line `-o` beats the config file, and keepalives are exactly
+  what a working `Host` block already sets (§4.1 sets them) — overriding would be Harlequin
+  quietly retuning someone else's connection. The docs say to set them in the `Host` block;
+  `--ssh-option` is there for anyone who wants to anyway.
 - **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
   `tui.run()` and the `hsql` run, plus an `atexit` backstop.
+- **No reconnect in v1, but the IDE says when the tunnel dies.** A thread waiting on the child
+  posts a notification when it exits, so a session whose forward dropped shows
+  `tunnel closed: <ssh's last line>` rather than an unexplained wall of query errors. `hsql`
+  is short-lived enough that the adapter's own connection error is the whole story.
+
+The `Tunnel` ABC an earlier draft proposed is not in v1. One implementation does not need an
+abstract base; the second one (§9, §12) is when it earns itself.
 
 ### 5.1 Asking `ssh` what it is about to forward
 
 In the 4.1 shape the forward lives in `ssh_config`, so Harlequin does not know the port it
-should be polling. `ssh -G` answers that: it applies every `Host` and `Match` block, prints
-the resolved configuration, and connects to nothing. Confirmed against the motivating config:
+should poll. `ssh -G` answers that: it applies every `Host` and `Match` block, prints the
+resolved configuration, and connects to nothing. Verified against the motivating config:
 
 ```
 $ ssh -G redshift_prod | grep -i forward
@@ -305,10 +289,10 @@ localforward 15439 [data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com]:
 ```
 
 **Probe with the argv we are about to run**, not with the destination alone — `ssh -G` echoes
-back command-line `-L` and `-o` flags along with the config's, so
+command-line `-L` and `-o` flags back along with the config's, so
 
 ```python
-forwards = _parse_forwards(run([*argv_without_N, "-G"]))
+forwards = _parse_forwards(run([*argv, "-G"]))
 ```
 
 gives one list whether the forward came from `--ssh-forward`, from a `Host` block, or from
@@ -316,79 +300,58 @@ both. There is no "config forwards" path and "flag forwards" path to keep in agr
 because `ssh` merges them before we look.
 
 Parsing is two whitespace-separated fields after the keyword, each `port`, `[host]:port`, or a
-unix socket path; brackets are how it writes a host, and they make IPv6 unambiguous. A
-`localforward` whose listen side is a socket path counts as a forward but is not polled.
-`dynamicforward` (SOCKS) and `remoteforward` are not forwards this feature can use — see the
-error below.
+unix socket path; the brackets are how `ssh` writes a host, and they make IPv6 unambiguous. A
+forward whose listen side is a socket path counts as a forward but is not polled.
 
-Three things now have an exact answer instead of a guess:
+Three things get an exact answer instead of a guess:
 
 - **The readiness poll** watches the real local ports.
-- **`--ssh-host` that forwards nothing** is a usage error, and it can say what it found:
+- **`--ssh-host` that forwards nothing** is a usage error that can say what it found:
   `redshift_prod resolves no LocalForward; add one to your Host block or pass --ssh-forward`
-  — with a distinct message when the config has a `DynamicForward` instead, since that is a
-  working SOCKS proxy the adapter cannot use.
-- **The notice and the cache key** can name the far side even when Harlequin never saw it.
+  — with a distinct message when the config has a `DynamicForward` (SOCKS) instead, which is a
+  working tunnel the adapter cannot use.
+- **The notice and the cache key** can name the far side even though Harlequin never saw it.
 
-`ssh -G` costs one subprocess (~10-30ms, no network) on invocations that tunnel, and nothing
-on the ones that do not. If it exits non-zero or prints something this cannot parse,
-Harlequin degrades rather than fails: no poll, no forwards-nothing error, a short grace
-period, and the adapter's own connection is the test.
+`ssh -G` costs one subprocess (~10–30ms, no network) on invocations that tunnel, and nothing
+on the ones that do not. If it exits non-zero or prints something this cannot parse, Harlequin
+degrades rather than fails: no poll, no forwards-nothing error, a short grace period, and the
+adapter's own connection is the test.
 
 ### 5.2 A local port that is already bound
 
 The default is to **fail**: `ExitOnForwardFailure=yes` means `ssh` exits with
 `bind: Address already in use`, and Harlequin reports it. A port that is already answering is
-not evidence that the right tunnel is behind it, and connecting to the wrong database because
+not evidence that the right tunnel is behind it, and reaching the wrong database because
 something else happened to be on 15439 is worse than an error at start-up.
 
-`--tunnel-reuse` (`tunnel_reuse = true`) opts into the other behavior, for the person who
-keeps a `ssh -fN redshift_prod` running all day and does not want Harlequin fighting it: if
-**every** local port `ssh -G` reported is already accepting connections, skip the child
-entirely and say so.
+`--ssh-reuse` (`ssh_reuse = true`) opts into the other behavior, for the person who keeps
+`ssh -fN redshift_prod` running all day and does not want Harlequin fighting it: if **every**
+local port `ssh -G` reported is already accepting connections, skip the child and say so.
 
 ```
-tunnel: 127.0.0.1:15439 already listening; reusing (--tunnel-reuse)
+ssh: 127.0.0.1:15439 already listening; reusing (--ssh-reuse)
 ```
 
-If only some of them answer, that is a half-open state nobody meant, and it is an error
-naming the ports either way.
-
-- **The only `-o` Harlequin imposes is `ExitOnForwardFailure=yes`**, and only because a
-  forward that silently did not happen is the one failure the user cannot diagnose. Notably
-  *not* imposed: `ServerAliveInterval`. A command-line `-o` beats the user's config file, and
-  keepalives are exactly the sort of thing a working `Host` block already sets — overriding
-  them would be Harlequin quietly retuning a connection someone else configured. The docs say
-  to set them in the `Host` block; `--ssh-option` is there for anyone who wants to anyway.
-- **No reconnect in v1, but the IDE says when the tunnel dies.** A thread waiting on the
-  child posts a notification when it exits, so a session whose forward dropped shows
-  `tunnel closed: <ssh's last line>` rather than an unexplained wall of query errors. `hsql`
-  is short-lived enough that the adapter's own connection error is the whole story.
+If only some of them answer, that is a half-open state nobody meant, and it is an error naming
+the ports either way.
 
 ## 6. The CLI and config surface
 
 New options on **both** commands. A profile serves both, and `hsql` is where this matters
 most: a cron job or an agent cannot ask a human to run `ssh -fN` in another terminal first.
 
-| option | meaning |
-|---|---|
-| `--ssh-host TEXT` | `[user@]host[:port]`, or a `Host` alias from `~/.ssh/config` |
-| `--ssh-forward TEXT` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT`. Omit when `ssh_config` has it |
-| `--ssh-option KEY=VALUE` | repeatable `-o`; `IdentityFile`, `ProxyJump`, `User`, anything |
-| `--tunnel-command TEXT` | §4.7; mutually exclusive with `--ssh-host` |
-| `--tunnel-port INT` | repeatable; ports the readiness poll waits for |
-| `--tunnel-timeout FLOAT` | seconds to wait (default 10) |
-| `--tunnel-reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
+| option | profile key | meaning |
+|---|---|---|
+| `--ssh-host TEXT` | `ssh_host` | `[user@]host[:port]`, or a `Host` alias from `~/.ssh/config` |
+| `--ssh-forward TEXT` | `ssh_forward` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT`. Omit when `ssh_config` has it |
+| `--ssh-option KEY=VALUE` | `ssh_option` | repeatable `-o`; `IdentityFile`, `ProxyJump`, `User`, anything |
+| `--ssh-reuse` | `ssh_reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
+| `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
-Three SSH flags, not nine. An earlier draft had `--ssh-user`, `--ssh-port`, `--ssh-identity`
-and more; every one of them is `ssh_config` or `-o` spelled twice, and the docs' advice is to
-write a `Host` block, which is reusable outside Harlequin and is where a user's `ProxyJump`,
-certificate and `Match` rules already live.
-
-`--ssh-host` with neither `--ssh-forward` nor a `LocalForward` in its resolved config is a
-usage error naming both places — a tunnel that forwards nothing is always a mistake, and it is
-better caught before an SSH handshake than after one. `ssh -G` is what makes the check real
-(§5.1).
+Five flags. An earlier draft had nine, including `--ssh-user`, `--ssh-port` and
+`--ssh-identity`; every one of those is `ssh_config` or `-o` spelled a second time, and the
+docs' advice is to write a `Host` block — reusable outside Harlequin, and where a user's
+`ProxyJump`, certificate and `Match` rules already live.
 
 No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
 for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
@@ -399,45 +362,46 @@ missing today.
 `first_pass.attach_adapter_options()`. Worth a survey of published adapters before merging; I
 know of none that claims one.
 
-**The start-up notice.** `hsql` on stderr (never stdout — that belongs to query output), the
-IDE as a notification and on the debug screen:
+**The start-up notice**, on `hsql`'s stderr (never stdout — that belongs to query output) and
+as an IDE notification and debug-screen line:
 
 ```
-tunnel: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 via ssh redshift_prod
+ssh: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 via redshift_prod
 ```
 
 One line, and it is what tells a user which database they are actually looking at.
 
 ### 6.1 A config file must not be able to run a command
 
-This is the one place the feature can make Harlequin *less* safe, and it is why SSH keeps its
-own flags rather than collapsing into `--tunnel-command`.
-
 Config files are discovered in the **working directory**, including `pyproject.toml`. Clone a
 repository, run `harlequin` in it, and today the worst a hostile config can do is name a
-database. With `tunnel_command`, it would run a shell command. The same is true of
-`ssh_option`, because `ProxyCommand=…` is a command.
+database.
 
-Proposed rule: **`tunnel_command` and `ssh_option` are honored only from the user's own
-config** — an explicit `--config-path`, the user config dir, or `$HOME` — and from the command
-line. A profile supplied by a file found in the working directory that sets either one is a
-config error naming the file. `config.py` already tracks which file supplied each profile
-(`Provenance`), so the check has the information it needs. `ssh_host` and `ssh_forward` are
-names and ports, not commands, and stay allowed everywhere.
+Four of the five keys above are names, ports and a flag. `ssh_option` is not: `-o
+ProxyCommand=…` runs a command, and so does `LocalCommand` with `PermitLocalCommand`.
+
+Proposed rule: **`ssh_option` is honored only from the user's own config** — an explicit
+`--config-path`, the user config dir, or `$HOME` — and from the command line. A profile
+supplied by a file found in the working directory that sets it is a config error naming the
+file. `config.py` already tracks which file supplied each profile (`Provenance`), so the check
+has what it needs.
+
+This is also the reason a general "run this command" option is a bigger decision than it
+looks, and part of why there isn't one in v1 (§12).
 
 ## 7. Ordering, cache keys, and the two commands
 
 ```
-first_pass -> click parses -> profile merge -> Tunnel.start()   <-- prompts happen HERE
+first_pass -> click parses -> profile merge -> SshTunnel.start()   <-- prompts happen HERE
                                                      |
                                         adapter_cls(...) -> tui.run() / hsql runs
                                                      |
-                                              ExitStack unwinds -> Tunnel.stop()
+                                              ExitStack unwinds -> stop()
 ```
 
 The IDE opens its database on a worker thread after the app is running, which is right for a
 database and wrong for a tunnel: once Textual owns the terminal, `ssh` cannot ask for a
-passphrase and a 2FA push has nowhere to print "check your phone". Starting the tunnel in the
+passphrase and a 2FA push has nowhere to print "check your phone". Starting the child in the
 click callback also means one error path for both commands — `pretty_print_error` /
 `diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) — before a widget is mounted.
 
@@ -446,14 +410,14 @@ every CLI that tunnels does and what a user who configured one expects.
 
 **Cache keys need one small change.** Nothing is rewritten, so `get_connection_hash()` and
 `adapter.connection_id` are already stable across runs — but two bastions fronting two
-databases both look like `localhost:5439`, and would share a catalog cache and a query
-history. The ssh destination and the forward specs join the hashed material.
+databases both look like `localhost:15439`, and would share a catalog cache and a query
+history. The ssh destination and the resolved forwards join the hashed material.
 
 ## 8. Public API impact
 
 **None.** No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`,
-`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinTunnelError(HarlequinError)`
-in `exception.py`, and one new module, `harlequin/tunnel.py`.
+`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinSshError(HarlequinError)` in
+`exception.py`, and one new module, `harlequin/ssh.py`.
 
 That an adapter cannot tell it is tunneled is not an accident — it is the property being
 bought, and it is why this works for adapters nobody in this org maintains.
@@ -462,20 +426,17 @@ bought, and it is why this works for adapters nobody in this org maintains.
 
 **v1 adds no dependency at all**: `subprocess`, `socket`, `shlex`.
 
-`harlequin/tunnel.py` imports no Textual and no adapter, and joins the "adapter API is
-reachable without the TUI" import-linter contract. It is imported from the CLI callbacks only
-when a tunnel was asked for, so 4.9 pays nothing — `scripts/cold_start.py` should show no
-change.
+`harlequin/ssh.py` imports no Textual and no adapter, and joins the "adapter API is reachable
+without the TUI" import-linter contract. It is imported from the CLI callbacks only when
+`ssh_host` is set, so 4.9 pays nothing — `scripts/cold_start.py` should show no change.
 
-**When paramiko would earn its place** — as `harlequin[ssh]`, a second `Tunnel`
-implementation, nothing else changing:
+**When paramiko would earn its place** — as `harlequin[ssh]`, a second implementation behind
+whatever interface the two then share:
 
 - Windows users without OpenSSH. It ships with Windows 10+, but is removable.
 - Containers: this repo's own dev container has no `ssh` binary, and neither does the
   `python:3.x-slim` image most people build on.
-- Anything wanting in-process sockets rather than a listener — the shape Google's Cloud SQL
-  *connector* (as opposed to its proxy binary) wants, and the one thing `--tunnel-command`
-  cannot express.
+- In-process sockets rather than a listener — the shape Google's Cloud SQL *connector* wants.
 
 Until one of those has a user asking, the argument on the issue stands: an unmaintained
 wrapper is not worth taking, and a maintained one is still a `cryptography` dependency on
@@ -483,40 +444,41 @@ every Harlequin install, to solve a problem `ssh` already solves on the same mac
 
 ## 10. Testing
 
-**End to end, no SSH server, no `online` marker.** `--tunnel-command` makes the whole
-lifecycle testable with a Python child as the forwarder:
+No SSH server, and no `online` marker.
+
+**Lifecycle, all three OSes.** `SshTunnel` takes an argv and a list of ports, so a test can
+hand it a Python child instead of `ssh`:
 
 ```python
---tunnel-command "{sys.executable} -m tests.tcp_forward 5432 127.0.0.1 {real_port}"
---tunnel-port 5432
+SshTunnel(argv=[sys.executable, "-m", "tests.tcp_forward", "15439", "127.0.0.1", str(port)],
+          ports=[15439])
 ```
 
-A ~30-line loopback TCP forwarder in `tests/`, a stub server on the far side, and the test
-asserts that the adapter reached through it, that the readiness poll waited, and that the
-child is dead once the command exits. Runs on all three OSes and needs no secrets.
+A ~30-line loopback TCP forwarder in `tests/` and a stub server on the far side cover start,
+poll, reuse, timeout, the death notification, and teardown.
 
-**Unit, no network:**
+**End to end, Unix.** A fake `ssh` on `PATH` — a Python script that understands `-G` and `-L`
+well enough to print a `localforward` line and then forward — exercises the real CLI path
+including the `-G` probe. Skipped on Windows, where the lifecycle tests above are the
+coverage.
+
+**Unit, no processes:**
 
 | case | expected |
 |---|---|
 | `--ssh-forward 5432` | argv contains `-L 127.0.0.1:5432:localhost:5432` |
-| `--ssh-forward db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` |
-| `--ssh-forward 15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` |
+| `--ssh-forward db.internal:5439` | `-L 127.0.0.1:5439:db.internal:5439` |
+| `--ssh-forward 15439:db.internal:5439` | `-L 127.0.0.1:15439:db.internal:5439` |
 | `--ssh-forward` repeated | one child, two `-L` |
-| `--ssh-host` alone, `-G` reports a `localforward` | argv has no `-L`, poll watches that port |
-| `-G` output `localforward 15439 [host]:5439` | parsed as local 15439, remote host:5439 |
-| `-G` output with a bind address, IPv6, a socket path | parsed; the socket path is not polled |
+| `-G` line `localforward 15439 [host]:5439` | local 15439, remote host:5439 |
+| `-G` with a bind address, IPv6, a socket path | parsed; the socket path is not polled |
 | `-G` reports only `dynamicforward` | usage error, distinct message |
 | `-G` exits non-zero or prints garbage | no poll, no forwards-nothing error, still starts |
 | `--ssh-host` alone, no forward anywhere | usage error naming both places |
-| port bound, no `--tunnel-reuse` | ssh's `bind: Address already in use`, exit 3 |
-| port bound, `--tunnel-reuse` | no child started, notice printed, adapter connects |
-| two ports, one bound, `--tunnel-reuse` | error naming both |
-| `--ssh-host` and `--tunnel-command` | usage error, exit 2 |
 | a garbage forward spec | usage error naming the three forms |
-| `tunnel_command` from a cwd-discovered config | config error naming the file (§6.1) |
-| child exits during the poll | `HarlequinTunnelError` quoting its stderr, exit 3 |
-| poll times out | ditto, naming `--tunnel-timeout` |
+| `ssh_option` from a cwd-discovered config | config error naming the file (§6.1) |
+| child exits during the poll | `HarlequinSshError` quoting its stderr, exit 3 |
+| poll times out | ditto, naming `--ssh-timeout` |
 | profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
 | cache key | two ssh hosts, same conn_str, two different hashes |
 
@@ -525,12 +487,13 @@ client where one exists.
 
 ## 11. Phasing
 
-1. **`harlequin/tunnel.py`** — the `Tunnel` ABC, `SubprocessTunnel`, argv construction, the
-   readiness poll, `HarlequinTunnelError`. Unit tests only; no CLI. Mergeable alone.
-2. **Wire it into both commands** — the options, the `ExitStack`, the notice, the cache-key
-   change, the §6.1 provenance rule, and the loopback end-to-end test.
-3. **`--tunnel-command`**, `--info` / debug-screen reporting, regenerated config schema.
-4. **Docs** in `tconbeer/harlequin-web`: the "details are the far side's" contract, and the
+1. **`harlequin/ssh.py`** — `SshTunnel`, argv construction, the `-G` probe and parser, the
+   readiness poll, `HarlequinSshError`. Unit and lifecycle tests; no CLI. Mergeable alone.
+2. **Wire it into both commands** — the five options, the `ExitStack`, the notice, the
+   cache-key change, the §6.1 provenance rule, and the end-to-end test.
+3. **`--info` / debug-screen reporting**, the IDE's tunnel-died notification, regenerated
+   config schema.
+4. **Docs** in `tconbeer/harlequin-web`: the "details name the local end" contract, and the
    `Host` block as the recommended way to configure a tunnel. Plus a `CHANGELOG.md` entry
    under `[Unreleased]` → Features, referencing
    [#545](https://github.com/tconbeer/harlequin/issues/545).
@@ -539,8 +502,8 @@ client where one exists.
 
 | | why not |
 |---|---|
-| **Rewriting the adapter's host/port** (the issue's original sketch, and an earlier draft of this doc) | Core has to know which option is the host, and there is no general answer: a new `role=` declaration no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
-| **Only `--tunnel-command`, with SSH as one way to spell it** | Mechanically correct — `--tunnel-command 'ssh -N redshift_prod'` is the whole feature. Rejected for §6.1: a name in a config file is safe and a command is not, and the safety rule is only writable if the two are different keys. The ergonomics are the secondary argument: `ssh_host` needs no quoting, survives a Windows shell, and is what someone looks for in `--help`. |
+| **Rewriting the adapter's host/port** (the issue's original sketch, and the first draft of this doc) | Core has to know which option is the host, and there is no general answer: a new `role=` declaration no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
+| **A generic `--tunnel-command`** (`cloud-sql-proxy`, `aws ssm`, `kubectl port-forward`, Teleport) | Deferred, not refused. It is ~30 lines over `SshTunnel` and it is the natural home for the Cloud SQL request — but it is a "run this string" option, which needs the §6.1 rule to be airtight before it ships, and 4.7 already works without Harlequin managing the process. Nothing in v1 forecloses it: the flags are namespaced `--ssh-*` precisely so a `--tunnel-*` family can arrive beside them. |
 | **A `{tunnel_port}` placeholder** the user writes into their conn_str | General and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable *without* the tunnel rather than merely wrong. |
 | **A SOCKS proxy (`ssh -D`) with `socket.socket` patched** | The one design where the driver keeps the real hostname, so TLS verification is untouched. It only works for pure-Python drivers: psycopg2, mysqlclient, ODBC and duckdb's extensions open sockets in C and never see Python's `socket` module. |
 | **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings, and the adapters that need it most are out-of-tree. |
@@ -551,20 +514,20 @@ client where one exists.
 
 ## 13. Settled in review
 
-- **`ssh -G` reports `localforward`**, verified against the config in §4.1:
-  `localforward 15439 [data-analytics.…:5439`. The readiness poll, the forwards-nothing
-  error and the notice all lean on it, with a documented degradation for output it cannot
-  parse (§5.1).
-- **A bound local port fails.** `--tunnel-reuse` is the opt-in for reusing a tunnel someone
-  else started (§5.2).
+- **No rewriting of connection details.** They name the local end of the forward (§3).
+- **`ssh -G` reports `localforward`**, verified against the config in §4.1, so the readiness
+  poll and the forwards-nothing error are exact (§5.1).
+- **A bound local port fails**; `--ssh-reuse` is the opt-in (§5.2).
+- **Every option starts with `ssh`.** Five of them.
+- **No `--tunnel-command` in v1**, and no `require_tunnel` profile key.
 
 ## 14. Open questions for review
 
-1. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
-   `0.0.0.0` would expose the far side's database to the user's network, which seems like a
-   thing to make people ask for.
-2. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait
-   for someone to be bitten?
-3. **Naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one splits
-   `--tunnel-timeout` and `--tunnel-reuse` away from their siblings. Alternative: `--ssh-*`
-   everywhere plus `--tunnel-command`, with `--ssh-timeout` and `--ssh-reuse` covering both.
+1. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded
+   for `--ssh-forward`; `0.0.0.0` would expose the far side's database to the user's network,
+   which seems like a thing to make people ask for. (`ssh_config` can already do it, which is
+   an argument for leaving the flag simple.)
+2. **`ssh_option` in a project-local config** — §6.1 proposes refusing it there. The
+   alternative is refusing `ssh_option` from *any* config file, CLI only, which is simpler to
+   explain and to test but would stop someone putting `ProxyJump` in their own
+   `~/.config/harlequin/config.toml`.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -1,142 +1,65 @@
 # SSH tunnels — a design for [#545](https://github.com/tconbeer/harlequin/issues/545)
 
-A proposal for connecting Harlequin and `hsql` to a database that is only reachable through
-an SSH host, **with any adapter, including out-of-tree ones that are never changed**.
+Reach a database through an SSH host, from either command, **with any adapter — including
+out-of-tree ones that are never changed.** Nothing here is implemented yet.
 
-Nothing here is implemented. This is the design to argue with before the first PR.
+## Summary
 
----
+- **Harlequin runs `ssh`; it does not touch connection details.** The user's details already
+  name the local end of a forward. Core never learns which adapter option is the host, never
+  parses a DSN, and adds nothing to the adapter API — which is why every adapter works,
+  including ones nobody in this org maintains.
+- **Four flags, all `--ssh-*`, none of them parsed.** `--ssh-host` and `--ssh-forward` go to
+  `ssh` verbatim. Anything they cannot say goes in a `Host` block, which `--ssh-host` names.
+- **No new dependencies** — the blocker on the issue since 2025 — and the user's whole
+  `~/.ssh/config` comes for free: `LocalForward`, `ProxyJump`, agent, certificates, `Match`.
+- **The tunnel starts before Textual**, so a passphrase or 2FA prompt reaches a human. It is a
+  child process, not `ssh -f`, so it dies with the session instead of outliving it.
 
-## Bottom line up front
-
-1. **Harlequin manages a tunnel; it does not touch connection details.** The user's
-   connection details name the local end of a forward, and that is the whole contract. A
-   profile that works today with `ssh -fN redshift_prod` running in another terminal works
-   unchanged, with one key added.
-2. **That is what makes it work with any adapter.** Core never learns which of an adapter's
-   options is the host, never parses a DSN, and adds nothing to the adapter API. An adapter
-   cannot tell it is tunneled, and one published four years ago works today.
-3. **The forwarder is `ssh`, run as a child process.** **Zero new dependencies** — which
-   answers the four-year-old blocker on the issue — and it inherits the user's whole
-   `~/.ssh/config`: `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match`
-   blocks, 2FA. `ssh -G` tells us what it is about to forward, so nothing is guessed.
-4. **Four flags, all `--ssh-*`, none of them parsed.** `--ssh-host` and `--ssh-forward` go
-   to `ssh` verbatim; the one thing Harlequin parses is `ssh -G`'s *output*. No
-   `--ssh-user`/`--ssh-port`/`--ssh-identity`: those are `ssh_config` spelled twice, and a
-   `Host` block is where a complicated setup belongs — and no `-o` passthrough, so nothing
-   Harlequin reads can hand `ssh` a command to run.
-5. **The tunnel comes up before Textual does**, so a passphrase or 2FA prompt can reach a
-   human — and it is a child process, not `ssh -f`, so it dies with the session instead of
-   outliving it.
-
-What core owns is the **lifecycle**: bring the forward up before anything connects, report
-what went wrong in the two commands' own error paths, tear it down on exit. That is the whole
-of the feature.
-
----
-
-## 1. What the issue asks for
-
-> Need to think through whether this is an adapter feature or a harlequin feature. Maybe
-> it's a library that adapters can use. Would be nice to provide CLI options for
-> configuring an ssh tunnel, and then intercept/rewrite the host/port/etc options passed
-> through to the adapter.
-
-The maintainer's blocker (Feb 2025) was dependencies: `sshtunnel` looks perfect and has not
-shipped in four years; paramiko was offered in reply as the maintained thing underneath it.
-This design needs neither.
-
-**The rewrite half of the issue is what it drops.** §12 has the reasoning; the short version
-is that intercepting connection details means core guessing which of an adapter's options is
-a host, and guessing wrong quietly.
-
-## 2. Ten seconds of SSH, for the rest of this document
+## 1. Ten seconds of SSH
 
 | | |
 |---|---|
-| `-L 15439:redshift.internal:5439` | **local forward.** Listen on `127.0.0.1:15439` here; anything that connects is carried over the SSH connection and delivered to `redshift.internal:5439` **as resolved by the SSH host**. |
-| `LocalForward 15439 redshift.internal:5439` | The same directive, written in `~/.ssh/config` under a `Host` block instead of on the command line. |
-| `-N` | Don't run a remote command. "I am here for the forwards." |
-| `-f` | Fork into the background once the forwards are up. |
-| `-J`, `ProxyJump` | Reach the destination through another SSH host first. Chains. |
-| `-o KEY=VALUE` | Set any `ssh_config` keyword for this invocation. Beats the config file. |
-| `-o ExitOnForwardFailure=yes` | If a forward can't be set up, exit instead of connecting anyway. |
-| `ssh -G host` | Print the resolved config — every `Host`/`Match` block applied, plus any flags on this command line — and connect to nothing. |
+| `-L 15439:redshift.internal:5439` | **local forward.** Listen on `127.0.0.1:15439`; deliver to `redshift.internal:5439` **as resolved by the SSH host**. |
+| `LocalForward 15439 redshift.internal:5439` | the same directive, in a `~/.ssh/config` `Host` block |
+| `-N` | run no remote command; I am here for the forwards |
+| `-f` | fork to the background once the forwards are up |
+| `-o ExitOnForwardFailure=yes` | exit if a forward cannot be set up, rather than connecting anyway |
+| `ssh -G host` | print the resolved config — `Host`/`Match` blocks plus this command line's flags — and connect to nothing |
 
-**`ssh -fN redshift_prod` and `ssh -L …` are not alternatives.** The forward in that command
-is real; it is just written down somewhere else. `-f` and `-N` say *how to run*; `-L` and
-`LocalForward` say *what to forward*, and they are one directive in two places.
+`ssh -fN redshift_prod` and `ssh -L …` are not alternatives. `-f` and `-N` say *how to run*;
+`-L` and `LocalForward` say *what to forward*, and they are one directive in two places. **A
+user who already tunnels has the forward in their ssh config**, so `--ssh-forward` is optional
+and the motivating case (§3.1) never uses it.
 
-That matters here: **a user who already tunnels has the forward in their ssh config**, and
-asking them to repeat it on Harlequin's command line would be a step backwards. `--ssh-forward`
-is optional, and §4.1 — the motivating case — never uses it.
-
-## 3. The model
-
-```
-   ssh_host = "redshift_prod"    ───────►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
-                                           (the -L comes from ~/.ssh/config)
-
-   -a postgres                             adapter dials 127.0.0.1:15439
-   host = "localhost", port = 15439        the local end of `LocalForward 15439 …:5439`
-```
-
-One rule, and it is the whole contract:
+## 2. The contract
 
 **The connection details name the local end of the forward.** Harlequin runs the tunnel and
-touches nothing else.
-
-In the config behind that example (§4.1) the forward is `LocalForward 15439 <redshift>:5439`,
-so the local end is `localhost:15439` and that is what the profile says. The ports differ,
-and nothing in Harlequin needs to know or care. The far side's address appears once, in the
-ssh config, where it already was.
-
-Nothing is rewritten. `conn_str` and every adapter option reach the adapter exactly as the
-user wrote them, and the adapter is never told a tunnel exists.
-
-When the forward is *not* already in the ssh config, `--ssh-forward` writes one. **Its value
-is whatever you would write after `ssh -L`, passed through untouched:**
+touches nothing else. `conn_str` and every adapter option reach the adapter exactly as typed;
+the adapter is never told a tunnel exists.
 
 ```
---ssh-forward 15439:db.internal:5439   ->   ssh -L 15439:db.internal:5439 …
+   ssh_host = "redshift_prod"   ─►  ssh -N -o ExitOnForwardFailure=yes redshift_prod
+                                    (the -L comes from ~/.ssh/config)
+
+   host = "localhost"           ─►  adapter dials 127.0.0.1:15439, the local end of
+   port = 15439                     `LocalForward 15439 …:5439`
 ```
 
-Harlequin defines no shorthands and validates nothing here. `ssh` already documents this
-syntax, already rejects a malformed one with a better message than we would write, and
-already knows what a bare `LOCAL:HOST:PORT` binds. An invented shorthand would be a second
-syntax for users to learn and a parser for us to get wrong.
+Consequences worth naming:
 
-**The docs should recommend a distinct local port**, as the config in §4.1 does with `15439`.
-It sidesteps the collision case, and it is most of the mitigation for the hazard below:
-nothing else on a developer's laptop listens on 15439, so a profile run without its tunnel
-fails to connect instead of quietly reaching a local database on 5432.
-
-### What this model gives up, and what it buys
-
-A local port that is already bound is a **hard error** (§5.2), not a workaround.
-
-What it buys, beyond not guessing:
-
-- **TLS still works the way the user asked for it.** Nothing silently changes the hostname the
-  driver validates against.
-- **`connection_id` and the catalog cache key stay stable across runs** (§7): no ephemeral
-  port lands in the config the hash is taken over.
+- **Nothing is rewritten**, so `connection_id` and the catalog cache key stay stable across
+  runs, and TLS still verifies the hostname the user asked for.
 - **DuckDB and SQLite need no special case.** They ignore the tunnel; a duckdb `ATTACH` of
   `postgres://localhost:15439/prod` goes through it like anything else.
+- **A profile with `host = "localhost"` is only correct with its tunnel up.** Run it without
+  `ssh_host` and it reaches whatever is on that port locally. Recommend a distinct local port
+  — `15439`, not `5439` — so that mistake is a connection refused rather than the wrong
+  database. The `ssh_*` keys sit in the same profile, so they travel together.
 
-### The hazard this model does have
+## 3. Examples
 
-A profile that says `host = "localhost"` is only correct with the tunnel up. Run it without
-`ssh_host` and it reaches whatever is on your machine at that port — which, if the forward
-uses the database's own port number, may be a database, just the wrong one. A distinct local
-port makes it a connection refused instead, and the `ssh_*` keys live in the same profile as
-the connection details, so they travel together.
-
-## 4. Worked examples
-
-### 4.1 A Redshift cluster behind a bastion, with the forward already in `~/.ssh/config`
-
-The motivating case — a real config, from this repo's author:
+### 3.1 The motivating case: a real `Host` block
 
 ```
 Host redshift_prod
@@ -147,8 +70,8 @@ Host redshift_prod
   ServerAliveCountMax 3
 ```
 
-Today: `ssh -fN redshift_prod`, then `harlequin -a postgres --host localhost --port 15439 …`,
-then remember to kill the ssh later.
+Today: `ssh -fN redshift_prod`, then `harlequin --host localhost --port 15439 …`, then
+remember to kill the ssh.
 
 ```toml
 [profiles.redshift]
@@ -159,115 +82,66 @@ dbname = "prod"
 ssh_host = "redshift_prod"
 ```
 
-`harlequin -P redshift`, and `hsql -P redshift -c "select 1"`. **One key.** No
-`--ssh-forward`, no user, no identity file, no keepalive settings — the `Host` block says all
-of it, and Harlequin runs `ssh -N -o ExitOnForwardFailure=yes redshift_prod`. The connection
-details are exactly the ones that work today.
+`harlequin -P redshift`, `hsql -P redshift -c "select 1"`. **One key.** The connection details
+are the ones that already work. Local `15439`, remote `5439` — the profile names the local
+end, which is all the contract says.
 
-Note the ports: local `15439`, remote `5439`. The profile names the **local** end, which is
-the only thing the contract says.
-
-### 4.2 The same cluster, with nothing in `~/.ssh/config`
-
-The §4.1 `Host` block, translated as far as the four options go:
+### 3.2 The same cluster, no `~/.ssh/config`
 
 ```bash
-harlequin -a postgres \
-  --host localhost --port 15439 --dbname prod --user tco \
+harlequin -a postgres --host localhost --port 15439 --dbname prod --user tco \
   --ssh-host tco@web-1 \
   --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439
 ```
 
-```toml
-[profiles.redshift-no-dotfiles]
-adapter = "postgres"
-host = "localhost"
-port = 15439
-dbname = "prod"
-user = "tco"
-ssh_host = "tco@web-1"
-ssh_forward = ["15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439"]
-```
+`HostName` + `User` → `--ssh-host tco@web-1`. `LocalForward` → `--ssh-forward`, the same text
+with the space turned into a colon. (`--user` is Redshift's user; `tco@` is the SSH host's.)
+The keepalives have **no flag** — see §8. This is the shape for CI or an agent with no
+dotfiles; everyone else writes the `Host` block.
 
-`HostName web-1` and `User tco` are `--ssh-host tco@web-1`; `LocalForward` is
-`--ssh-forward`, the same text with the space turned into a colon. Note the two unrelated
-users, which happen to share a name here: `--user` is Redshift's, `tco@` is the SSH host's.
+### 3.3 Others
 
-**`ServerAliveInterval 60` and `ServerAliveCountMax 3` have no flag**, by decision (§12).
-Without them the tunnel keeps ssh's defaults, which send no keepalives — fine for an `hsql`
-invocation that lasts seconds, and the reason an all-day IDE session behind a NAT wants the
-`Host` block in §4.1. Two lines of `~/.ssh/config` buy it, and they buy it for `ssh` too.
+| | |
+|---|---|
+| database on the SSH host | `--ssh-forward 5432:localhost:5432` — `localhost` is the far side's |
+| local 5432 already taken | `--ssh-forward 15432:db.internal:5432`, details say `15432` |
+| two databases, one host | `--ssh-forward` twice; one child, two `-L` |
+| a jump host in front | `ProxyJump` in the `Host` block. Chains work because `ssh` does them |
+| Cloud SQL, `kubectl`, SSM | run the proxy yourself and point at its local port — that already works, because of §2. Harlequin just does not own its lifetime (§8) |
+| not tunneled | no `ssh_host`, no `harlequin.ssh` import, no cost |
 
-Compare §4.1, which is this same connection in one key.
+## 4. The options
 
-### 4.3 Postgres running on the bastion itself
+Both commands, since one profile serves both and `hsql` is where it matters most: a cron job
+cannot ask a human to run `ssh -fN` first.
 
-```bash
-harlequin -a postgres --host localhost --port 5432 \
-          --ssh-host bastion --ssh-forward 5432:localhost:5432
-```
+| option | profile key | meaning |
+|---|---|---|
+| `--ssh-host TEXT` | `ssh_host` | the destination, verbatim to `ssh`: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
+| `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, verbatim. Omit when `ssh_config` has it |
+| `--ssh-allow-reuse` | `ssh_allow_reuse` | on a bind collision, warn and connect anyway instead of failing (§5.3) |
+| `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
-`localhost` in the forward is the SSH host's localhost — that is `ssh -L` semantics, not
-ours.
+No short declarations — `-o` is `--output` in both commands. These join the reserved spellings
+in `first_pass.attach_adapter_options()`; no published adapter appears to claim one.
 
-### 4.4 You already run a local Postgres on 5432
+**Harlequin parses none of these values.** `ssh` owns its own syntax and error messages, so
+there is no Harlequin-shaped subset of either to document or to get wrong. The only parsing in
+this feature is of `ssh -G`'s *output* (§5.1) — something `ssh` prints, not something a user
+typed.
 
-```bash
-harlequin -a postgres --host localhost --port 15432 \
-          --ssh-host bastion --ssh-forward 15432:db.internal:5432
-```
+`--ssh-host` with no forward anywhere is a usage error naming both places to put one.
 
-The two ports agree because the user wrote both. Nothing infers anything.
-
-### 4.5 Two databases through one bastion
-
-```bash
-harlequin -a postgres --ssh-host bastion \
-          --ssh-forward 15432:pg.internal:5432 \
-          --ssh-forward 15433:analytics.internal:5432 \
-          "postgresql://me@localhost:15432/app" "postgresql://me@localhost:15433/analytics"
-```
-
-One `ssh` child, two `-L`s.
-
-### 4.6 A jump host in front of the bastion
-
-Nothing new: `ProxyJump jump.example.com` in the `Host` block. Chains of three work because
-`ssh` does them, not because we do.
-
-### 4.7 Cloud SQL and other proxies — works, but Harlequin does not run them
-
-The issue thread asks for Cloud SQL, which is not SSH. In v1 the user runs the proxy
-themselves and points at its local port:
-
-```bash
-cloud-sql-proxy --port 3306 my-proj:us-central1:my-instance &
-hsql -a mysql --host 127.0.0.1 --port 3306 --database app -c "select 1"
-```
-
-That already works, and it works *because of* the contract in §3 — the details name a local
-endpoint and Harlequin does not care what is behind it. What v1 does not do is manage that
-process's lifetime the way it manages `ssh`'s. §12 says why that is deferred rather than
-refused.
-
-### 4.8 A key with a passphrase, or 2FA
+**The start-up notice**, on `hsql`'s stderr (never stdout) and as an IDE notification and
+debug-screen line:
 
 ```
-$ hsql -P redshift -c "select count(*) from events"
-Enter passphrase for key '/home/tco/.ssh/id_ed25519':
-ssh: 127.0.0.1:15439 -> data-analytics…:5439 via redshift_prod
+ssh: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 via redshift_prod
 ```
 
-The prompt is `ssh`'s, on the real terminal, because the child starts before Textual (in the
-IDE) and before any output (in `hsql`). An agent running `hsql` unattended uses a key with no
-passphrase or an agent, exactly as it would for `ssh` itself.
+It is what tells a user which database they are actually looking at.
 
-### 4.9 Something that is not tunneled
-
-`harlequin my.db`, `hsql -a postgres --host prod.example.com …`. No `ssh_host`, no
-`harlequin.ssh` import, no cost.
-
-## 5. The forwarder
+## 5. Behavior
 
 `harlequin/ssh.py`, one class:
 
@@ -284,278 +158,140 @@ class SshTunnel:
     def __exit__(self, *exc: Any) -> None: self.stop()
 ```
 
-- **Foreground, not `-f`.** The child keeps the terminal, so prompts reach the human, and we
-  keep the handle, so it can be killed. `ssh -fN` backgrounds itself and outlives the
-  session — which is why the manual workflow needs a `kill` afterwards and this does not.
-- **Readiness** is a connect-poll against each local port `ssh -G` reported (§5.1) until
-  `--ssh-timeout` (default 10s), which also notices the child exiting early. On failure the
-  error quotes ssh's stderr verbatim: its diagnostics are better than any we would write.
-- **The only `-o` Harlequin imposes is `ExitOnForwardFailure=yes`**, because a forward that
-  silently did not happen is the one failure a user cannot diagnose. Notably *not* imposed:
-  `ServerAliveInterval`. A command-line `-o` beats the config file, and keepalives are exactly
-  what a working `Host` block already sets (§4.1 sets them) — overriding would be Harlequin
-  quietly retuning someone else's connection. The docs say to set them in the `Host` block,
-  which is also the only place to set them (§4.2).
-- **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
-  `tui.run()` and the `hsql` run, plus an `atexit` backstop.
-- **No reconnect in v1, but the IDE says when the tunnel dies.** A thread waiting on the child
-  posts a notification when it exits, so a session whose forward dropped shows
-  `tunnel closed: <ssh's last line>` rather than an unexplained wall of query errors. `hsql`
-  is short-lived enough that the adapter's own connection error is the whole story.
+```
+first_pass -> click parses -> profile merge -> SshTunnel.start()   <-- prompts happen HERE
+                                                    |
+                                       adapter_cls(...) -> tui.run() / hsql runs
+                                                    |
+                                             ExitStack unwinds -> stop()
+```
 
-The `Tunnel` ABC an earlier draft proposed is not in v1. One implementation does not need an
-abstract base; the second one (§9, §12) is when it earns itself.
+- **Before Textual, in the click callback.** Once Textual owns the terminal, `ssh` cannot ask
+  for a passphrase and a 2FA push has nowhere to print "check your phone". It also gives both
+  commands one error path — `pretty_print_error` / `diagnostics.report_error`, exit code 3.
+- **Foreground, not `-f`.** The child keeps the terminal, so prompts work, and we keep the
+  handle, so it can be killed. Teardown is `terminate()` then `kill()` from a
+  `contextlib.ExitStack` around `tui.run()` and the `hsql` run, plus an `atexit` backstop.
+- **`ExitOnForwardFailure=yes` is the only `-o` Harlequin imposes**, because a forward that
+  silently did not happen is the one failure a user cannot diagnose. Notably not imposed:
+  `ServerAliveInterval`. A command-line `-o` beats the config file, and §3.1 already sets
+  keepalives — overriding them would be Harlequin retuning someone else's connection.
+- **The IDE says when the tunnel dies.** A thread waiting on the child posts
+  `tunnel closed: <ssh's last line>`, so a dropped forward is not an unexplained wall of query
+  errors. No reconnect in v1. `hsql` is short-lived; the adapter's error is the whole story.
 
-### 5.1 Asking `ssh` what it is about to forward
-
-In the 4.1 shape the forward lives in `ssh_config`, so Harlequin does not know the port it
-should poll. `ssh -G` answers that: it applies every `Host` and `Match` block, prints the
-resolved configuration, and connects to nothing. Verified against the motivating config:
+### 5.1 `ssh -G` says what is about to be forwarded
 
 ```
 $ ssh -G redshift_prod | grep -i forward
 localforward 15439 [data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com]:5439
 ```
 
-**Probe with the argv we are about to run**, not with the destination alone — `ssh -G` echoes
-command-line `-L` and `-o` flags back along with the config's, so
-
-```python
-forwards = _parse_forwards(run([*argv, "-G"]))
-```
-
-gives one list whether the forward came from `--ssh-forward`, from a `Host` block, or from
-both. There is no "config forwards" path and "flag forwards" path to keep in agreement,
-because `ssh` merges them before we look.
+**Probe with the argv we are about to run.** `ssh -G` echoes command-line `-L` flags back
+along with the config's, so one call returns one list whether the forward came from
+`--ssh-forward`, a `Host` block, or both — there are not two sources to keep in agreement.
 
 Parsing is two whitespace-separated fields after the keyword, each `port`, `[host]:port`, or a
-unix socket path; the brackets are how `ssh` writes a host, and they make IPv6 unambiguous. A
-forward whose listen side is a socket path counts as a forward but is not polled.
+socket path (which counts as a forward but is not polled). It costs one subprocess, ~10–30ms,
+no network. If `-G` fails or prints something unparseable, Harlequin degrades: no poll, no
+forwards-nothing error, a short grace period, and the adapter's connection is the test.
 
-Three things get an exact answer instead of a guess:
+### 5.2 Readiness
 
-- **The readiness poll** watches the real local ports.
-- **`--ssh-host` that forwards nothing** is a usage error that can say what it found:
-  `redshift_prod resolves no LocalForward; add one to your Host block or pass --ssh-forward`
-  — with a distinct message when the config has a `DynamicForward` (SOCKS) instead, which is a
-  working tunnel the adapter cannot use.
-- **The notice and the cache key** can name the far side even though Harlequin never saw it.
+Connect-poll each local port `-G` reported until `--ssh-timeout` (default 10s), noticing the
+child exiting early. On failure, the error quotes ssh's stderr verbatim — its diagnostics are
+better than any we would write.
 
-`ssh -G` costs one subprocess (~10–30ms, no network) on invocations that tunnel, and nothing
-on the ones that do not. If it exits non-zero or prints something this cannot parse, Harlequin
-degrades rather than fails: no poll, no forwards-nothing error, a short grace period, and the
-adapter's own connection is the test.
+### 5.3 A local port that is already bound
 
-### 5.2 A local port that is already bound
+Harlequin always tries to start the tunnel; `ExitOnForwardFailure=yes` means `ssh` exits
+rather than connecting without the forward. What happens next is the flag:
 
-The default is to **fail**: `ExitOnForwardFailure=yes` means `ssh` exits with
-`bind: Address already in use`, and Harlequin reports it. A port that is already answering is
-not evidence that the right tunnel is behind it, and reaching the wrong database because
-something else happened to be on 15439 is worse than an error at start-up.
-
-`--ssh-reuse` (`ssh_reuse = true`) opts into the other behavior, for the person who keeps
-`ssh -fN redshift_prod` running all day and does not want Harlequin fighting it: if **every**
-local port `ssh -G` reported is already accepting connections, skip the child and say so.
-
-```
-ssh: 127.0.0.1:15439 already listening; reusing (--ssh-reuse)
-```
-
-If only some of them answer, that is a half-open state nobody meant, and it is an error naming
-the ports either way.
-
-## 6. The CLI and config surface
-
-New options on **both** commands. A profile serves both, and `hsql` is where this matters
-most: a cron job or an agent cannot ask a human to run `ssh -fN` in another terminal first.
-
-| option | profile key | meaning |
-|---|---|---|
-| `--ssh-host TEXT` | `ssh_host` | the destination, handed to `ssh` verbatim: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
-| `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, handed over verbatim. Omit when `ssh_config` has it |
-| `--ssh-reuse` | `ssh_reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
-| `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
-
-**No short declarations for any of them**, and no `-o` passthrough — `-o` is `--output` in
-both commands.
-
-**Harlequin parses none of these values.** `--ssh-host` and `--ssh-forward` are handed to
-`ssh` as they were typed, so `ssh` owns their syntax and their error messages, and there is no
-Harlequin-shaped subset of either to document. The only parsing anywhere in this feature is of
-`ssh -G`'s output (§5.1), which is a machine-readable thing `ssh` prints rather than a string
-a user typed.
-
-Four flags. An earlier draft had nine, then five. **A setup these four cannot express belongs
-in a `Host` block**, which `--ssh-host` names — reusable outside Harlequin, and where a user's
-identity file, keepalives, `ProxyJump`, certificate and `Match` rules already live.
-
-### 6.1 Why there is no `-o` escape hatch
-
-Config files are discovered in the **working directory**, including `pyproject.toml`. Clone a
-repository, run `harlequin` in it, and the worst a hostile config can do is name a database
-and a host to connect to.
-
-An `--ssh-option KEY=VALUE` passthrough would change that: `-o ProxyCommand=…` is arbitrary
-code execution, and so are `LocalCommand`, `KnownHostsCommand` and whatever OpenSSH adds next.
-A deny-list would mostly work — `KnownHostsCommand` arrived in 8.5, so it is a list to
-revisit on every OpenSSH release, and a keyword missed is a hole. Four flags that are a
-hostname, a forward spec, a boolean and a number have nothing to deny.
-
-`ProxyCommand` in the user's own `~/.ssh/config` is unaffected and always was: that is their
-file, Harlequin never writes it, and a cloned repository cannot reach it. What is closed off
-is Harlequin becoming a way to run one.
-
-Rejected for the same reason: **`--ssh-config PATH`** (`ssh -F`). It looks safer, being a path
-rather than a keyword, but the file it names can hold a `ProxyCommand` — the same threat with
-an extra step, and no deny-list even possible.
-
-## 7. Ordering, cache keys, and the two commands
-
-```
-first_pass -> click parses -> profile merge -> SshTunnel.start()   <-- prompts happen HERE
-                                                     |
-                                        adapter_cls(...) -> tui.run() / hsql runs
-                                                     |
-                                              ExitStack unwinds -> stop()
-```
-
-The IDE opens its database on a worker thread after the app is running, which is right for a
-database and wrong for a tunnel: once Textual owns the terminal, `ssh` cannot ask for a
-passphrase and a 2FA push has nowhere to print "check your phone". Starting the child in the
-click callback also means one error path for both commands — `pretty_print_error` /
-`diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) — before a widget is mounted.
-
-The cost is that `harlequin -P redshift` authenticates before showing a UI, which is what
-every CLI that tunnels does and what a user who configured one expects.
-
-**Cache keys need one small change.** Nothing is rewritten, so `get_connection_hash()` and
-`adapter.connection_id` are already stable across runs — but two bastions fronting two
-databases both look like `localhost:15439`, and would share a catalog cache and a query
-history. The ssh destination and the resolved forwards join the hashed material.
-
-## 8. Public API impact
-
-**None.** No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`,
-`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinSshError(HarlequinError)` in
-`exception.py`, and one new module, `harlequin/ssh.py`.
-
-That an adapter cannot tell it is tunneled is not an accident — it is the property being
-bought, and it is why this works for adapters nobody in this org maintains.
-
-## 9. Dependencies, imports, packaging
-
-**v1 adds no dependency at all**: `subprocess`, `socket`, `shlex`.
-
-`harlequin/ssh.py` imports no Textual and no adapter, and joins the "adapter API is reachable
-without the TUI" import-linter contract. It is imported from the CLI callbacks only when
-`ssh_host` is set, so 4.9 pays nothing — `scripts/cold_start.py` should show no change.
-
-**When paramiko would earn its place** — as `harlequin[ssh]`, a second implementation behind
-whatever interface the two then share:
-
-- Windows users without OpenSSH. It ships with Windows 10+, but is removable.
-- Containers: this repo's own dev container has no `ssh` binary, and neither does the
-  `python:3.x-slim` image most people build on.
-- In-process sockets rather than a listener — the shape Google's Cloud SQL *connector* wants.
-
-Until one of those has a user asking, the argument on the issue stands: an unmaintained
-wrapper is not worth taking, and a maintained one is still a `cryptography` dependency on
-every Harlequin install, to solve a problem `ssh` already solves on the same machine.
-
-## 10. Testing
-
-No SSH server, and no `online` marker.
-
-**Lifecycle, all three OSes.** `SshTunnel` takes an argv and a list of ports, so a test can
-hand it a Python child instead of `ssh`:
-
-```python
-SshTunnel(argv=[sys.executable, "-m", "tests.tcp_forward", "15439", "127.0.0.1", str(port)],
-          ports=[15439])
-```
-
-A ~30-line loopback TCP forwarder in `tests/` and a stub server on the far side cover start,
-poll, reuse, timeout, the death notification, and teardown.
-
-**End to end, Unix.** A fake `ssh` on `PATH` — a Python script that understands `-G` and `-L`
-well enough to print a `localforward` line and then forward — exercises the real CLI path
-including the `-G` probe. Skipped on Windows, where the lifecycle tests above are the
-coverage.
-
-**Unit, no processes:**
-
-| case | expected |
+| | |
 |---|---|
-| `--ssh-forward 15439:db.internal:5439` | argv contains `-L 15439:db.internal:5439`, unchanged |
-| `--ssh-forward` repeated | one child, two `-L`, in order |
-| `--ssh-host ssh://tco@web-1:2222` | argv ends with that string, unparsed |
-| a malformed forward spec | ssh's own error, quoted, exit 3 — no Harlequin message |
-| `-G` line `localforward 15439 [host]:5439` | local 15439, remote host:5439 |
-| `-G` with a bind address, IPv6, a socket path | parsed; the socket path is not polled |
-| `-G` reports only `dynamicforward` | usage error, distinct message |
-| `-G` exits non-zero or prints garbage | no poll, no forwards-nothing error, still starts |
-| `--ssh-host` alone, no forward anywhere | usage error naming both places |
-| the argv | contains no `-o` but `ExitOnForwardFailure=yes` |
-| `-o` | still means `--output`, in both commands, alongside every ssh flag |
-| child exits during the poll | `HarlequinSshError` quoting its stderr, exit 3 |
-| poll times out | ditto, naming `--ssh-timeout` |
-| profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
-| cache key | two ssh hosts, same conn_str, two different hashes |
+| default | fail and exit 3, quoting ssh (`bind: Address already in use`) |
+| `--ssh-allow-reuse` | if **every** forwarded port is now accepting connections, warn and connect anyway |
 
-One test runs `ssh -V` and skips if absent, to prove the built argv is accepted by a real
-client where one exists.
+```
+ssh: 127.0.0.1:15439 is already bound; connecting through the existing listener (--ssh-allow-reuse)
+```
 
-## 11. Phasing
+The reuse test is behavioral — the child failed, but the ports answer — rather than a match
+against ssh's message, so it does not depend on wording. If only some ports answer, that is a
+half-open state nobody meant: fail either way.
 
-1. **`harlequin/ssh.py`** — `SshTunnel`, argv construction, the `-G` probe and parser, the
-   readiness poll, `HarlequinSshError`. Unit and lifecycle tests; no CLI. Mergeable alone.
-2. **Wire it into both commands** — the four options, the `ExitStack`, the notice, the
-   cache-key change, and the end-to-end test.
-3. **`--info` / debug-screen reporting**, the IDE's tunnel-died notification, regenerated
-   config schema.
-4. **Docs** in `tconbeer/harlequin-web`: the "details name the local end" contract, and the
-   `Host` block as the recommended way to configure a tunnel. Plus a `CHANGELOG.md` entry
-   under `[Unreleased]` → Features, referencing
-   [#545](https://github.com/tconbeer/harlequin/issues/545).
+Failing by default is the safe direction: a port that answers is not proof the right tunnel is
+behind it. `--ssh-allow-reuse` is for the person who keeps `ssh -fN redshift_prod` running all
+day and does not want Harlequin fighting it.
 
-## 12. Alternatives considered
+## 6. What this touches
 
-| | why not |
+**No public API change.** Nothing in `HarlequinAdapter`, `HarlequinConnection`,
+`HarlequinCursor`, `AbstractOption`, `catalog.py` or `driver.py`. One new
+`HarlequinSshError(HarlequinError)`, one new module.
+
+**No dependency**: `subprocess`, `socket`. `harlequin/ssh.py` imports no Textual and no
+adapter, joins the "adapter API is reachable without the TUI" contract, and is imported only
+when `ssh_host` is set — `scripts/cold_start.py` should show no change.
+
+**One cache-key change.** Two bastions fronting two databases both look like
+`localhost:15439`, and would share a catalog cache and query history. The ssh destination and
+the resolved forwards join the hashed material.
+
+**Config, for free.** A command's click params claim its profile keys, so `ssh_*` become valid
+profile and JSON-schema keys with no further plumbing; regenerate `schemas/config-v1.json`.
+
+## 7. Testing, and phasing
+
+No SSH server, no `online` marker.
+
+- **Lifecycle, all three OSes.** `SshTunnel` takes an argv and ports, so tests hand it a
+  Python child: a ~30-line loopback forwarder in `tests/`, covering start, poll, timeout,
+  reuse, half-open, the death notification, and teardown.
+- **End to end, Unix.** A fake `ssh` on `PATH` that understands `-G` and `-L` exercises the
+  real CLI path including the probe. Skipped on Windows.
+- **Unit**: `--ssh-forward` reaches argv unchanged and repeats in order; `--ssh-host` is
+  unparsed; `-G` lines with a bind address, IPv6 and a socket path parse; `-G` returning only
+  `dynamicforward` is a usage error; `-G` garbage degrades; no forward anywhere is a usage
+  error; the argv carries `ExitOnForwardFailure` and no other `-o`; `-o` still means
+  `--output`; profile round trip; two ssh hosts hash differently.
+- One test runs `ssh -V` and skips if absent, proving the argv is accepted by a real client.
+
+Phasing: **(1)** `harlequin/ssh.py` — argv, `-G` probe and parser, poll, reuse,
+`HarlequinSshError`; unit and lifecycle tests, no CLI. **(2)** the four options, the
+`ExitStack`, the notice, the cache key, the end-to-end test. **(3)** `--info` and debug-screen
+reporting, the death notification, regenerated schema. **(4)** docs in `harlequin-web` — the
+contract, and the `Host` block as the recommended setup — plus a `CHANGELOG.md` entry under
+`[Unreleased]` → Features citing [#545](https://github.com/tconbeer/harlequin/issues/545).
+
+## 8. Rejected and deferred
+
+**Rejected.**
+
+| | |
 |---|---|
-| **Rewriting the adapter's host/port** (the issue's original sketch, and the first draft of this doc) | Core has to know which option is the host, and there is no general answer: a new `role=` declaration no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
-| **A generic `--tunnel-command`** (`cloud-sql-proxy`, `aws ssm`, `kubectl port-forward`, Teleport) | Deferred, not refused. It is ~30 lines over `SshTunnel` and it is the natural home for the Cloud SQL request — but it is a "run this string" option, which is the thing §6.1 declines to let a config file do, and 4.7 already works without Harlequin managing the process. Nothing in v1 forecloses it: the flags are namespaced `--ssh-*` precisely so a `--tunnel-*` family can arrive beside them. |
-| **An `--ssh-option KEY=VALUE` passthrough** | §6.1. It would be the only option needing a security check, and the only realistic thing it buys over a `Host` block is keepalives for a caller with no dotfiles (§4.2). `--ssh-keepalive SECONDS` is the narrow version if that turns out to sting; it is easier to add later than to remove a documented flag. |
-| **A `{tunnel_port}` placeholder** the user writes into their conn_str | General and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable *without* the tunnel rather than merely wrong. |
-| **A SOCKS proxy (`ssh -D`) with `socket.socket` patched** | The one design where the driver keeps the real hostname, so TLS verification is untouched. It only works for pure-Python drivers: psycopg2, mysqlclient, ODBC and duckdb's extensions open sockets in C and never see Python's `socket` module. |
-| **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings, and the adapters that need it most are out-of-tree. |
-| **A library adapters call (`harlequin-tunnel`)** | Adapters must opt in, so "works with any adapter" becomes "works with adapters that adopted it". Reasonable *in addition*, for an adapter that wants a tunnel inside its own connection (the Cloud SQL connector); not a substitute. |
-| **`sshtunnel`** | The blocker on the issue: four years without a release, and it is a wrapper over paramiko for behavior we would otherwise get from a binary already on the machine. |
-| **paramiko directly, in v1** | A `cryptography` dependency on every install, and it reimplements the part of `~/.ssh/config` users already have working. Kept as the v2 backend, §9. |
-| **Tell users to run `ssh -fN` themselves** | It works, and it is what people do today — including the author of this repo. It also means a second terminal, an orphaned tunnel to remember to kill, and a profile that only connects if a human ran something first, which is exactly what `hsql` in a cron job or an agent loop cannot do. |
+| **Rewriting the adapter's host/port** (the issue's sketch, and this doc's first draft) | Core would have to know which option is the host: a `role=` declaration no adapter has, a name-matching guess, and a DSN rewrite — three mechanisms that can be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` and breaks TLS hostname verification unasked. |
+| **`--ssh-option KEY=VALUE`** | `-o ProxyCommand=…` is arbitrary code execution, and config files are discovered in the working directory — a cloned repo's `pyproject.toml` must not be able to run a command. A deny-list would mostly work, but `KnownHostsCommand` arrived in OpenSSH 8.5, so it is a list to revisit forever and a miss is a hole. Four flags that are a hostname, a forward spec, a boolean and a number have nothing to deny. A `ProxyCommand` in the user's own `~/.ssh/config` is unaffected and always was. |
+| **`--ssh-config PATH`** (`ssh -F`) | Looks safer — a path, not a keyword — but the file it names can hold a `ProxyCommand`. Same threat, extra step, no deny-list possible. |
+| **`--ssh-user` / `--ssh-port` / `--ssh-identity`** | `ssh_config` spelled a second time. |
+| **A configurable local bind address** | `ssh_config` and the forward spec already do it; `0.0.0.0` should take deliberate effort. |
+| **`require_tunnel = true`** | A distinct local port already turns the mistake into a connection refused. |
+| **A `{tunnel_port}` placeholder in the conn_str** | General, but a second thing to learn for the same result, and it makes the profile unusable *without* the tunnel. |
+| **SOCKS (`ssh -D`) with `socket.socket` patched** | Keeps the real hostname, so TLS is untouched — but only works for pure-Python drivers. psycopg2, mysqlclient, ODBC and duckdb open sockets in C. |
+| **Per-adapter `--ssh-*`** | N implementations, N spellings, and the adapters that need it most are out-of-tree. |
+| **A library adapters call** | Opt-in, so "any adapter" becomes "adapters that adopted it". Fine *in addition*, for something like the Cloud SQL connector. |
+| **`sshtunnel`** | Four years without a release, wrapping paramiko for behavior a binary on the machine already has. |
+| **paramiko in v1** | A `cryptography` dependency on every install, reimplementing the `~/.ssh/config` handling users already have working. |
+| **"Just run `ssh -fN` yourself"** | Works today, but means a second terminal, an orphaned tunnel to kill, and a profile that only connects if a human ran something first — which `hsql` in a cron job cannot do. |
 
-## 13. Settled in review
+**Deferred, and what brings each back.**
 
-- **No rewriting of connection details.** They name the local end of the forward (§3).
-- **`ssh -G` reports `localforward`**, verified against the config in §4.1, so the readiness
-  poll and the forwards-nothing error are exact (§5.1).
-- **A bound local port fails**; `--ssh-reuse` is the opt-in (§5.2).
-- **Four options, every one starting with `ssh`**, no short declarations, no `-o`
-  passthrough — so there is nothing to deny-list and nothing a project-local config file can
-  make `ssh` execute (§6.1).
-- **Harlequin parses no ssh syntax.** `--ssh-host` and `--ssh-forward` are verbatim; a setup
-  those cannot express goes in a `Host` block that `--ssh-host` names.
-- **The local bind address is not configurable**; whatever the forward spec or the `Host`
-  block says.
-- **Not in v1**: `--tunnel-command`, a `require_tunnel` profile key, `--ssh-config`.
-
-## 14. Deferred, and what would bring each back
-
-| | when |
+| | |
 |---|---|
-| `--ssh-keepalive SECONDS` | someone runs an all-day IDE session with no `~/.ssh/config` and gets dropped (§4.2) |
-| `--tunnel-command` | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, and §6.1's reasoning has an answer for a "run this string" option (§4.7) |
-| a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary (§9) |
-| reconnect after a dropped tunnel | the death notification (§5) proves to be not enough |
+| `--ssh-keepalive SECONDS` | someone runs an all-day IDE session with no `~/.ssh/config` and gets dropped (§3.2) |
+| `--tunnel-command` for non-SSH proxies | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, with an answer to the code-execution problem above |
+| a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary |
+| reconnect after a drop | the death notification proves not to be enough |
 
-Each is additive: the four flags are namespaced, the one class has no ABC to satisfy, and no
-adapter is involved in any of it.
+Each is additive: the flags are namespaced, one class has no ABC to satisfy, and no adapter is
+involved in any of it.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -20,10 +20,11 @@ Nothing here is implemented. This is the design to argue with before the first P
    answers the four-year-old blocker on the issue — and it inherits the user's whole
    `~/.ssh/config`: `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match`
    blocks, 2FA. `ssh -G` tells us what it is about to forward, so nothing is guessed.
-4. **Five flags, all `--ssh-*`, none of them parsed.** `--ssh-host` and `--ssh-forward` go
+4. **Four flags, all `--ssh-*`, none of them parsed.** `--ssh-host` and `--ssh-forward` go
    to `ssh` verbatim; the one thing Harlequin parses is `ssh -G`'s *output*. No
    `--ssh-user`/`--ssh-port`/`--ssh-identity`: those are `ssh_config` spelled twice, and a
-   `Host` block is where a complicated setup belongs.
+   `Host` block is where a complicated setup belongs — and no `-o` passthrough, so nothing
+   Harlequin reads can hand `ssh` a command to run.
 5. **The tunnel comes up before Textual does**, so a passphrase or 2FA prompt can reach a
    human — and it is a child process, not `ssh -f`, so it dies with the session instead of
    outliving it.
@@ -168,16 +169,13 @@ the only thing the contract says.
 
 ### 4.2 The same cluster, with nothing in `~/.ssh/config`
 
-The §4.1 `Host` block, translated flag for flag — every line of it, so that what the five
-options can and cannot say is visible:
+The §4.1 `Host` block, translated as far as the four options go:
 
 ```bash
 harlequin -a postgres \
   --host localhost --port 15439 --dbname prod --user tco \
   --ssh-host tco@web-1 \
-  --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
-  --ssh-option ServerAliveInterval=60 \
-  --ssh-option ServerAliveCountMax=3
+  --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439
 ```
 
 ```toml
@@ -189,18 +187,18 @@ dbname = "prod"
 user = "tco"
 ssh_host = "tco@web-1"
 ssh_forward = ["15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439"]
-ssh_option = ["ServerAliveInterval=60", "ServerAliveCountMax=3"]
 ```
 
-Line by line: `HostName web-1` and `User tco` are `--ssh-host tco@web-1`; `LocalForward`
-is `--ssh-forward`, the same text with the space turned into a colon; and the two keepalive
-settings are the **only** lines that need `--ssh-option`. Note the two unrelated users, which
-happen to share a name here: `--user` is Redshift's, `tco@` is the SSH host's.
+`HostName web-1` and `User tco` are `--ssh-host tco@web-1`; `LocalForward` is
+`--ssh-forward`, the same text with the space turned into a colon. Note the two unrelated
+users, which happen to share a name here: `--user` is Redshift's, `tco@` is the SSH host's.
 
-Compare §4.1, which is the same connection in one key. This is the shape for a CI job or an
-agent with no dotfiles, and the docs' advice is to write the `Host` block instead.
+**`ServerAliveInterval 60` and `ServerAliveCountMax 3` have no flag**, by decision (§12).
+Without them the tunnel keeps ssh's defaults, which send no keepalives — fine for an `hsql`
+invocation that lasts seconds, and the reason an all-day IDE session behind a NAT wants the
+`Host` block in §4.1. Two lines of `~/.ssh/config` buy it, and they buy it for `ssh` too.
 
-**What this example is really for** is §14.1: `--ssh-option` exists for those last two lines.
+Compare §4.1, which is this same connection in one key.
 
 ### 4.3 Postgres running on the bastion itself
 
@@ -234,9 +232,8 @@ One `ssh` child, two `-L`s.
 
 ### 4.6 A jump host in front of the bastion
 
-Nothing new. `ProxyJump jump.example.com` in the `Host` block, or
-`--ssh-option ProxyJump=jump.example.com`. Chains of three work because `ssh` does them, not
-because we do.
+Nothing new: `ProxyJump jump.example.com` in the `Host` block. Chains of three work because
+`ssh` does them, not because we do.
 
 ### 4.7 Cloud SQL and other proxies — works, but Harlequin does not run them
 
@@ -297,8 +294,8 @@ class SshTunnel:
   silently did not happen is the one failure a user cannot diagnose. Notably *not* imposed:
   `ServerAliveInterval`. A command-line `-o` beats the config file, and keepalives are exactly
   what a working `Host` block already sets (§4.1 sets them) — overriding would be Harlequin
-  quietly retuning someone else's connection. The docs say to set them in the `Host` block;
-  `--ssh-option` is there for anyone who wants to anyway.
+  quietly retuning someone else's connection. The docs say to set them in the `Host` block,
+  which is also the only place to set them (§4.2).
 - **Teardown** is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping
   `tui.run()` and the `hsql` run, plus an `atexit` backstop.
 - **No reconnect in v1, but the IDE says when the tunnel dies.** A thread waiting on the child
@@ -376,13 +373,11 @@ most: a cron job or an agent cannot ask a human to run `ssh -fN` in another term
 |---|---|---|
 | `--ssh-host TEXT` | `ssh_host` | the destination, handed to `ssh` verbatim: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
 | `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, handed over verbatim. Omit when `ssh_config` has it |
-| `--ssh-option KEY=VALUE` | `ssh_option` | repeatable; becomes one `-o`. Some keywords are refused (§6.1) |
 | `--ssh-reuse` | `ssh_reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
 | `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
-**No short declarations for any of them.** In particular `-o` is *not* an alias for
-`--ssh-option`: `-o` is `--output` in both commands, and an ssh flag may not take a spelling
-the output path already has.
+**No short declarations for any of them**, and no `-o` passthrough — `-o` is `--output` in
+both commands.
 
 **Harlequin parses none of these values.** `--ssh-host` and `--ssh-forward` are handed to
 `ssh` as they were typed, so `ssh` owns their syntax and their error messages, and there is no
@@ -390,59 +385,29 @@ Harlequin-shaped subset of either to document. The only parsing anywhere in this
 `ssh -G`'s output (§5.1), which is a machine-readable thing `ssh` prints rather than a string
 a user typed.
 
-Five flags. An earlier draft had nine, including `--ssh-user`, `--ssh-port` and
-`--ssh-identity`; every one of those is `ssh_config` spelled a second time. **A setup too
-complicated for these five belongs in a `Host` block**, which `--ssh-host` can then name —
-reusable outside Harlequin, and where a user's `ProxyJump`, certificate and `Match` rules
-already live.
+Four flags. An earlier draft had nine, then five. **A setup these four cannot express belongs
+in a `Host` block**, which `--ssh-host` names — reusable outside Harlequin, and where a user's
+identity file, keepalives, `ProxyJump`, certificate and `Match` rules already live.
 
-No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
-for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
-ever added it is `secret=True`, and `redact._SECRET_NAME` grows `passphrase`, which it is
-missing today.
-
-`hsql`'s flags are the frozen part of its API, so these join the reserved spellings in
-`first_pass.attach_adapter_options()`. Worth a survey of published adapters before merging; I
-know of none that claims one.
-
-**The start-up notice**, on `hsql`'s stderr (never stdout — that belongs to query output) and
-as an IDE notification and debug-screen line:
-
-```
-ssh: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 via redshift_prod
-```
-
-One line, and it is what tells a user which database they are actually looking at.
-
-### 6.1 Some `-o` keywords are refused
+### 6.1 Why there is no `-o` escape hatch
 
 Config files are discovered in the **working directory**, including `pyproject.toml`. Clone a
-repository, run `harlequin` in it, and today the worst a hostile config can do is name a
-database.
+repository, run `harlequin` in it, and the worst a hostile config can do is name a database
+and a host to connect to.
 
-Four of the five options above are a name, a forward spec, a flag and a number. `ssh_option`
-is the one that is not: several `ssh_config` keywords run a program or hand something to the
-far side, and `-o ProxyCommand=…` is arbitrary code execution from a file in the current
-directory.
+An `--ssh-option KEY=VALUE` passthrough would change that: `-o ProxyCommand=…` is arbitrary
+code execution, and so are `LocalCommand`, `KnownHostsCommand` and whatever OpenSSH adds next.
+A deny-list would mostly work — `KnownHostsCommand` arrived in 8.5, so it is a list to
+revisit on every OpenSSH release, and a keyword missed is a hole. Four flags that are a
+hostname, a forward spec, a boolean and a number have nothing to deny.
 
-So `--ssh-option` **refuses a keyword on a short deny-list**, wherever the value came from —
-command line or config file alike:
+`ProxyCommand` in the user's own `~/.ssh/config` is unaffected and always was: that is their
+file, Harlequin never writes it, and a cloned repository cannot reach it. What is closed off
+is Harlequin becoming a way to run one.
 
-| refused | because | do this instead |
-|---|---|---|
-| `ProxyCommand` | runs a program | `ProxyJump`, or a `Host` block in `~/.ssh/config` |
-| `LocalCommand`, `PermitLocalCommand` | runs a program | a `Host` block |
-| `KnownHostsCommand` | runs a program | a `Host` block |
-| `ForwardAgent` | hands your agent to the far side | a `Host` block, if you really mean it |
-
-Matched case-insensitively, because `ssh_config` keywords are. The error names the keyword and
-the alternative.
-
-A deny-list rather than a rule about which file the value came from: it is one check in one
-place, it needs no provenance plumbing, and it is the same answer however the value arrived.
-It deliberately does **not** reach into `~/.ssh/config` — a `ProxyCommand` there is the user's
-own, in a file Harlequin never writes and a cloned repository cannot reach. What it stops is
-Harlequin becoming a way to run one.
+Rejected for the same reason: **`--ssh-config PATH`** (`ssh -F`). It looks safer, being a path
+rather than a keyword, but the file it names can hold a `ProxyCommand` — the same threat with
+an extra step, and no deny-list even possible.
 
 ## 7. Ordering, cache keys, and the two commands
 
@@ -530,10 +495,8 @@ coverage.
 | `-G` reports only `dynamicforward` | usage error, distinct message |
 | `-G` exits non-zero or prints garbage | no poll, no forwards-nothing error, still starts |
 | `--ssh-host` alone, no forward anywhere | usage error naming both places |
-| `--ssh-option ProxyCommand=…`, from CLI or config | usage error naming the keyword (§6.1) |
-| `--ssh-option proxycommand=…` | same; keywords are case-insensitive |
-| `--ssh-option ProxyJump=…` | allowed, reaches argv as one `-o` |
-| `-o` still means `--output` | both commands, with `--ssh-option` also set |
+| the argv | contains no `-o` but `ExitOnForwardFailure=yes` |
+| `-o` | still means `--output`, in both commands, alongside every ssh flag |
 | child exits during the poll | `HarlequinSshError` quoting its stderr, exit 3 |
 | poll times out | ditto, naming `--ssh-timeout` |
 | profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
@@ -546,8 +509,8 @@ client where one exists.
 
 1. **`harlequin/ssh.py`** — `SshTunnel`, argv construction, the `-G` probe and parser, the
    readiness poll, `HarlequinSshError`. Unit and lifecycle tests; no CLI. Mergeable alone.
-2. **Wire it into both commands** — the five options, the `ExitStack`, the notice, the
-   cache-key change, the §6.1 provenance rule, and the end-to-end test.
+2. **Wire it into both commands** — the four options, the `ExitStack`, the notice, the
+   cache-key change, and the end-to-end test.
 3. **`--info` / debug-screen reporting**, the IDE's tunnel-died notification, regenerated
    config schema.
 4. **Docs** in `tconbeer/harlequin-web`: the "details name the local end" contract, and the
@@ -560,7 +523,8 @@ client where one exists.
 | | why not |
 |---|---|
 | **Rewriting the adapter's host/port** (the issue's original sketch, and the first draft of this doc) | Core has to know which option is the host, and there is no general answer: a new `role=` declaration no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where a local forward reaches with none. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
-| **A generic `--tunnel-command`** (`cloud-sql-proxy`, `aws ssm`, `kubectl port-forward`, Teleport) | Deferred, not refused. It is ~30 lines over `SshTunnel` and it is the natural home for the Cloud SQL request — but it is a "run this string" option, which needs the §6.1 rule to be airtight before it ships, and 4.7 already works without Harlequin managing the process. Nothing in v1 forecloses it: the flags are namespaced `--ssh-*` precisely so a `--tunnel-*` family can arrive beside them. |
+| **A generic `--tunnel-command`** (`cloud-sql-proxy`, `aws ssm`, `kubectl port-forward`, Teleport) | Deferred, not refused. It is ~30 lines over `SshTunnel` and it is the natural home for the Cloud SQL request — but it is a "run this string" option, which is the thing §6.1 declines to let a config file do, and 4.7 already works without Harlequin managing the process. Nothing in v1 forecloses it: the flags are namespaced `--ssh-*` precisely so a `--tunnel-*` family can arrive beside them. |
+| **An `--ssh-option KEY=VALUE` passthrough** | §6.1. It would be the only option needing a security check, and the only realistic thing it buys over a `Host` block is keepalives for a caller with no dotfiles (§4.2). `--ssh-keepalive SECONDS` is the narrow version if that turns out to sting; it is easier to add later than to remove a documented flag. |
 | **A `{tunnel_port}` placeholder** the user writes into their conn_str | General and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable *without* the tunnel rather than merely wrong. |
 | **A SOCKS proxy (`ssh -D`) with `socket.socket` patched** | The one design where the driver keeps the real hostname, so TLS verification is untouched. It only works for pure-Python drivers: psycopg2, mysqlclient, ODBC and duckdb's extensions open sockets in C and never see Python's `socket` module. |
 | **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings, and the adapters that need it most are out-of-tree. |
@@ -575,29 +539,23 @@ client where one exists.
 - **`ssh -G` reports `localforward`**, verified against the config in §4.1, so the readiness
   poll and the forwards-nothing error are exact (§5.1).
 - **A bound local port fails**; `--ssh-reuse` is the opt-in (§5.2).
-- **Every option starts with `ssh`.** Five of them, no short declarations — `-o` stays
-  `--output`.
+- **Four options, every one starting with `ssh`**, no short declarations, no `-o`
+  passthrough — so there is nothing to deny-list and nothing a project-local config file can
+  make `ssh` execute (§6.1).
 - **Harlequin parses no ssh syntax.** `--ssh-host` and `--ssh-forward` are verbatim; a setup
   those cannot express goes in a `Host` block that `--ssh-host` names.
-- **The local bind address is not configurable.** Whatever the forward spec or the `Host`
-  block says, which for a bare `LOCAL:HOST:PORT` is ssh's own default.
-- **`--ssh-option` refuses `ProxyCommand` and four friends** (§6.1), which replaces the
-  provenance rule an earlier draft proposed.
-- **No `--tunnel-command` in v1**, and no `require_tunnel` profile key.
+- **The local bind address is not configurable**; whatever the forward spec or the `Host`
+  block says.
+- **Not in v1**: `--tunnel-command`, a `require_tunnel` profile key, `--ssh-config`.
 
-## 14. Open questions for review
+## 14. Deferred, and what would bring each back
 
-1. **Does `--ssh-option` earn its place?** §4.2 is the evidence: translating a real `Host`
-   block, four of its five lines land on `--ssh-host` and `--ssh-forward`, and only the
-   keepalives need `--ssh-option`. Three ways to go, and the recommendation is the second:
+| | when |
+|---|---|
+| `--ssh-keepalive SECONDS` | someone runs an all-day IDE session with no `~/.ssh/config` and gets dropped (§4.2) |
+| `--tunnel-command` | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, and §6.1's reasoning has an answer for a "run this string" option (§4.7) |
+| a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary (§9) |
+| reconnect after a dropped tunnel | the death notification (§5) proves to be not enough |
 
-   | | |
-   |---|---|
-   | **Keep it, with the §6.1 deny-list** | The full escape hatch. Costs a deny-list against a program that keeps adding keywords — `KnownHostsCommand` arrived in OpenSSH 8.5, so the list is a standing obligation, and a keyword we miss is a hole. |
-   | **Drop it — four flags, no §6.1** ← | A setup these four cannot express goes in a `Host` block, which `--ssh-host` names. Closed by construction rather than by a list we maintain. The CI job this would strand can write four lines of ssh config beside the key it already had to write. |
-   | **Replace it with `--ssh-keepalive SECONDS`** | `-o ServerAliveInterval=N -o ServerAliveCountMax=3`, which is exactly what §4.2 needed and nothing else. One narrow option, no arbitrary keywords, no deny-list. A good follow-up if dropping `--ssh-option` turns out to sting. |
-
-   Related and rejected either way: **`--ssh-config PATH`** (point `ssh -F` at another config
-   file). It looks safer than `--ssh-option` — a path, not a keyword — but the file it names
-   can hold a `ProxyCommand`, and a repo-local Harlequin config naming a repo-local ssh config
-   is the §6.1 threat with an extra step and no deny-list possible.
+Each is additive: the four flags are namespaced, the one class has no ABC to satisfy, and no
+adapter is involved in any of it.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -20,8 +20,10 @@ Nothing here is implemented. This is the design to argue with before the first P
    answers the four-year-old blocker on the issue — and it inherits the user's whole
    `~/.ssh/config`: `LocalForward`, `ProxyJump`, agent, certificates, hardware keys, `Match`
    blocks, 2FA. `ssh -G` tells us what it is about to forward, so nothing is guessed.
-4. **Five flags, all `--ssh-*`.** No generic `--tunnel-command` in v1 (§12), no
-   `--ssh-user`/`--ssh-port`/`--ssh-identity` — those are `ssh_config` spelled twice.
+4. **Five flags, all `--ssh-*`, none of them parsed.** `--ssh-host` and `--ssh-forward` go
+   to `ssh` verbatim; the one thing Harlequin parses is `ssh -G`'s *output*. No
+   `--ssh-user`/`--ssh-port`/`--ssh-identity`: those are `ssh_config` spelled twice, and a
+   `Host` block is where a complicated setup belongs.
 5. **The tunnel comes up before Textual does**, so a passphrase or 2FA prompt can reach a
    human — and it is a child process, not `ssh -f`, so it dies with the session instead of
    outliving it.
@@ -91,13 +93,17 @@ ssh config, where it already was.
 Nothing is rewritten. `conn_str` and every adapter option reach the adapter exactly as the
 user wrote them, and the adapter is never told a tunnel exists.
 
-When the forward is *not* already in the ssh config, `--ssh-forward` writes one:
+When the forward is *not* already in the ssh config, `--ssh-forward` writes one. **Its value
+is whatever you would write after `ssh -L`, passed through untouched:**
 
-| `--ssh-forward` | becomes | |
-|---|---|---|
-| `15439:db.internal:5439` | `-L 127.0.0.1:15439:db.internal:5439` | the general form, and the one to recommend |
-| `db.internal:5439` | `-L 127.0.0.1:5439:db.internal:5439` | shorthand: same port on both ends |
-| `5432` | `-L 127.0.0.1:5432:localhost:5432` | shorthand: the database runs on the SSH host |
+```
+--ssh-forward 15439:db.internal:5439   ->   ssh -L 15439:db.internal:5439 …
+```
+
+Harlequin defines no shorthands and validates nothing here. `ssh` already documents this
+syntax, already rejects a malformed one with a better message than we would write, and
+already knows what a bare `LOCAL:HOST:PORT` binds. An invented shorthand would be a second
+syntax for users to learn and a parser for us to get wrong.
 
 **The docs should recommend a distinct local port**, as the config in §4.1 does with `15439`.
 It sidesteps the collision case, and it is most of the mitigation for the hazard below:
@@ -175,10 +181,12 @@ works, and it is what an agent or a CI job with no dotfiles has to do.
 ### 4.3 Postgres running on the bastion itself
 
 ```bash
-harlequin -a postgres --host localhost --port 5432 --ssh-host bastion --ssh-forward 5432
+harlequin -a postgres --host localhost --port 5432 \
+          --ssh-host bastion --ssh-forward 5432:localhost:5432
 ```
 
-`--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`.
+`localhost` in the forward is the SSH host's localhost — that is `ssh -L` semantics, not
+ours.
 
 ### 4.4 You already run a local Postgres on 5432
 
@@ -342,16 +350,27 @@ most: a cron job or an agent cannot ask a human to run `ssh -fN` in another term
 
 | option | profile key | meaning |
 |---|---|---|
-| `--ssh-host TEXT` | `ssh_host` | `[user@]host[:port]`, or a `Host` alias from `~/.ssh/config` |
-| `--ssh-forward TEXT` | `ssh_forward` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT`. Omit when `ssh_config` has it |
-| `--ssh-option KEY=VALUE` | `ssh_option` | repeatable `-o`; `IdentityFile`, `ProxyJump`, `User`, anything |
+| `--ssh-host TEXT` | `ssh_host` | the destination, handed to `ssh` verbatim: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
+| `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, handed over verbatim. Omit when `ssh_config` has it |
+| `--ssh-option KEY=VALUE` | `ssh_option` | repeatable; becomes one `-o`. Some keywords are refused (§6.1) |
 | `--ssh-reuse` | `ssh_reuse` | if the forwarded ports already answer, use them instead of starting a child (§5.2) |
 | `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
+**No short declarations for any of them.** In particular `-o` is *not* an alias for
+`--ssh-option`: `-o` is `--output` in both commands, and an ssh flag may not take a spelling
+the output path already has.
+
+**Harlequin parses none of these values.** `--ssh-host` and `--ssh-forward` are handed to
+`ssh` as they were typed, so `ssh` owns their syntax and their error messages, and there is no
+Harlequin-shaped subset of either to document. The only parsing anywhere in this feature is of
+`ssh -G`'s output (§5.1), which is a machine-readable thing `ssh` prints rather than a string
+a user typed.
+
 Five flags. An earlier draft had nine, including `--ssh-user`, `--ssh-port` and
-`--ssh-identity`; every one of those is `ssh_config` or `-o` spelled a second time, and the
-docs' advice is to write a `Host` block — reusable outside Harlequin, and where a user's
-`ProxyJump`, certificate and `Match` rules already live.
+`--ssh-identity`; every one of those is `ssh_config` spelled a second time. **A setup too
+complicated for these five belongs in a `Host` block**, which `--ssh-host` can then name —
+reusable outside Harlequin, and where a user's `ProxyJump`, certificate and `Match` rules
+already live.
 
 No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
 for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
@@ -371,23 +390,35 @@ ssh: 127.0.0.1:15439 -> data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.c
 
 One line, and it is what tells a user which database they are actually looking at.
 
-### 6.1 A config file must not be able to run a command
+### 6.1 Some `-o` keywords are refused
 
 Config files are discovered in the **working directory**, including `pyproject.toml`. Clone a
 repository, run `harlequin` in it, and today the worst a hostile config can do is name a
 database.
 
-Four of the five keys above are names, ports and a flag. `ssh_option` is not: `-o
-ProxyCommand=…` runs a command, and so does `LocalCommand` with `PermitLocalCommand`.
+Four of the five options above are a name, a forward spec, a flag and a number. `ssh_option`
+is the one that is not: several `ssh_config` keywords run a program or hand something to the
+far side, and `-o ProxyCommand=…` is arbitrary code execution from a file in the current
+directory.
 
-Proposed rule: **`ssh_option` is honored only from the user's own config** — an explicit
-`--config-path`, the user config dir, or `$HOME` — and from the command line. A profile
-supplied by a file found in the working directory that sets it is a config error naming the
-file. `config.py` already tracks which file supplied each profile (`Provenance`), so the check
-has what it needs.
+So `--ssh-option` **refuses a keyword on a short deny-list**, wherever the value came from —
+command line or config file alike:
 
-This is also the reason a general "run this command" option is a bigger decision than it
-looks, and part of why there isn't one in v1 (§12).
+| refused | because | do this instead |
+|---|---|---|
+| `ProxyCommand` | runs a program | `ProxyJump`, or a `Host` block in `~/.ssh/config` |
+| `LocalCommand`, `PermitLocalCommand` | runs a program | a `Host` block |
+| `KnownHostsCommand` | runs a program | a `Host` block |
+| `ForwardAgent` | hands your agent to the far side | a `Host` block, if you really mean it |
+
+Matched case-insensitively, because `ssh_config` keywords are. The error names the keyword and
+the alternative.
+
+A deny-list rather than a rule about which file the value came from: it is one check in one
+place, it needs no provenance plumbing, and it is the same answer however the value arrived.
+It deliberately does **not** reach into `~/.ssh/config` — a `ProxyCommand` there is the user's
+own, in a file Harlequin never writes and a cloned repository cannot reach. What it stops is
+Harlequin becoming a way to run one.
 
 ## 7. Ordering, cache keys, and the two commands
 
@@ -466,17 +497,19 @@ coverage.
 
 | case | expected |
 |---|---|
-| `--ssh-forward 5432` | argv contains `-L 127.0.0.1:5432:localhost:5432` |
-| `--ssh-forward db.internal:5439` | `-L 127.0.0.1:5439:db.internal:5439` |
-| `--ssh-forward 15439:db.internal:5439` | `-L 127.0.0.1:15439:db.internal:5439` |
-| `--ssh-forward` repeated | one child, two `-L` |
+| `--ssh-forward 15439:db.internal:5439` | argv contains `-L 15439:db.internal:5439`, unchanged |
+| `--ssh-forward` repeated | one child, two `-L`, in order |
+| `--ssh-host ssh://tco@web-1:2222` | argv ends with that string, unparsed |
+| a malformed forward spec | ssh's own error, quoted, exit 3 — no Harlequin message |
 | `-G` line `localforward 15439 [host]:5439` | local 15439, remote host:5439 |
 | `-G` with a bind address, IPv6, a socket path | parsed; the socket path is not polled |
 | `-G` reports only `dynamicforward` | usage error, distinct message |
 | `-G` exits non-zero or prints garbage | no poll, no forwards-nothing error, still starts |
 | `--ssh-host` alone, no forward anywhere | usage error naming both places |
-| a garbage forward spec | usage error naming the three forms |
-| `ssh_option` from a cwd-discovered config | config error naming the file (§6.1) |
+| `--ssh-option ProxyCommand=…`, from CLI or config | usage error naming the keyword (§6.1) |
+| `--ssh-option proxycommand=…` | same; keywords are case-insensitive |
+| `--ssh-option ProxyJump=…` | allowed, reaches argv as one `-o` |
+| `-o` still means `--output` | both commands, with `--ssh-option` also set |
 | child exits during the poll | `HarlequinSshError` quoting its stderr, exit 3 |
 | poll times out | ditto, naming `--ssh-timeout` |
 | profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
@@ -518,16 +551,19 @@ client where one exists.
 - **`ssh -G` reports `localforward`**, verified against the config in §4.1, so the readiness
   poll and the forwards-nothing error are exact (§5.1).
 - **A bound local port fails**; `--ssh-reuse` is the opt-in (§5.2).
-- **Every option starts with `ssh`.** Five of them.
+- **Every option starts with `ssh`.** Five of them, no short declarations — `-o` stays
+  `--output`.
+- **Harlequin parses no ssh syntax.** `--ssh-host` and `--ssh-forward` are verbatim; a setup
+  those cannot express goes in a `Host` block that `--ssh-host` names.
+- **The local bind address is not configurable.** Whatever the forward spec or the `Host`
+  block says, which for a bare `LOCAL:HOST:PORT` is ssh's own default.
+- **`--ssh-option` refuses `ProxyCommand` and four friends** (§6.1), which replaces the
+  provenance rule an earlier draft proposed.
 - **No `--tunnel-command` in v1**, and no `require_tunnel` profile key.
 
 ## 14. Open questions for review
 
-1. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded
-   for `--ssh-forward`; `0.0.0.0` would expose the far side's database to the user's network,
-   which seems like a thing to make people ask for. (`ssh_config` can already do it, which is
-   an argument for leaving the flag simple.)
-2. **`ssh_option` in a project-local config** — §6.1 proposes refusing it there. The
-   alternative is refusing `ssh_option` from *any* config file, CLI only, which is simpler to
-   explain and to test but would stop someone putting `ProxyJump` in their own
-   `~/.config/harlequin/config.toml`.
+1. **Does `--ssh-option` earn its place at all?** It is the only option that needs a
+   deny-list, and everything it can express a `Host` block can express better. Dropping it
+   would take v1 to four flags and delete §6.1 outright. Keeping it is the answer for a CI job
+   or an agent with no dotfiles, which is the same audience `--ssh-forward` exists for.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -14,7 +14,7 @@ out-of-tree ones that are never changed.** Nothing here is implemented yet.
 - **No new dependencies** — the blocker on the issue since 2025 — and the user's whole
   `~/.ssh/config` comes for free: `LocalForward`, `ProxyJump`, agent, certificates, `Match`.
 - **The tunnel starts before Textual**, so a passphrase or 2FA prompt reaches a human — or
-  `--ssh-no-prompt` refuses to prompt at all, for scripts and agents. It is a child process,
+  `--ssh-batch-mode` refuses to prompt at all, for scripts and agents. It is a child process,
   not `ssh -f`, so it dies with the session instead of outliving it.
 
 ## 1. Ten seconds of SSH
@@ -94,7 +94,7 @@ end, which is all the contract says.
 harlequin -a postgres --host localhost --port 15439 --dbname prod --user tco \
   --ssh-host tco@web-1 \
   --ssh-forward 15439:data-analytics.<aws-acct>.us-east-1.redshift.amazonaws.com:5439 \
-  --ssh-no-prompt
+  --ssh-batch-mode
 ```
 
 `HostName` + `User` → `--ssh-host tco@web-1`. `LocalForward` → `--ssh-forward`, the same text
@@ -122,7 +122,7 @@ cannot ask a human to run `ssh -fN` first.
 |---|---|---|
 | `--ssh-host TEXT` | `ssh_host` | the destination, verbatim to `ssh`: a `Host` alias, `host`, `user@host`, or `ssh://user@host:port` |
 | `--ssh-forward TEXT` | `ssh_forward` | repeatable; whatever follows `ssh -L`, verbatim. Omit when `ssh_config` has it |
-| `--ssh-no-prompt` | `ssh_no_prompt` | `-o BatchMode=yes`: fail rather than ask for a passphrase, password or host key (§5.2) |
+| `--ssh-batch-mode` | `ssh_batch_mode` | ssh's `BatchMode`: fail rather than ask for a passphrase, password or host key (§5.2) |
 | `--ssh-allow-reuse` | `ssh_allow_reuse` | on a bind collision, warn and connect anyway instead of failing (§5.3) |
 | `--ssh-timeout FLOAT` | `ssh_timeout` | seconds to wait for the forwards (default 10) |
 
@@ -209,7 +209,8 @@ better than any we would write.
 **A prompt nobody answers is what the timeout catches**, and catching it late is not good
 enough for a script: `ssh` asks for a passphrase, a password, or confirmation of an unknown
 host key, and an unattended caller waits out the whole timeout and then reports something
-vague. `--ssh-no-prompt` passes `-o BatchMode=yes`, so `ssh` fails immediately and says which
+vague. `--ssh-batch-mode` passes `-o BatchMode=yes` — ssh's own name for it, so anyone who
+knows the `ssh_config` keyword knows the flag — and `ssh` fails immediately, saying which
 credential it wanted. An agent, a cron job and CI should all set it.
 
 Without the flag the timeout is still the backstop, so nothing hangs forever — and when it
@@ -267,9 +268,9 @@ No SSH server, no `online` marker.
 - **Unit**: `--ssh-forward` reaches argv unchanged and repeats in order; `--ssh-host` is
   unparsed; `-G` lines with a bind address, IPv6 and a socket path parse; `-G` returning only
   `dynamicforward` is a usage error; `-G` garbage degrades; no forward anywhere is a usage
-  error; the argv carries `ExitOnForwardFailure` and, with `--ssh-no-prompt`, `BatchMode=yes` and
+  error; the argv carries `ExitOnForwardFailure` and, with `--ssh-batch-mode`, `BatchMode=yes` and
   nothing else; `-o` still means `--output`; a timeout with the child alive names
-  `--ssh-no-prompt`; profile round trip; two ssh hosts hash differently.
+  `--ssh-batch-mode`; profile round trip; two ssh hosts hash differently.
 - One test runs `ssh -V` and skips if absent, proving the argv is accepted by a real client.
 
 Phasing: **(1)** `harlequin/ssh.py` — argv, `-G` probe and parser, poll, reuse,
@@ -307,7 +308,7 @@ contract, and the `Host` block as the recommended setup — plus a `CHANGELOG.md
 | `--tunnel-command` for non-SSH proxies | a Cloud SQL or `kubectl` user wants Harlequin to own the proxy's lifetime, with an answer to the code-execution problem above |
 | a paramiko backend, `harlequin[ssh]` | a user on Windows or in a container with no `ssh` binary |
 | reconnect after a drop | the death notification proves not to be enough |
-| `--ssh-no-prompt` on by default in `hsql` | interactive `hsql` users turn out to be rarer than scripted ones. Default-off is the same behavior in both commands today, which is easier to explain |
+| `--ssh-batch-mode` on by default in `hsql` | interactive `hsql` users turn out to be rarer than scripted ones. Default-off is the same behavior in both commands today, which is easier to explain |
 
 Each is additive: the flags are namespaced, one class has no ABC to satisfy, and no adapter is
 involved in any of it.

--- a/docs/plans/ssh-tunnels-design.md
+++ b/docs/plans/ssh-tunnels-design.md
@@ -9,29 +9,27 @@ Nothing here is implemented. This is the design to argue with before the first P
 
 ## Bottom line up front
 
-1. **The tunnel belongs to core, not to adapters.** Every adapter that talks to a network
-   database needs the same thing, and the ones that need it most are the ones this repo
-   does not own. An adapter-by-adapter implementation is N implementations, N spellings,
-   and N adapters that never get around to it.
-2. **A tunnel is two mechanisms, and they are separable**: something that makes a remote
-   endpoint reachable at `127.0.0.1:<port>`, and a **rewrite** that gets the adapter to
-   dial that address instead of the real one. The second is the hard part and the one that
-   has to work for an adapter core knows nothing about.
-3. **Ship the forwarder as a subprocess, not as a library.** `ssh -L`, plus a generic
-   `--tunnel-command` for everything that is not SSH (`cloud-sql-proxy`, `aws ssm`,
-   `kubectl port-forward`, `teleport`). This answers the four-year-old blocker on the issue
-   — sshtunnel is unmaintained, paramiko is a real dependency — with **zero new
-   dependencies**, and it inherits the user's entire `~/.ssh/config`: `ProxyJump`, agent,
-   certificates, hardware keys, `Match` blocks, 2FA. A paramiko backend stays possible
-   behind the same ABC and an extra (`harlequin[ssh]`); §9 says what would trigger it.
-4. **Rewriting is layered, and the bottom layer works with every adapter shipped today**:
-   an option's declared role (new, precise, opt-in for adapters), a name backstop for
-   `host`/`port` (the same move `harlequin.redact` already makes for passwords), and a DSN
-   rewrite inside `conn_str`. Whatever it does, it says so out loud.
-5. **The tunnel comes up before Textual does.** That is not an implementation detail: it is
-   the only way an SSH password, a key passphrase or a 2FA prompt can reach a human.
+1. **Harlequin manages a tunnel; it does not touch connection details.** The user gives the
+   adapter the address the database has **from the SSH host's side**, and the tunnel makes
+   that address true on this machine. `--ssh-forward 5432` binds `127.0.0.1:5432` here and
+   forwards it there, so a conn_str of `postgresql://user@localhost:5432/app` needs no
+   rewriting — it is already pointing at the tunnel.
+2. **That is what makes it work with any adapter.** Core never has to know which of an
+   adapter's options is the host, never parses a DSN, and adds nothing to the adapter API.
+   An adapter cannot tell it is tunneled, and one published four years ago works today.
+3. **The forwarder is a subprocess, not a library.** `ssh -L`, plus a generic
+   `--tunnel-command` for what is not SSH (`cloud-sql-proxy`, `aws ssm`,
+   `kubectl port-forward`, Teleport). **Zero new dependencies** — which answers the
+   four-year-old blocker on the issue — and it inherits the user's whole `~/.ssh/config`:
+   `ProxyJump`, agent, certificates, hardware keys, `Match` blocks, 2FA. A paramiko backend
+   stays possible behind the same ABC and an extra (`harlequin[ssh]`); §8 says what would
+   trigger it.
+4. **The tunnel comes up before Textual does.** Not an implementation detail: it is the only
+   way an SSH password, a key passphrase, or a 2FA prompt can reach a human.
 
-Scope of v1: **one hop, one forwarded endpoint, for the life of one invocation.**
+What core owns is the **lifecycle** — bring the forward up before anything connects, report
+what went wrong in the two commands' own error paths, tear it down on exit — and that is the
+whole of the feature.
 
 ---
 
@@ -44,11 +42,15 @@ Scope of v1: **one hop, one forwarded endpoint, for the life of one invocation.*
 
 Two later comments matter:
 
-- The maintainer's blocker (Feb 2025): `sshtunnel` looks perfect and has not shipped in
-  four years. paramiko was offered in reply as the maintained thing underneath it.
-- A request for **Cloud SQL** (Google's connector), which is not SSH at all. It is the
-  reason the abstraction below is "a thing that makes a remote endpoint reachable
-  locally", with SSH as one instance, rather than an SSH feature with a config file.
+- The maintainer's blocker (Feb 2025): `sshtunnel` looks perfect and has not shipped in four
+  years. paramiko was offered in reply as the maintained thing underneath it.
+- A request for **Cloud SQL**, which is not SSH at all. It is the reason the abstraction here
+  is "a subprocess that makes a remote endpoint reachable locally", with SSH as one instance.
+
+**The rewrite half of the issue is what this design drops.** §11 has the reasoning; the short
+version is that intercepting connection details means core guessing which of an adapter's
+options is a host, and guessing wrong quietly. Binding the local end to the port the user
+already typed reaches the same place with none of that.
 
 ## 2. Where the code sits today
 
@@ -61,370 +63,309 @@ Both commands build a config dict, instantiate one adapter with it, and connect:
 | connection closed | `app.py:action_quit()` | never explicitly; the process exits |
 | cache key | `adapter.connection_id` or `get_connection_hash(conn_str, config)` (`cli.py:553`) | n/a |
 
-Four existing facts the design leans on:
+Two existing facts the design leans on:
 
-- **One invocation, one adapter.** `first_pass()` already settles which one, before click
-  parses anything, and `attach_adapter_options()` puts only that adapter's options on the
-  command. So at the moment the rewrite has to happen, the adapter class is in hand and its
-  `ADAPTER_OPTIONS` can be inspected.
 - **A command's own click params are what claim a profile key.** `parse_profile_options()`
-  takes `command_options` from `{param.name for param in cmd.params}`; anything else in the
+  takes `command_options` from `{param.name for param in cmd.params}`; anything else in a
   profile must be a declared option of the adapter. New `--ssh-*` options on both commands
   therefore become valid profile keys and JSON-schema keys with no further plumbing.
-- **`AbstractOption` already carries semantics core acts on.** `secret=True` is the
-  precedent: core cannot enumerate what is sensitive across every adapter, so the adapter
-  declares it and one module acts on it.
-- **`harlequin.redact` already parses DSNs**, for the password inside them, with a
-  name-based backstop for the adapters that predate the declaration. The endpoint rewrite
-  needs the same two moves against the same strings.
+- **`first_pass()` settles the adapter before click parses anything**, so nothing here
+  changes the start-up cost of an invocation that does not tunnel.
 
-## 3. The shape
+## 3. The model
 
 ```
-                    spec (CLI + profile)
-                            |
-             harlequin.tunnel.resolve()  ──► RewritePlan   (pure; no I/O)
-                            |                    │
-                 Tunnel.start()  ──► Endpoint    │  what to dial, and where it is written
-                            |                    ▼
-                            └────────► rewritten conn_str + options
-                                                 |
-                                    adapter_cls(conn_str, **options)
+   --ssh-host bastion                        ssh -N -T \
+   --ssh-forward 5432          ───────►        -o ExitOnForwardFailure=yes \
+                                               -L 127.0.0.1:5432:localhost:5432 bastion
+
+   -a postgres                               adapter dials 127.0.0.1:5432
+   "postgresql://me@localhost:5432/app"  ──► which is the far side's localhost:5432
 ```
 
-Three pieces, in a new `harlequin/tunnel.py` (plus `harlequin/dsn.py`, §5.3):
+Two rules, and they are the whole contract:
 
-```python
-@dataclass(frozen=True)
-class Endpoint:
-    host: str
-    port: int
+1. **Connection details are read from the SSH host's side.** `localhost` means the bastion's
+   localhost. `db.internal` means whatever the bastion resolves that to.
+2. **`--ssh-forward` binds the same port locally by default**, so the address the user typed
+   is the address that now works here. `--ssh-forward 5432` is `-L 127.0.0.1:5432:localhost:5432`.
 
-class Tunnel(ABC):
-    """Something that makes one remote endpoint reachable on localhost."""
+Nothing rewrites anything. `conn_str` and every adapter option reach the adapter exactly as
+the user wrote them, and the adapter is never told a tunnel exists.
 
-    @abstractmethod
-    def start(self, remote: Endpoint) -> Endpoint:
-        """Bring the forward up and return the local endpoint. Blocks until it
-        is accepting connections. Raises HarlequinTunnelError."""
+Three spellings of `--ssh-forward`, matching `ssh -L` from the right:
 
-    def stop(self) -> None:
-        return None
+| written | means |
+|---|---|
+| `5432` | `-L 127.0.0.1:5432:localhost:5432` — the database runs on the bastion |
+| `db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` — the bastion is a jump host |
+| `15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` — something local already has 5432 |
 
-    def __enter__(self) -> Tunnel: ...
-    def __exit__(self, *exc: Any) -> None: self.stop()
-```
+Repeatable, because one `ssh` connection carries as many forwards as you like, and the IDE
+takes several `CONN_STR`s.
 
-`resolve()` is pure and is where all the interesting behavior is; the backends are small.
+### What this model gives up, and what it buys
+
+A local port collision is a **hard error**, not a workaround: `ExitOnForwardFailure=yes`
+means `ssh` exits and says `bind: Address already in use`, and the user picks a local port
+with the three-part form. That is the honest failure, and the alternative — quietly binding
+somewhere else — is the failure mode that makes people distrust the feature.
+
+What it buys, beyond not guessing:
+
+- **TLS still works the way the user asked for it.** Nothing silently changes the hostname
+  the driver validates against; whatever they typed is what gets verified.
+- **`connection_id` and the catalog cache key stay stable across runs** (§7), because there
+  is no ephemeral port in the config the hash is taken over.
+- **DuckDB and SQLite need no special case.** They ignore the tunnel; a duckdb `ATTACH` of
+  `postgres://localhost:5432/app` goes through it like anything else.
+
+### The hazard this model does have
+
+A profile that says `host = "localhost"` is only correct with the tunnel up. Run it without
+`--ssh-host` and it connects to whatever is on **your** 5432 — which on a developer's laptop
+may well be a database, just the wrong one.
+
+Mitigation, in order of how much they cost: the `ssh_*` keys live in the same profile as the
+connection details, so they travel together and the failure needs someone to have deliberately
+overridden one of them; the start-up notice (§6) says on stderr what was forwarded; and if
+this proves to bite in practice, a `require_tunnel = true` profile key can refuse to connect
+without one. Not proposed for v1.
 
 ## 4. The forwarder
 
 ### 4.1 `SubprocessTunnel` — the only backend in v1
 
-```
-ssh -N -T -o ExitOnForwardFailure=yes -L 127.0.0.1:54321:db.internal:5432 bastion
+```python
+class Tunnel(ABC):
+    """A child process that makes remote endpoints reachable on localhost."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start it and block until the forwarded ports accept connections.
+        Raises HarlequinTunnelError, quoting the child's stderr."""
+
+    def stop(self) -> None: ...
+    def __enter__(self) -> Tunnel: ...
+    def __exit__(self, *exc: Any) -> None: self.stop()
 ```
 
-- The local port is chosen by binding `127.0.0.1:0`, reading the port, and closing the
-  socket, then handing that number to `ssh`. There is a race; it is the race every tool
-  that does this has, and `ExitOnForwardFailure=yes` turns losing it into a clean error
-  rather than a silent no-forward. `--ssh-local-port` pins it for anyone who cares.
 - The child stays in the **foreground** (no `-f`) with the terminal attached, so
   `Enter passphrase for key ...` and a 2FA prompt reach the human. Readiness is a
-  connect-poll against the local port with `--tunnel-timeout` (default 10s), which also
-  notices the child exiting; on failure, the child's stderr is what the error message
-  quotes, verbatim.
-- Teardown is `terminate()` then `kill()`, from a `contextlib.ExitStack` that wraps
-  `tui.run()` and the `hsql` run, plus an `atexit` backstop.
+  connect-poll against each forwarded local port with `--tunnel-timeout` (default 10s),
+  which also notices the child exiting early; on failure the error quotes the child's stderr
+  verbatim, because `ssh`'s diagnostics are better than any we would write.
+- Teardown is `terminate()` then `kill()`, from a `contextlib.ExitStack` wrapping `tui.run()`
+  and the `hsql` run, plus an `atexit` backstop.
+- `-o ServerAliveInterval=30`. No reconnect in v1: a dead tunnel surfaces as the adapter's own
+  connection error, which is already an error modal in the IDE and exit 3 in `hsql`.
 
-The user's `~/.ssh/config` is read by `ssh` itself. `--ssh bastion` gets `HostName`, `User`,
-`Port`, `IdentityFile`, `ProxyJump`, `Match` — all of it, correct, for free, and matching
-whatever the user already tests with `ssh bastion`. This is the single strongest argument
-for the subprocess: **the configuration surface is not ours to reimplement or to document.**
+The user's `~/.ssh/config` is read by `ssh` itself, so `--ssh-host bastion` picks up
+`HostName`, `User`, `Port`, `IdentityFile` and `ProxyJump` from a `Host bastion` block — all
+of it, correct, and matching whatever the user already tests with `ssh bastion`. This is the
+strongest argument for the subprocess: **that configuration surface is not ours to
+reimplement or to document.**
 
-### 4.2 `--tunnel-command` — the same backend, for everything that is not SSH
+### 4.2 `--tunnel-command` — the same lifecycle, for what is not SSH
 
 ```bash
-hsql --tunnel-command 'cloud-sql-proxy --port {local_port} my-proj:us-central1:pg' -a postgres
-hsql --tunnel-command 'aws ssm start-session --target i-0abc --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host={remote_host},portNumber={remote_port},localPortNumber={local_port}'
-hsql --tunnel-command 'kubectl port-forward svc/pg {local_port}:{remote_port}'
+hsql --tunnel-command 'cloud-sql-proxy --port 5432 my-proj:us-central1:pg' --tunnel-port 5432
+hsql --tunnel-command 'kubectl port-forward svc/pg 5432:5432' --tunnel-port 5432
 ```
 
-Placeholders: `{local_port}`, `{remote_host}`, `{remote_port}`. Same lifecycle, same
-readiness poll, same teardown; `--ssh` is sugar over it with an argv we build.
+The command binds whatever port the user's connection details name — the same contract as
+§3, so there is nothing to substitute. `--tunnel-port` (repeatable) is what the readiness
+poll watches; omit it and Harlequin starts the child and carries on.
 
-This is ~40 lines on top of the SSH backend and it covers the Cloud SQL request on the
-issue, every corporate access proxy, and the next one nobody has heard of yet. It is also
-what makes the whole feature **testable in CI without an SSH server** (§10).
+Roughly 30 lines on top of the SSH backend. It covers the Cloud SQL request on the issue,
+every corporate access proxy, and the next one nobody has heard of yet — and it is what makes
+the whole feature **testable in CI without an SSH server** (§9).
 
-### 4.3 What v1 does not do
+### 4.3 Not in v1
 
-One hop and one endpoint. Multiple forwards over one `ssh` connection is a one-line
-extension (`-L` repeats) and can wait for someone who wants it. No reconnect: `ssh` gets
-`-o ServerAliveInterval=30`, and a dead tunnel surfaces as the adapter's own connection
-error, which is already an error modal in the IDE and exit 3 in `hsql`.
+Reconnect, and `ssh` control-socket multiplexing (which would let a second Harlequin reuse a
+live connection, and which Windows OpenSSH does not support anyway).
 
-## 5. The rewrite — the part that has to work with any adapter
+## 5. Public API impact
 
-`resolve()` answers two questions with no I/O: **what remote endpoint is this invocation
-about to dial**, and **where do I write the local one so the adapter uses it**. It returns
-a plan, which the CLI applies after `Tunnel.start()`:
+**None.** No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`,
+`AbstractOption`, `catalog.py` or `driver.py`. One new `HarlequinTunnelError(HarlequinError)`
+in `exception.py`, and one new module, `harlequin/tunnel.py`.
 
-```python
-@dataclass(frozen=True)
-class RewritePlan:
-    remote: Endpoint
-    sites: tuple[Site, ...]      # option pair, or a span inside a conn_str
-    described: str               # "--host/--port", "conn_str[0]" -- what we print
-```
-
-Three sources, in precedence order. All of them are consulted; if two name **different**
-remote endpoints, that is an error naming both, resolved by `--tunnel-remote HOST:PORT`.
-
-### 5.1 Declared roles (new, precise, opt-in)
-
-An additive keyword on `AbstractOption`, exactly parallel to `secret=`:
-
-```python
-TextOption(name="host", ..., role="host")
-TextOption(name="port", ..., role="port")
-```
-
-- `role: ClassVar[str] = ""` as a class attribute and a ctor kwarg, so a third-party
-  subclass that predates it still answers (the `getattr` move `to_dict()` already makes).
-- Reported by `to_dict()`, so it shows up in `hsql --spec` and the generated config schema.
-- Nothing in core requires it. It is how an adapter with an unguessable spelling
-  (`--server`, `--endpoint`, `--bootstrap-servers`) opts into being tunneled correctly, and
-  the in-tree adapters have nothing to declare.
-
-### 5.2 The name backstop (works with every adapter installed today)
-
-When no option declares a role, core matches option names — `host`, `hostname`, `server`,
-`address` paired with `port` — the same way `redact._SECRET_NAME` matches password-ish keys,
-and for exactly the same reason: **every adapter's options predate the declaration**, and an
-adapter the user installed last year is the whole point of the feature.
-
-This is a guess, so it is guarded three ways:
-
-1. It only runs when the user asked for a tunnel. Nothing changes for anyone else.
-2. It only matches options **the invocation actually set** (CLI or profile). An unset option
-   is not evidence of anything.
-3. **It prints what it did.** `hsql` on stderr, the IDE as a notification and on the debug
-   screen:
-   ```
-   tunnel: forwarding db.internal:5432 -> 127.0.0.1:54321 (ssh bastion); rewrote --host, --port
-   ```
-   Visibility is the mitigation for a wrong guess, and it is also the thing that tells a
-   user their adapter needs `role=` upstream.
-
-### 5.3 Inside `conn_str`
-
-Adapters that take a DSN (`postgres://user:pw@db.internal:5432/app`) carry the endpoint
-positionally, where no option describes it. Core rewrites the host and port **in place** for
-two forms:
-
-- URI-shaped: `scheme://[user[:pass]@]host[:port][/...]`
-- libpq keyword-shaped: `host=db.internal port=5432 dbname=app`
-
-Anything else is refused with a message pointing at `--tunnel-remote` and the adapter's own
-host option. `redact.py` already has regexes for the second thing it finds in these strings;
-this proposes lifting the parse into `harlequin/dsn.py` and having both callers use it, so
-"where is the host in a DSN" and "where is the password in a DSN" cannot drift apart. (The
-existing precedent for two implementations of one string question is
-`export._deduplicate_column_names()`, and AGENTS.md is not fond of it.)
-
-### 5.4 When there is nothing to rewrite
-
-DuckDB, SQLite, and any adapter with no network endpoint: `resolve()` finds no site, and the
-invocation **fails** with a usage error rather than silently connecting around the tunnel.
-
-```
-hsql: no host to forward for adapter 'duckdb'.
-      This adapter declares no host option and the connection string names no host.
-      Use --tunnel-remote HOST:PORT if you meant to forward something else.
-```
-
-Failing loudly matters: the silent version connects straight to a database the user believed
-was reachable only through a bastion.
+That an adapter cannot tell it is tunneled is not an accident of the design — it is the
+property being bought, and it is why this works for adapters nobody in this org maintains.
 
 ## 6. The CLI and config surface
 
-New options on **both** commands (a profile serves both, and `hsql` is where an agent or a
-cron job needs this most). All are `ssh_*`/`tunnel_*` profile keys with the same spelling.
+New options on **both** commands. A profile serves both, and `hsql` is where this matters
+most: a cron job or an agent cannot ask a human to run `ssh -L` in another terminal first.
 
 | option | meaning |
 |---|---|
-| `--ssh [user@]host[:port]` | the jump host, as `ssh` would take it; also an alias from `~/.ssh/config` |
-| `--ssh-identity PATH` | `-i` |
-| `--ssh-option KEY=VALUE` | repeatable `-o` passthrough; the escape hatch for everything not listed |
-| `--tunnel-command TEXT` | §4.2; mutually exclusive with `--ssh` |
-| `--tunnel-remote HOST:PORT` | name the remote endpoint instead of discovering it |
-| `--tunnel-local-port INT` | pin the local port (default: ephemeral) |
-| `--tunnel-timeout FLOAT` | seconds to wait for the forward (default 10) |
+| `--ssh-host TEXT` | the jump host, or a `Host` alias from `~/.ssh/config` |
+| `--ssh-user TEXT` | `ssh -l`; defaults to whatever ssh_config or the local user says |
+| `--ssh-port INT` | the SSH port, if not 22 |
+| `--ssh-identity PATH` | `ssh -i` |
+| `--ssh-forward TEXT` | repeatable; `PORT`, `HOST:PORT`, or `LOCAL:HOST:PORT` (§3) |
+| `--ssh-option KEY=VALUE` | repeatable `-o` passthrough; the escape hatch for the rest |
+| `--tunnel-command TEXT` | §4.2; mutually exclusive with `--ssh-host` |
+| `--tunnel-port INT` | repeatable; ports the readiness poll waits for |
+| `--tunnel-timeout FLOAT` | seconds to wait (default 10) |
 
-Seven spellings, namespaced. `hsql`'s flags are the frozen part of its API, so these join the
-reserved set in `first_pass.attach_adapter_options()`: an adapter that declares `--ssh-host`
-today loses that spelling and keeps the option under its profile key, visibly, in `--help`.
-(Worth a survey of published adapters before merging; I know of none that claims one.)
+`--ssh-host` with no `--ssh-forward` is a usage error naming the three spellings: a tunnel
+that forwards nothing is always a mistake, and it is better caught before an SSH handshake
+than after one.
 
-No password flags. `--ssh-password` would be a credential in `ps` output and in shell
-history for a case `ssh` already handles better with keys, an agent, or its own prompt. If
-one is added later it is `secret=True` and `redact._SECRET_NAME` grows `passphrase`, which it
-is missing today.
+No password flag. `--ssh-password` would be a credential in `ps` output and in shell history,
+for a case `ssh` already handles better with a key, an agent, or its own prompt. If one is
+ever added it is `secret=True`, and `redact._SECRET_NAME` grows `passphrase`, which it is
+missing today.
 
-In a config file, unremarkably:
+`hsql`'s flags are the frozen part of its API, so these join the reserved spellings in
+`first_pass.attach_adapter_options()`: an adapter that declares `--ssh-host` today would lose
+that spelling, visibly, in `--help`, and keep the option under its profile key. Worth a survey
+of published adapters before merging; I know of none that claims one.
+
+In a config file, unremarkably — and note that the connection details are the far side's:
 
 ```toml
 [profiles.prod]
 adapter = "postgres"
-host = "db.internal"
+host = "localhost"
 port = 5432
 dbname = "app"
-ssh = "bastion.example.com"
+ssh_host = "bastion.example.com"
+ssh_forward = ["5432"]
 ```
 
-Both commands pick this up through the existing profile merge; `config_schema.py` generates
-the keys from click params, so `schemas/config-v1.json` regenerates with
-`scripts/write_config_schema.py` and the schema test keeps them honest.
+Both commands pick this up through the existing profile merge. `config_schema.py` generates
+its keys from click params, so `schemas/config-v1.json` regenerates with
+`scripts/write_config_schema.py`, and the schema test keeps them honest.
 
-## 7. Ordering, and why the tunnel comes up before Textual
+**The start-up notice.** `hsql` on stderr (never stdout — that belongs to query output), the
+IDE as a notification and on the debug screen:
 
 ```
-first_pass -> click parses -> profile merge -> resolve()  [pure]
-                                                  |
-                                            Tunnel.start()      <-- prompts happen HERE
-                                                  |
-                                            apply the plan
-                                                  |
-                              adapter_cls(...) -> tui.run() / hsql runs
+tunnel: 127.0.0.1:5432 -> localhost:5432 via ssh bastion.example.com
+```
+
+One line, and it is what tells a user which database they are actually looking at.
+
+## 7. Ordering, cache keys, and the two commands
+
+```
+first_pass -> click parses -> profile merge -> Tunnel.start()   <-- prompts happen HERE
+                                                     |
+                                        adapter_cls(...) -> tui.run() / hsql runs
+                                                     |
+                                              ExitStack unwinds -> Tunnel.stop()
 ```
 
 The IDE opens its database on a worker thread after the app is running, which is right for a
 database and wrong for a tunnel: once Textual owns the terminal, `ssh` cannot ask for a
-passphrase, and a 2FA push has nowhere to print "check your phone". Starting the tunnel in
-the click callback also means one error path for both commands —
-`pretty_print_error` / `diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) —
-before a single widget is mounted.
+passphrase and a 2FA push has nowhere to print "check your phone". Starting the tunnel in the
+click callback also means one error path for both commands — `pretty_print_error` /
+`diagnostics.report_error`, exit code 3 (`ExitCode.CONNECTION`) — before a widget is mounted.
 
-The cost is that `harlequin --ssh ...` authenticates before showing a UI, which is what every
-CLI that tunnels does, and is what the user expects from having typed an SSH flag.
+The cost is that `harlequin --ssh-host …` authenticates before showing a UI, which is what
+every CLI that tunnels does and what a user who typed an SSH flag expects.
 
-## 8. Two things that break quietly if we forget them
+**Cache keys need one small change.** Nothing is rewritten, so `get_connection_hash()` and
+`adapter.connection_id` are already stable across runs — but two bastions fronting two
+databases both look like `localhost:5432`, and would share a catalog cache and a query
+history. The ssh destination (and the forward specs) join the hashed material.
 
-**Cache keys.** `get_connection_hash(conn_str, config)` is computed from the config dict, and
-`adapter.connection_id` is usually a hydrated connection string. Hash the **pre-rewrite**
-values, or an ephemeral local port changes the key on every run and the user silently loses
-query history and the catalog cache. Concretely: compute the hash in `cli.py` before applying
-the plan, and when a tunnel is active prefer it over `adapter.connection_id` (which will have
-`127.0.0.1:54321` baked into it). The ssh destination joins the hashed material, so two
-bastions to two databases do not collide.
+## 8. Dependencies, imports, packaging
 
-**TLS.** An adapter told to connect to `127.0.0.1` will fail certificate hostname
-verification under `sslmode=verify-full` and friends. Core cannot fix this generically —
-libpq has `host`/`hostaddr` for exactly this, other drivers have nothing — so it is
-documented, and the rewrite notice is the place a user finds out why their `verify-full`
-connection started failing.
+**v1 adds no dependency at all**: `subprocess`, `socket`, `shlex`.
 
-## 9. Dependencies, imports, packaging
-
-**v1 adds no dependency at all.** `subprocess`, `socket`, `shlex`.
-
-`harlequin/tunnel.py` and `harlequin/dsn.py` import no Textual and no adapter; both join the
-"adapter API is reachable without the TUI" import-linter contract, and `harlequin.tunnel` is
-imported from the CLI callbacks only when a tunnel was asked for, so an invocation without
-one pays nothing (`scripts/cold_start.py` should show no change).
+`harlequin/tunnel.py` imports no Textual and no adapter, and joins the "adapter API is
+reachable without the TUI" import-linter contract. It is imported from the CLI callbacks only
+when a tunnel was asked for, so an invocation without one pays nothing —
+`scripts/cold_start.py` should show no change.
 
 **When paramiko would earn its place** — as `harlequin[ssh]`, a second `Tunnel`
-implementation, no change anywhere else:
+implementation, nothing else changing:
 
-- Windows users without OpenSSH (it ships with Windows 10+, but is removable and absent from
-  many CI images).
+- Windows users without OpenSSH. It ships with Windows 10+, but is removable.
 - Containers: this repo's own dev container has no `ssh` binary, and neither does the
   `python:3.x-slim` image most people build on.
-- Anything needing in-process sockets rather than a listener — which is also the shape the
-  Google Cloud SQL *connector* (as opposed to its proxy binary) wants, and the one thing
-  `--tunnel-command` genuinely cannot express.
+- Anything wanting in-process sockets rather than a listener — which is the shape Google's
+  Cloud SQL *connector* (as opposed to its proxy binary) wants, and the one thing
+  `--tunnel-command` cannot express.
 
 Until one of those has a user asking, the argument on the issue stands: an unmaintained
-wrapper is not worth taking, and a maintained one is still a cryptography dependency for
-every Harlequin install to solve a problem `ssh` already solves on the same machine.
+wrapper is not worth taking, and a maintained one is still a `cryptography` dependency on
+every Harlequin install, to solve a problem `ssh` already solves on the same machine.
 
-## 10. Testing
+## 9. Testing
 
-**Unit, no network** — `resolve()` is a pure function and gets the table:
-
-| adapter shape | conn_str | options set | expected |
-|---|---|---|---|
-| declares `role="host"`/`"port"` | — | `--server`, `--port` | rewrites both |
-| `host`/`port` names only | — | `--host`, `--port` | rewrites both, with a notice |
-| DSN, URI form | `postgres://u@db:5432/app` | — | rewrites the span |
-| DSN, libpq form | `host=db port=5432` | — | rewrites both keys |
-| both, agreeing | DSN + `--host` | | rewrites both sites |
-| both, disagreeing | | | `HarlequinTunnelError`, names both |
-| duckdb / sqlite | file path | | usage error, §5.4 |
-| DSN we cannot parse | `weird::thing` | | usage error naming `--tunnel-remote` |
-
-**End to end, no SSH server.** `--tunnel-command` makes the whole path testable with a
-python subprocess as the forwarder:
+**End to end, no SSH server, no `online` marker.** `--tunnel-command` makes the whole
+lifecycle testable with a Python child as the forwarder:
 
 ```python
---tunnel-command "{sys.executable} -m tests.tcp_forward {local_port} {remote_host} {remote_port}"
+--tunnel-command "{sys.executable} -m tests.tcp_forward 5432 127.0.0.1 {real_port}"
+--tunnel-port 5432
 ```
 
-A ~30-line loopback TCP forwarder in `tests/`, a real SQLite-over-TCP or a stub server on the
-far side, and the test asserts the adapter actually reached through it, that the local port
-was substituted, and that the child is dead after the command exits. Runs on all three OSes,
-needs no `online` marker, no secrets, no `ssh`.
+A ~30-line loopback TCP forwarder in `tests/`, a stub server on the far side, and the test
+asserts that the adapter reached through it, that the readiness poll waited, and that the
+child is dead once the command exits. Runs on all three OSes and needs no secrets.
 
-**The SSH argv** is asserted as data (`_ssh_argv(spec, remote, local) == [...]`) rather than
-by running it. One test does run `ssh -V` and skips if absent, to prove the built argv is at
-least accepted by a real client where one exists.
+**Unit, no network:**
 
-## 11. Public API impact
+| case | expected |
+|---|---|
+| `--ssh-forward 5432` | argv contains `-L 127.0.0.1:5432:localhost:5432` |
+| `--ssh-forward db.internal:5432` | `-L 127.0.0.1:5432:db.internal:5432` |
+| `--ssh-forward 15432:db.internal:5432` | `-L 127.0.0.1:15432:db.internal:5432` |
+| `--ssh-forward` repeated | one child, two `-L` |
+| `--ssh-host` with no `--ssh-forward` | usage error, exit 2 |
+| `--ssh-host` and `--tunnel-command` | usage error, exit 2 |
+| a garbage forward spec | usage error naming the three forms |
+| child exits during the poll | `HarlequinTunnelError` quoting its stderr, exit 3 |
+| poll times out | ditto, naming `--tunnel-timeout` |
+| profile round trip | `ssh_host`/`ssh_forward` survive the merge and reach the argv |
+| cache key | two ssh hosts, same conn_str, two different hashes |
 
-Additive only; every out-of-tree adapter keeps working untouched:
+One test runs `ssh -V` and skips if absent, to prove the built argv is accepted by a real
+client where one exists.
 
-- `AbstractOption.role` — new class attribute + ctor kwarg + `to_dict()` key. Adapters that
-  never set it are handled by §5.2.
-- `HarlequinTunnelError(HarlequinError)` in `exception.py`.
-- No change to `HarlequinAdapter`, `HarlequinConnection`, `HarlequinCursor`, `catalog.py` or
-  `driver.py`. **An adapter does not know it is tunneled**, which is the property that makes
-  this work for adapters nobody in this org maintains.
+## 10. Phasing
 
-## 12. Alternatives considered
+1. **`harlequin/tunnel.py`** — the `Tunnel` ABC, `SubprocessTunnel`, argv construction, the
+   readiness poll, `HarlequinTunnelError`. Unit tests only; no CLI. Mergeable alone.
+2. **Wire it into both commands** — the options, the `ExitStack`, the notice, the cache-key
+   change, and the loopback end-to-end test.
+3. **`--tunnel-command`**, `--info` / debug-screen reporting, regenerated config schema.
+4. **Docs** in `tconbeer/harlequin-web` — including the "details are the far side's" contract,
+   which is the whole of what a user has to learn — and a `CHANGELOG.md` entry under
+   `[Unreleased]` → Features, referencing
+   [#545](https://github.com/tconbeer/harlequin/issues/545).
+
+## 11. Alternatives considered
 
 | | why not |
 |---|---|
-| **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings; the adapters that need it most are out-of-tree. Exactly the "workaround here is a permanent tax" case AGENTS.md warns about — except the tax is paid N times, by other people. |
-| **A library adapters call (`harlequin-tunnel`)** | Adapters must opt in, so "works with any adapter" becomes "works with adapters that adopted it". Reasonable *in addition*, for an adapter that wants a tunnel inside its own connection (Cloud SQL connector); not a substitute. |
-| **`sshtunnel`** | The blocker on the issue. Four years without a release, and it is a wrapper over paramiko that we would be depending on for ~150 lines of behavior. |
-| **paramiko directly, in v1** | A real dependency (cryptography) on every install, and it reimplements the part of `~/.ssh/config` users already have working — `paramiko.SSHConfig` handles some of it, not `Match`, not certificates, not the agent story on Windows. Kept as the v2 backend, §9. |
-| **Tell users to run `ssh -L` themselves** | It works, and it is what people do today. It also means two terminals, a remembered port, and a profile that only works if a human ran something first — which is precisely what `hsql` in a cron job or an agent loop cannot do. |
-| **A nested `[profiles.x.ssh]` config table** | Prettier in TOML, but the CLI merge is flat by name (`merge_profile_with_cli`), so it would need a second mapping between flag names and config keys. Not worth it for seven keys. |
+| **Rewriting the adapter's host/port** (the issue's original sketch, and an earlier draft of this doc) | Core has to know which option is the host. There is no general answer: it would take a new `role=` declaration on `AbstractOption` that no published adapter has, a name-matching backstop for `host`/`port` that is a guess, and an in-place DSN rewrite for adapters that take a positional conn_str — three mechanisms, each with a way to be quietly wrong, to reach where `-L 5432:localhost:5432` reaches with none. It also bakes an ephemeral local port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification without the user having asked for it. |
+| **A `{tunnel_port}` placeholder** the user writes into their conn_str | Fully general and explicit, and it survives any option spelling — but it is a second thing to learn for the same result, and it makes a profile unusable without the tunnel rather than merely wrong. Worth revisiting only if the port-collision case turns out to be common. |
+| **A SOCKS proxy (`ssh -D`) with `socket.socket` patched** | The one design where the driver keeps the real hostname, so TLS verification is untouched. It only works for pure-Python drivers: psycopg2, mysqlclient, ODBC and duckdb's extensions open sockets in C and never see Python's `socket` module. |
+| **Each adapter grows `--ssh-*`** | N implementations of one thing, N spellings, and the adapters that need it most are out-of-tree. |
+| **A library adapters call (`harlequin-tunnel`)** | Adapters must opt in, so "works with any adapter" becomes "works with adapters that adopted it". Reasonable *in addition*, for an adapter that wants a tunnel inside its own connection (the Cloud SQL connector); not a substitute. |
+| **`sshtunnel`** | The blocker on the issue: four years without a release, and it is a wrapper over paramiko for behavior we would otherwise get from a binary already on the machine. |
+| **paramiko directly, in v1** | A `cryptography` dependency on every install, and it reimplements the part of `~/.ssh/config` users already have working. Kept as the v2 backend, §8. |
+| **Tell users to run `ssh -L` themselves** | It works, and it is what people do today. It also means two terminals, a remembered port, and a profile that only connects if a human ran something first — which is exactly what `hsql` in a cron job or an agent loop cannot do. |
 
-## 13. Phasing
+## 12. Open questions for review
 
-1. **`harlequin/dsn.py`** — lift the DSN parse out of `redact.py`, no behavior change, tests
-   pin the existing redaction. Small, mergeable alone.
-2. **`harlequin/tunnel.py`: `resolve()` + `RewritePlan`** — pure, plus `AbstractOption.role`
-   and the `to_dict()` key. The §10 table is the whole test suite. No CLI yet.
-3. **`SubprocessTunnel` + `--tunnel-command`** on both commands, with the lifecycle, the
-   notice, the cache-key fix, and the loopback end-to-end test.
-4. **`--ssh` and friends** — argv construction over PR 3, reserved spellings in
-   `attach_adapter_options()`, `--info` / debug-screen reporting, regenerated config schema.
-5. **Docs** in `tconbeer/harlequin-web`, and a `CHANGELOG.md` entry under `[Unreleased]`
-   → Features, referencing [#545](https://github.com/tconbeer/harlequin/issues/545).
-
-## 14. Open questions for review
-
-1. **Is the name backstop (§5.2) acceptable?** It is what makes the feature work with the
-   adapters people have installed right now, and it is a guess that prints itself. The strict
-   alternative is `role=` only, which means the feature does nothing useful until every
-   adapter ships a release.
-2. **`--ssh` sugar in v1, or `--tunnel-command` alone?** The generic one is strictly more
-   powerful and half the code; the sugar is what makes the feature discoverable and is what
-   the issue asks for.
-3. **Should `harlequin` (the IDE) offer to keep the tunnel across a reconnect** if a
-   reconnect action is ever added? Nothing needs it today.
-4. **Multiple `conn_str`s** are supported by the IDE. v1 forwards one endpoint and errors on
-   two distinct ones. Is anyone attaching two remote databases through one bastion?
+1. **Is `--ssh-forward` required, or can it default to `--ssh-port`-style guessing?** Required
+   is proposed. The alternative is reading the conn_str to find a port, which is the
+   inference this design exists to avoid — but it would make the common case one flag.
+2. **Should the local bind address be configurable?** `127.0.0.1` is proposed and hardcoded.
+   `0.0.0.0` would expose the far side's database to the user's network, which seems like a
+   thing to make people ask for.
+3. **`require_tunnel = true`** as a profile key, for the §3 hazard — worth it now, or wait for
+   someone to be bitten?
+4. **Flag naming**: `--ssh-*` for the SSH backend and `--tunnel-*` for the generic one reads
+   well but splits `--tunnel-timeout` away from its siblings. All `--ssh-*` with
+   `--ssh-command`? All `--tunnel-*`?


### PR DESCRIPTION
Refs #545. This is the design only — no implementation — so it does not close the issue.

Adds `docs/plans/ssh-tunnels-design.md`.

**What** are the key elements of this solution?

- **Harlequin runs `ssh`; it does not touch connection details.** The user's connection details already name the local end of a forward, so `host = "localhost"`, `port = 15439` reaches the adapter exactly as typed. Core never learns which adapter option is the host, never parses a DSN, and adds nothing to the adapter API — which is why it works with any adapter, including out-of-tree ones that are never changed.
- **Five flags, all `--ssh-*`, none of them parsed**: `--ssh-host` and `--ssh-forward` go to `ssh` verbatim (`ssh` owns its own syntax and error messages), plus `--ssh-batch-mode`, `--ssh-allow-reuse` and `--ssh-timeout`. A setup those cannot express goes in a `~/.ssh/config` `Host` block, which `--ssh-host` names — so the motivating case is one profile key.
- **No new dependencies**, which answers the blocker on the issue since Feb 2025, and the user's whole ssh config comes for free: `LocalForward`, `ProxyJump`, agent, certificates, `Match`.
- **The tunnel starts before Textual**, so a passphrase or 2FA prompt can reach a human, and it is a child process rather than `ssh -f`, so it dies with the session instead of outliving it.
- **A keep-open and recovery strategy**: impose `ServerAliveInterval` only when the resolved config sets none; notify on an unexpected exit; and lazily restart `ssh` *and* reconnect the adapter before the next database action in the IDE.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The issue's original sketch was to intercept and rewrite the host/port passed to the adapter. That needs core to know which option is the host, and there is no general answer — it would take a new `role=` declaration no published adapter has, a name-matching guess, and a DSN rewrite, three mechanisms that can each be quietly wrong. It also bakes an ephemeral port into `connection_id` (losing the catalog cache every run) and breaks TLS hostname verification unasked. Binding the local end to the port the user already typed reaches the same place with none of that.

Alternatives assessed and rejected are collected in §8 of the doc, each with its reason: an `--ssh-option KEY=VALUE` passthrough (`-o ProxyCommand=…` is arbitrary code execution, and config files are discovered in the working directory), `--ssh-config PATH`, `sshtunnel` and paramiko, a SOCKS proxy with `socket.socket` patched, per-adapter `--ssh-*`, and "just run `ssh -fN` yourself". §8 also lists what is deferred and what would bring each back.

Tradeoffs worth flagging for review:

- A profile that says `host = "localhost"` is only correct with its tunnel up. The doc recommends a distinct local port so that mistake is a connection refused rather than the wrong database.
- One extra `ssh -G` subprocess (~20ms) on tunneled invocations, to learn which local port to wait on before the adapter connects — in the motivating case the forward is in the `Host` block and Harlequin never saw a port. It degrades to a short grace period if `-G` fails or cannot be parsed.
- Recovery reconnects the adapter, which loses session state (open transactions, temp tables). The notification says so rather than letting a user believe they are still inside a `BEGIN`.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: a topic on tunnels covering the contract (your connection details name the local end of the forward), the five flags, and the `Host` block as the recommended setup. It belongs with the implementation, not with this design.

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary. This PR adds a document. §7 specifies the test plan for the implementation: lifecycle tests on all three OSes driving `SshTunnel` with a Python child, an end-to-end test using a fake `ssh` on `PATH`, and unit tests for argv construction and `-G` parsing — no SSH server and no `online` marker anywhere.

Please complete the following checklist:
- [ ] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. — deliberately not: nothing here is user-facing yet. The entry belongs with the implementation, and §7's phasing says so.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aeuZNWbRfdiELvLju8VMU)_