### PR TITLE
Document the catalog modes, and secrets, in hsql's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ $ hsql -P dev -c "select * from users"
 (2 rows)
 ```
 
+hsql can also explore the catalog without writing SQL: `hsql --catalog --path mydb.analytics` lists a schema's relations (and `--path mydb.analytics.orders` lists that table's columns), while `hsql --catalog-search customer_id` searches every level at once.
+
 For more information on hsql, see the [getting started docs](https://harlequin.sh/docs/getting-started/hsql).
 
 ## Using Harlequin with Django

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -230,11 +230,7 @@ $ hsql "path/to/duck.db" --catalog --path duck.analytics
  duck.analytics.order_totals | order_totals | "analytics"."order_totals" | VIEW       | v
  duck.analytics.orders       | orders       | "analytics"."orders"       | BASE TABLE | t
 (3 rows)
-```
 
-Describing a table is listing it: a relation's children are its columns.
-
-```bash
 $ hsql "path/to/duck.db" --catalog --path duck.analytics.orders
  path                              | name        | query_name    | type          | type_label
 -----------------------------------+-------------+---------------+---------------+------------
@@ -245,27 +241,6 @@ $ hsql "path/to/duck.db" --catalog --path duck.analytics.orders
 (4 rows)
 ```
 
-Every listing has the same five columns:
-
-- `path` — pass it back to `--path` to list this object's children.
-- `name` — the object's name.
-- `query_name` — the identifier to paste into a query, quoted the way this database wants it, so you never have to guess between `"Orders"` and `` `orders` ``.
-- `type` — the database's own name for what this is: `DECIMAL(18,2)`, `BASE TABLE`, `schema`. Some adapters do not report it, and leave it empty.
-- `type_label` — the short label Harlequin shows in its Data Catalog, which every adapter fills in.
-
-How many levels there are, and what they mean, is the adapter's to say: DuckDB has databases, schemas, relations and columns, and other databases differ. Start with `--catalog` and no `--path` to see the top.
-
-A path is dotted segments, and it is not SQL: a segment that contains a dot, a double quote, or a `*` is written in double quotes — `--path 'duck."my.schema".orders'` — on every adapter, whatever that database quotes its own identifiers with. A `*` in the last segment filters the listing:
-
-```bash
-$ hsql "path/to/duck.db" --catalog --path 'duck.analytics.ord*'
- path                        | name         | query_name                 | type       | type_label
------------------------------+--------------+----------------------------+------------+------------
- duck.analytics.order_totals | order_totals | "analytics"."order_totals" | VIEW       | v
- duck.analytics.orders       | orders       | "analytics"."orders"       | BASE TABLE | t
-(2 rows)
-```
-
 A listing is rows, so every format and output option applies to it, exactly as they do to a query:
 
 ```bash
@@ -274,8 +249,6 @@ duck.analytics.customers,customers,"""analytics"".""customers""",BASE TABLE,t
 duck.analytics.order_totals,order_totals,"""analytics"".""order_totals""",VIEW,v
 duck.analytics.orders,orders,"""analytics"".""orders""",BASE TABLE,t
 ```
-
-`--limit` does not, and says so on stderr: it makes the database fetch fewer rows, and a listing is not a query. Cap a long listing with `--display-rows` instead, which the footer reports as `(1 of 2 rows)`.
 
 ### Searching the Catalog
 
@@ -291,7 +264,7 @@ $ hsql "path/to/duck.db" --catalog-search customer_id
 (3 rows)
 ```
 
-The rows are a listing's rows, so the same columns and the same formats apply, and `--path` narrows the search to one subtree:
+`--path` narrows the search to one subtree, and the output can be laid out like any query:
 
 ```bash
 $ hsql "path/to/duck.db" --catalog-search order --path duck.analytics -tA
@@ -299,15 +272,7 @@ duck.analytics.order_totals|order_totals|"analytics"."order_totals"|VIEW|v
 duck.analytics.orders|orders|"analytics"."orders"|BASE TABLE|t
 ```
 
-Searching is an optional adapter capability, because not every database can answer it in one query. The DuckDB and SQLite adapters can; an adapter that does not declare it says so and exits `2`, rather than quietly walking its whole catalog. `--info` reports which of yours can:
-
-```bash
-$ hsql --info -a duckdb | jq '.adapters.duckdb.capabilities'
-{
-  "implements_cancel": true,
-  "implements_catalog_search": true
-}
-```
+Note: not all adapters support catalog search at this time.
 
 ## Scripting with hsql
 

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -135,7 +135,22 @@ $ hsql -P dev -c "select * from users" --vertical --limit 5
 $ hsql -P warehouse -c "..." --parquet -o invoices.pq
 ```
 
-hsql reads the same config files as Harlequin, and merges them one profile at a time, nearest file first; pass `--config-path PATH` to read a single file instead, or `-P None` to skip them entirely. A profile's string values can name environment variables — `password = "${MYPASSWORD}"`, or `${MYHOST:-localhost}` to supply a default — so a config file your team shares holds no credentials. Values an adapter declares as secrets are masked wherever hsql prints them, including the password inside a connection string.
+hsql reads the same config files as Harlequin, and merges them one profile at a time, nearest file first; pass `--config-path PATH` to read a single file instead, or `-P None` to skip them entirely.
+
+### Keeping Credentials Out of Config Files
+
+A profile's string values can name environment variables, so a config file your team shares — and commits — holds no credentials:
+
+```toml
+[profiles.prod]
+adapter = "postgres"
+host = "${MYHOST:-localhost}"  # ${VAR:-default} supplies a default
+password = "${MYPASSWORD}"     # ${VAR} is required; hsql exits 2 if it is unset
+```
+
+Write `$${` for a literal `${`, if a value really does start with one.
+
+Values an adapter declares as secrets are masked wherever hsql prints them — `--config show`, `--info`, and error messages — as is the password inside a connection string.
 
 ### Inspecting and Writing Config Files
 
@@ -184,6 +199,114 @@ Additionally, for any layout, pass `--stats` to print summary info as JSON to st
 ```bash
 $ hsql -c "select 1" --format none  --stats
 {"status":"ok","statements":1,"rows":1,"truncated":false,"limit":500,"elapsed_ms":1,"columns":[{"name":"1","type":"#"}]}
+```
+
+## Exploring the Catalog
+
+Before you can write a query, you have to know what is in the database. `--catalog` lists the objects one level below `--path`, and exits without running SQL:
+
+```bash
+$ hsql "path/to/duck.db" --catalog
+ path | name | query_name | type     | type_label
+------+------+------------+----------+------------
+ duck | duck | "duck"     | database | db
+(1 row)
+```
+
+Every row's `path` is what lists that object's own children, so you walk down one level at a time:
+
+```bash
+$ hsql "path/to/duck.db" --catalog --path duck
+ path           | name      | query_name         | type   | type_label
+----------------+-----------+--------------------+--------+------------
+ duck.analytics | analytics | "duck"."analytics" | schema | sch
+ duck.main      | main      | "duck"."main"      | schema | sch
+(2 rows)
+
+$ hsql "path/to/duck.db" --catalog --path duck.analytics
+ path                        | name         | query_name                 | type       | type_label
+-----------------------------+--------------+----------------------------+------------+------------
+ duck.analytics.customers    | customers    | "analytics"."customers"    | BASE TABLE | t
+ duck.analytics.order_totals | order_totals | "analytics"."order_totals" | VIEW       | v
+ duck.analytics.orders       | orders       | "analytics"."orders"       | BASE TABLE | t
+(3 rows)
+```
+
+Describing a table is listing it: a relation's children are its columns.
+
+```bash
+$ hsql "path/to/duck.db" --catalog --path duck.analytics.orders
+ path                              | name        | query_name    | type          | type_label
+-----------------------------------+-------------+---------------+---------------+------------
+ duck.analytics.orders.customer_id | customer_id | "customer_id" | BIGINT        | ##
+ duck.analytics.orders.id          | id          | "id"          | BIGINT        | ##
+ duck.analytics.orders.placed_at   | placed_at   | "placed_at"   | TIMESTAMP     | ts
+ duck.analytics.orders.total       | total       | "total"       | DECIMAL(18,2) | #.#
+(4 rows)
+```
+
+Every listing has the same five columns:
+
+- `path` — pass it back to `--path` to list this object's children.
+- `name` — the object's name.
+- `query_name` — the identifier to paste into a query, quoted the way this database wants it, so you never have to guess between `"Orders"` and `` `orders` ``.
+- `type` — the database's own name for what this is: `DECIMAL(18,2)`, `BASE TABLE`, `schema`. Some adapters do not report it, and leave it empty.
+- `type_label` — the short label Harlequin shows in its Data Catalog, which every adapter fills in.
+
+How many levels there are, and what they mean, is the adapter's to say: DuckDB has databases, schemas, relations and columns, and other databases differ. Start with `--catalog` and no `--path` to see the top.
+
+A path is dotted segments, and it is not SQL: a segment that contains a dot, a double quote, or a `*` is written in double quotes — `--path 'duck."my.schema".orders'` — on every adapter, whatever that database quotes its own identifiers with. A `*` in the last segment filters the listing:
+
+```bash
+$ hsql "path/to/duck.db" --catalog --path 'duck.analytics.ord*'
+ path                        | name         | query_name                 | type       | type_label
+-----------------------------+--------------+----------------------------+------------+------------
+ duck.analytics.order_totals | order_totals | "analytics"."order_totals" | VIEW       | v
+ duck.analytics.orders       | orders       | "analytics"."orders"       | BASE TABLE | t
+(2 rows)
+```
+
+A listing is rows, so every format and output option applies to it, exactly as they do to a query:
+
+```bash
+$ hsql "path/to/duck.db" --catalog --path duck.analytics -tA --csv
+duck.analytics.customers,customers,"""analytics"".""customers""",BASE TABLE,t
+duck.analytics.order_totals,order_totals,"""analytics"".""order_totals""",VIEW,v
+duck.analytics.orders,orders,"""analytics"".""orders""",BASE TABLE,t
+```
+
+`--limit` does not, and says so on stderr: it makes the database fetch fewer rows, and a listing is not a query. Cap a long listing with `--display-rows` instead, which the footer reports as `(1 of 2 rows)`.
+
+### Searching the Catalog
+
+Walking is the wrong tool for *where does `orders` live* and *which tables have a `customer_id`*. `--catalog-search TERM` searches every level of the catalog at once, for objects whose name contains TERM:
+
+```bash
+$ hsql "path/to/duck.db" --catalog-search customer_id
+ path                                    | name        | query_name    | type   | type_label
+-----------------------------------------+-------------+---------------+--------+------------
+ duck.analytics.order_totals.customer_id | customer_id | "customer_id" | BIGINT | ##
+ duck.analytics.orders.customer_id       | customer_id | "customer_id" | BIGINT | ##
+ duck.main.staging_events.customer_id    | customer_id | "customer_id" | BIGINT | ##
+(3 rows)
+```
+
+The rows are a listing's rows, so the same columns and the same formats apply, and `--path` narrows the search to one subtree:
+
+```bash
+$ hsql "path/to/duck.db" --catalog-search order --path duck.analytics -tA
+duck.analytics.order_totals|order_totals|"analytics"."order_totals"|VIEW|v
+duck.analytics.orders|orders|"analytics"."orders"|BASE TABLE|t
+```
+
+Searching is an optional adapter capability, because not every database can answer it in one query. The DuckDB and SQLite adapters can; an adapter that does not declare it says so and exits `2`, rather than quietly walking its whole catalog. `--info` reports which of yours can:
+
+```bash
+$ hsql --info -a duckdb | jq '.adapters.duckdb.capabilities'
+{
+  "implements_cancel": true,
+  "implements_catalog_search": true
+}
 ```
 
 ## Scripting with hsql


### PR DESCRIPTION
Closes #524 (docs half — the `--catalog` and `--catalog-search` code landed in #1074, #1076 and #1079)

**What** are the key elements of this solution?

M2's PR 12 — Release B's docs. Two sections in `packaging/hsql/README.md`, plus one sentence in Harlequin's own `README.md`.

*Exploring the Catalog*, after Data Layouts, since a listing is rows and inherits every format:

- `--catalog` with `--path`, walked one level at a time: top → database → schema → relations → columns.
- A `-tA --csv` example, showing the formats apply.
- *Searching the Catalog*: `--catalog-search TERM`, `--path` as its scope, and a note that not every adapter supports catalog search today.

*Keeping Credentials Out of Config Files* splits the secrets guidance out of the config paragraph, where it had been one dense clause: a TOML example contrasting `${VAR}` with `${VAR:-default}`, the `$${` escape, that an unset required variable exits `2`, and where declared secrets are masked.

Harlequin's `README.md` gets one sentence pointing at both catalog modes from its agents section.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Every example is real output, captured from a scratch DuckDB database with two schemas and a view, rather than written by hand — so the column widths, the CSV quoting and the `-tA` separator are what a reader actually gets.

The README is explicitly a small subset of harlequin.sh, so this leans on examples over reference material: an earlier draft also documented each of the five listing columns, how many levels a catalog has, the path quoting rules, and why searching is an optional capability. That is the topic page's job, not this file's, so it came back out — the examples show the shape, and the site explains it.

Does this PR require a change to Harlequin's docs?
- [x] Yes; I haven't opened a PR, but the gist of the change is: the "Catalog and Introspection" topic under Headless & Agents at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web) is where the reference material belongs — the five columns a listing has, that the levels and their meaning are the adapter's to name, the path syntax (dotted segments, double-quoted on every adapter where a segment holds a dot, a quote or a `*`, and a trailing `*` to filter), that `--limit` does not apply to a listing and `--display-rows` is the cap, and that catalog search is a declared capability `--info` reports on.

Did you add or update tests for this change?
- [x] No, I believe tests aren't necessary. Nothing here is code; the two READMEs have no test surface.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. — Not in this PR: `[Unreleased]` already carries both features, and the adapter-author notes for `type_name` and `search_catalog()`, from the PRs that shipped them. There is no new user-facing change here to add.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---

One thing found while writing these docs and deliberately left alone, since this PR is docs-only: **`--stats` is silently ignored under `--catalog` and `--catalog-search`.** No summary line and no note, unlike `--limit`, which explains itself on stderr. Worth an issue if the two should agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GxUydSkqyTcXvhNonHKGN

---
_Generated by [Claude Code](https://claude.ai/code/session_015GxUydSkqyTcXvhNonHKGN)_