### PR TITLE
Add `--read-only`, and the capability declarations behind it (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Adds `hsql --catalog-search TERM`, which searches every level of the catalog for objects whose name contains TERM instead of listing a level at a time: `hsql --catalog-search customer_id` says which tables have that column, and `--path` narrows the search. It works with the DuckDB and SQLite adapters; `hsql --info` reports which of your adapters can search, and one that cannot says so instead of walking its catalog.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
-- Adds `hsql --read-only` (also `-r`), which connects read-only. An adapter that cannot enforce it makes `hsql` refuse to run at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can.
+- Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. An adapter that cannot enforce it refuses to start at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes
@@ -20,7 +20,8 @@ All notable changes to this project will be documented in this file.
 ### Adapter API Changes
 
 - Adds an optional `HarlequinConnection.search_catalog()`, which returns every catalog item whose label contains a term, paired with the labels of its ancestors. Adapters that implement it should set `IMPLEMENTS_CATALOG_SEARCH = True`, which is what `hsql --catalog-search` and `hsql --info` read.
-- Adds `IMPLEMENTS_READ_ONLY` and `IMPLEMENTS_VALIDATE_SQL` to `HarlequinAdapter`, both defaulting to `False`. Set `IMPLEMENTS_READ_ONLY = True` if `connect()` honors a `read_only=True` option, which is what `hsql --read-only` reads before it connects; set `IMPLEMENTS_VALIDATE_SQL = True` if the connection's `validate_sql()` is real. `hsql --info` reports both.
+- `HarlequinAdapter.__init__` now takes a `read_only` argument, which both commands pass to every adapter. Adapters that can connect in a mode the database refuses writes in should honor it and set `IMPLEMENTS_READ_ONLY = True`; adapters no longer need to declare a read-only option of their own, and the DuckDB and SQLite adapters have dropped theirs.
+- Adds `IMPLEMENTS_READ_ONLY` and `IMPLEMENTS_VALIDATE_SQL` to `HarlequinAdapter`, both defaulting to `False`. `--read-only` is refused for an adapter that does not declare the first; set the second if the connection's `validate_sql()` is real. `hsql --info` reports both.
 - Adds `CatalogItem.type_name`, the database's own name for an object's type, like `DECIMAL(18,2)`. It defaults to `None`, and `hsql --catalog` prints it in its `type` column, beside the short `type_label`. It is a new dataclass field appended after `children`, so subclasses that add their own fields should be constructed with keyword arguments.
 
 ## [2.10.0] - 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Adds `hsql --catalog-search TERM`, which searches every level of the catalog for objects whose name contains TERM instead of listing a level at a time: `hsql --catalog-search customer_id` says which tables have that column, and `--path` narrows the search. It works with the DuckDB and SQLite adapters; `hsql --info` reports which of your adapters can search, and one that cannot says so instead of walking its catalog.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
-- Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. An adapter that cannot enforce it refuses to start at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can.
+- Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. An adapter that cannot enforce it refuses to start at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can, and `harlequin --config` prompts for it.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Adds `hsql --catalog-search TERM`, which searches every level of the catalog for objects whose name contains TERM instead of listing a level at a time: `hsql --catalog-search customer_id` says which tables have that column, and `--path` narrows the search. It works with the DuckDB and SQLite adapters; `hsql --info` reports which of your adapters can search, and one that cannot says so instead of walking its catalog.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
+- Adds `hsql --read-only` (also `-r`), which connects read-only. An adapter that cannot enforce it makes `hsql` refuse to run at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes
@@ -19,6 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Adapter API Changes
 
 - Adds an optional `HarlequinConnection.search_catalog()`, which returns every catalog item whose label contains a term, paired with the labels of its ancestors. Adapters that implement it should set `IMPLEMENTS_CATALOG_SEARCH = True`, which is what `hsql --catalog-search` and `hsql --info` read.
+- Adds `IMPLEMENTS_READ_ONLY` and `IMPLEMENTS_VALIDATE_SQL` to `HarlequinAdapter`, both defaulting to `False`. Set `IMPLEMENTS_READ_ONLY = True` if `connect()` honors a `read_only=True` option, which is what `hsql --read-only` reads before it connects; set `IMPLEMENTS_VALIDATE_SQL = True` if the connection's `validate_sql()` is real. `hsql --info` reports both.
 - Adds `CatalogItem.type_name`, the database's own name for an object's type, like `DECIMAL(18,2)`. It defaults to `None`, and `hsql --catalog` prints it in its `type` column, beside the short `type_label`. It is a new dataclass field appended after `children`, so subclasses that add their own fields should be constructed with keyword arguments.
 
 ## [2.10.0] - 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changes
 
-- The single-dash `-readonly` spelling is gone; `--read-only` and `-r` are how both commands take it.
+- The DuckDB and SQLite adapters' single-dash `-readonly` CLI option has been removed. Use `-r` or `--read-only`.
 
 ### Features
 
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Adds `hsql --catalog-search TERM`, which searches every level of the catalog for objects whose name contains TERM instead of listing a level at a time: `hsql --catalog-search customer_id` says which tables have that column, and `--path` narrows the search. It works with the DuckDB and SQLite adapters; `hsql --info` reports which of your adapters can search, and one that cannot says so instead of walking its catalog.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
-- Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. An adapter that cannot enforce it refuses to start at all, instead of connecting and hoping; `hsql --info` reports which of your adapters can. The DuckDB and SQLite adapters can, and `harlequin --config` prompts for it.
+- Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. If set, Harlequin and hsql will refuse to connect to an adapter that cannot enforce a read-only mode.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- The SQLite adapter's `--mode` (`-m`) option now has an effect: it was silently ignored, so `--mode ro` opened a database that could still be written to, and `--read-only --mode rwc` connected instead of raising.
 - The autocomplete menu no longer opens for tokens that start with a number, and fuzzy matches now have to start at the beginning of a name or just after a `_`, so typing `1` and pressing enter inserts a newline again ([#803](https://github.com/tconbeer/harlequin/issues/803)).
 
 ### Adapter API Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Harlequin now has an `-o/--output` option to set the default directory or file path for the Data Exporter ([#926](https://github.com/tconbeer/harlequin/issues/926)).
 - `hsql -o` now also accepts a directory, and can write multiple result files in a single invocation.
 - Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. If set, Harlequin and hsql will refuse to connect to an adapter that cannot enforce a read-only mode.
+- `hsql --config validate` now reports a profile that sets `read_only` for an adapter that cannot enforce it.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- The single-dash `-readonly` spelling is gone; `--read-only` and `-r` are how both commands take it.
+
 ### Features
 
 - Adds `hsql --catalog`, which lists the catalog one level below `--path`: `--path mydb.analytics` lists that schema's relations and `--path mydb.analytics.orders` lists that table's columns (a trailing `*`, like `--path mydb.analytics.ord*`, filters). Each row carries the path that lists its own children, the correctly-quoted name to paste into a query, and the database's own name for the object's type (`DECIMAL(18,2)`, `BASE TABLE`, `schema`), and it is rows, so `--csv`, `-o` and `-t`/`-A` apply.

--- a/docs/plans/m2-hsql-technical-plan.md
+++ b/docs/plans/m2-hsql-technical-plan.md
@@ -749,11 +749,15 @@ place.
 
 ### 3.6 Safety: read-only and timeout
 
-**`--read-only`** sets `read_only=True` in the options handed to the adapter, and refuses
-before connecting when `IMPLEMENTS_READ_ONLY` is false (§3.4). In-tree, DuckDB and SQLite
-already accept the kwarg and already do the right thing with it, so they declare the flag and
-are done. Out-of-tree adapters are a long tail, and `hsql --info` is what makes the tail
-legible.
+**`--read-only`** is a `read_only` argument on `HarlequinAdapter.__init__`, passed by both
+commands, and refused before connecting when `IMPLEMENTS_READ_ONLY` is false (§3.4). An
+option of that name in the bag handed to the adapter would have worked in-tree, but only
+because DuckDB and SQLite each declare an option called `read-only` — a convention rather
+than a contract, and the same convention §1.8 rules out for the adapters that declare
+nothing (amended in PR 13, Ted's call). So the two in-tree adapters drop their own
+`read-only` options and take the argument, and `--read-only` is a core flag on `harlequin`
+as well as `hsql`. Out-of-tree adapters are a long tail, and `hsql --info` is what makes the
+tail legible.
 
 **`--timeout SECONDS`** is a wall clock over the whole run — execute *and* fetch, because
 DuckDB executes lazily and the work happens in `fetchall()` (§1.9):

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -176,6 +176,9 @@ class HarlequinConnection(ABC):
         Parses text as one or more queries; returns text if parsing does not result
         in an error; otherwise returns the empty string ("").
 
+        After implementing this method, set the adapter class variable
+        IMPLEMENTS_VALIDATE_SQL to True.
+
         Args:
             text (str): The text, which may compose one or more queries and partial
                 queries.
@@ -250,6 +253,12 @@ class HarlequinAdapter(ABC):
     IMPLEMENTS_CANCEL = False
     IMPLEMENTS_CATALOG_SEARCH = False
     """True if the connection's search_catalog() is real."""
+    IMPLEMENTS_READ_ONLY = False
+    """True if connect() honors a read_only=True option by opening a connection
+    that cannot write. Harlequin refuses `hsql --read-only` for an adapter that
+    does not declare it, rather than passing an option that may be ignored."""
+    IMPLEMENTS_VALIDATE_SQL = False
+    """True if the connection's validate_sql() is real."""
     ADAPTER_DETAILS: str | None = None
     ADAPTER_DRIVER_DETAILS: str | None = None
 

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -254,21 +254,27 @@ class HarlequinAdapter(ABC):
     IMPLEMENTS_CATALOG_SEARCH = False
     """True if the connection's search_catalog() is real."""
     IMPLEMENTS_READ_ONLY = False
-    """True if connect() honors a read_only=True option by opening a connection
-    that cannot write. Harlequin refuses `hsql --read-only` for an adapter that
-    does not declare it, rather than passing an option that may be ignored."""
+    """True if the adapter's read_only argument opens a connection that cannot
+    write. Harlequin refuses `--read-only` for an adapter that does not declare
+    it, rather than passing an argument that may be ignored."""
     IMPLEMENTS_VALIDATE_SQL = False
     """True if the connection's validate_sql() is real."""
     ADAPTER_DETAILS: str | None = None
     ADAPTER_DRIVER_DETAILS: str | None = None
 
     @abstractmethod
-    def __init__(self, conn_str: Sequence[str], **options: Any) -> None:
+    def __init__(
+        self, conn_str: Sequence[str], read_only: bool = False, **options: Any
+    ) -> None:
         """
         Initialize an adapter.
 
         Args:
             - conn_str (Sequence[str]): One or more connection strings. May be empty.
+            - read_only (bool): True if this connection must not be able to write.
+                Harlequin passes True only to an adapter that declares
+                IMPLEMENTS_READ_ONLY; an adapter that declares it must connect in
+                a mode the database itself refuses writes in, or raise.
             - **options (Any): Options received from the command line, config file,
                 or env variables. Adapters should be robust to receiving both subsets
                 and supersets of their declared options. They should disregard any

--- a/src/harlequin/adapter.py
+++ b/src/harlequin/adapter.py
@@ -252,13 +252,8 @@ class HarlequinAdapter(ABC):
     """DEPRECATED. Adapter Copy formats are now ignored by Harlequin."""
     IMPLEMENTS_CANCEL = False
     IMPLEMENTS_CATALOG_SEARCH = False
-    """True if the connection's search_catalog() is real."""
     IMPLEMENTS_READ_ONLY = False
-    """True if the adapter's read_only argument opens a connection that cannot
-    write. Harlequin refuses `--read-only` for an adapter that does not declare
-    it, rather than passing an argument that may be ignored."""
     IMPLEMENTS_VALIDATE_SQL = False
-    """True if the connection's validate_sql() is real."""
     ADAPTER_DETAILS: str | None = None
     ADAPTER_DRIVER_DETAILS: str | None = None
 
@@ -271,10 +266,9 @@ class HarlequinAdapter(ABC):
 
         Args:
             - conn_str (Sequence[str]): One or more connection strings. May be empty.
-            - read_only (bool): True if this connection must not be able to write.
+            - read_only (bool): True if this connection must be read-only.
                 Harlequin passes True only to an adapter that declares
-                IMPLEMENTS_READ_ONLY; an adapter that declares it must connect in
-                a mode the database itself refuses writes in, or raise.
+                IMPLEMENTS_READ_ONLY.
             - **options (Any): Options received from the command line, config file,
                 or env variables. Adapters should be robust to receiving both subsets
                 and supersets of their declared options. They should disregard any

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -396,7 +396,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         is_flag=True,
         help=(
             "Connect read-only, and refuse to start at all if the adapter "
-            "cannot. Not every adapter can; see `hsql --info`."
+            "cannot. To check an adapter's capabilities, use `hsql --info`."
         ),
     )
     @click.option(

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -551,14 +551,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 ctx.exit(2)
         show_s3: str | None = config.pop("show_s3", None)
         export_path: Path | str | None = config.pop("output", None)
-        # off the options and into an argument of its own: `read_only` is a
-        # parameter of every adapter's constructor rather than an option any of
-        # them declares, and a bool there whatever a profile wrote.
         read_only: bool = bool(config.pop("read_only", False))
         if read_only and not adapter_cls.IMPLEMENTS_READ_ONLY:
-            # before connecting, and before the app starts: an adapter that
-            # cannot enforce read-only is free to ignore the argument, and a
-            # session that believed it was read-only would write
             pretty_print_error(
                 HarlequinConfigError(
                     msg=(

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -279,14 +279,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     is the right trade -- the one that got faster is the one that opens the IDE.
     """
     installed_adapter_names = adapter_names()
-    first_pass_config = first_pass(
-        argv,
-        installed_adapter_names,
-        program="harlequin",
-        # click splits an unknown `-readonly` into a cluster of short options,
-        # one of which is this pass's own `-a`
-        extra_options=[click.Option(["-r", "-readonly", "--read-only"], is_flag=True)],
-    )
+    first_pass_config = first_pass(argv, installed_adapter_names, program="harlequin")
     adapters: dict[str, type[HarlequinAdapter]] = {}
     if first_pass_config.wants_help:
         adapters = load_adapter_plugins()
@@ -396,12 +389,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             "to use to connect to the database at CONN_STR."
         ),
     )
-    # `-r` and `-readonly` as well as the long spelling: read-only is core's to
-    # ask for on every adapter, so every spelling of it is core's too.
     @click.option(
         "--read-only",
         "-r",
-        "-readonly",
         "read_only",
         is_flag=True,
         help=(

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -128,6 +128,7 @@ HARLEQUIN_OPTION_GROUPS: list[OptionGroupDict] = [
         "options": [
             "--profile",
             "--adapter",
+            "--read-only",
             "--show-files",
             "--show-s3",
             "--theme",
@@ -278,7 +279,14 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     is the right trade -- the one that got faster is the one that opens the IDE.
     """
     installed_adapter_names = adapter_names()
-    first_pass_config = first_pass(argv, installed_adapter_names, program="harlequin")
+    first_pass_config = first_pass(
+        argv,
+        installed_adapter_names,
+        program="harlequin",
+        # click splits an unknown `-readonly` into a cluster of short options,
+        # one of which is this pass's own `-a`
+        extra_options=[click.Option(["-r", "-readonly", "--read-only"], is_flag=True)],
+    )
     adapters: dict[str, type[HarlequinAdapter]] = {}
     if first_pass_config.wants_help:
         adapters = load_adapter_plugins()
@@ -386,6 +394,19 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         help=(
             "The name of an installed database adapter plug-in "
             "to use to connect to the database at CONN_STR."
+        ),
+    )
+    # `-r` and `-readonly` as well as the long spelling: read-only is core's to
+    # ask for on every adapter, so every spelling of it is core's too.
+    @click.option(
+        "--read-only",
+        "-r",
+        "-readonly",
+        "read_only",
+        is_flag=True,
+        help=(
+            "Connect read-only, and refuse to start at all if the adapter "
+            "cannot. Not every adapter can; see `hsql --info`."
         ),
     )
     @click.option(
@@ -540,12 +561,32 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 ctx.exit(2)
         show_s3: str | None = config.pop("show_s3", None)
         export_path: Path | str | None = config.pop("output", None)
+        # off the options and into an argument of its own: `read_only` is a
+        # parameter of every adapter's constructor rather than an option any of
+        # them declares, and a bool there whatever a profile wrote.
+        read_only: bool = bool(config.pop("read_only", False))
+        if read_only and not adapter_cls.IMPLEMENTS_READ_ONLY:
+            # before connecting, and before the app starts: an adapter that
+            # cannot enforce read-only is free to ignore the argument, and a
+            # session that believed it was read-only would write
+            pretty_print_error(
+                HarlequinConfigError(
+                    msg=(
+                        f"{adapter_name} does not declare read-only support, so "
+                        "--read-only cannot be honored. See `hsql --info`."
+                    ),
+                    title="Harlequin could not start.",
+                )
+            )
+            ctx.exit(2)
 
         # instantiate the adapter, which was named and imported above -- the
         # key comes off either way, because what is left is its options
         config.pop("adapter", None)
         try:
-            adapter_instance = adapter_cls(conn_str=conn_str, **config)
+            adapter_instance = adapter_cls(
+                conn_str=conn_str, read_only=read_only, **config
+            )
         except HarlequinConfigError as e:
             pretty_print_error(e)
             ctx.exit(2)

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -703,8 +703,8 @@ def _validate_profile(
         # the one key a profile can be wrong about without misspelling
         # anything: every command refuses to connect under it
         problems.add(
-            f"Profile sets read_only, but the {adapter} adapter does not "
-            "declare read-only support.",
+            f"Profile sets read_only, but its adapter ({adapter}) does not "
+            "support read-only connections.",
             key="read_only",
         )
     parse_profile_options(

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -78,6 +78,7 @@ else:
 if TYPE_CHECKING:
     from tomlkit.toml_document import TOMLDocument
 
+    from harlequin.adapter import HarlequinAdapter
     from harlequin.options import AbstractOption
 
 DEFAULT_ADAPTER = "duckdb"
@@ -422,7 +423,7 @@ def load_profile_and_keymaps(
 def validate_config_files(
     config_path: Path | None,
     *,
-    adapter_options: Callable[[str], Sequence[AbstractOption] | None],
+    adapter_class: Callable[[str], type[HarlequinAdapter] | None],
     command_options: Collection[str],
     provenance: Provenance | None = None,
 ) -> list[ConfigProblem]:
@@ -442,10 +443,11 @@ def validate_config_files(
     does not set, wherever it is written, rather than only in the one profile a
     run would have selected.
 
-    `adapter_options` is the second pass's price: one adapter import per
-    adapter a profile names. It may raise `HarlequinConfigError` for a name
-    nothing installed provides, which is recorded against the profile that
-    named it.
+    `adapter_class` is the second pass's price: one adapter import per adapter
+    a profile names. It may raise `HarlequinConfigError` for a name nothing
+    installed provides, which is recorded against the profile that named it.
+    The class rather than its options, because a profile can also be wrong
+    about what its adapter can do, and only the class says.
 
     Raises: HarlequinConfigError if `config_path` names a file that is not
     there -- the one problem that is not in a config file.
@@ -462,7 +464,7 @@ def validate_config_files(
                     key=f"profiles.{name}",
                     problems=problems,
                 ),
-                adapter_options=adapter_options,
+                adapter_class=adapter_class,
                 command_options=command_options,
                 problems=problems.at(path, f"profiles.{name}"),
             )
@@ -673,7 +675,7 @@ def _search_directories() -> Iterator[tuple[Path, tuple[str, ...]]]:
 def _validate_profile(
     profile: Profile,
     *,
-    adapter_options: Callable[[str], Sequence[AbstractOption] | None],
+    adapter_class: Callable[[str], type[HarlequinAdapter] | None],
     command_options: Collection[str],
     problems: Problems,
 ) -> None:
@@ -689,14 +691,26 @@ def _validate_profile(
         )
         return
     try:
-        declared = adapter_options(adapter)
+        adapter_cls = adapter_class(adapter)
     except HarlequinConfigError as e:
         problems.add(e.msg, key="adapter")
         return
+    if (
+        profile.get("read_only")
+        and adapter_cls is not None
+        and not adapter_cls.IMPLEMENTS_READ_ONLY
+    ):
+        # the one key a profile can be wrong about without misspelling
+        # anything: every command refuses to connect under it
+        problems.add(
+            f"Profile sets read_only, but the {adapter} adapter does not "
+            "declare read-only support.",
+            key="read_only",
+        )
     parse_profile_options(
         profile,
         adapter=adapter,
-        adapter_options=declared,
+        adapter_options=None if adapter_cls is None else adapter_cls.ADAPTER_OPTIONS,
         command_options=command_options,
         problems=problems,
     )

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -700,8 +700,6 @@ def _validate_profile(
         and adapter_cls is not None
         and not adapter_cls.IMPLEMENTS_READ_ONLY
     ):
-        # the one key a profile can be wrong about without misspelling
-        # anything: every command refuses to connect under it
         problems.add(
             f"Profile sets read_only, but its adapter ({adapter}) does not "
             "support read-only connections.",

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -66,8 +66,7 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
-    # not asked of an adapter that cannot enforce it: the profile that answered
-    # yes is one Harlequin would refuse to start under
+    # only prompt for read-only if the adapter supports it
     read_only = False
     if adapter_cls.IMPLEMENTS_READ_ONLY:
         read_only = questionary.confirm(

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -185,8 +185,6 @@ def _wizard(config_path: Path | None) -> None:
         new_profile["limit"] = limit
 
     if read_only:
-        # only when it is on: read-write is the default, and a profile that
-        # says so is a line a reader has to work out the meaning of
         new_profile["read_only"] = read_only
 
     if show_files:

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -64,6 +64,12 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
+    read_only = questionary.confirm(
+        message="Should this profile connect read-only?",
+        default=bool(selected_profile.get("read_only", False)),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+
     theme = questionary.select(
         message="What theme should this profile use?",
         choices=sorted(VALID_THEMES.keys()),
@@ -177,6 +183,11 @@ def _wizard(config_path: Path | None) -> None:
         # only when there is one: an unlimited fetch is the default, and a key
         # that says so is a line the reader has to work out the meaning of.
         new_profile["limit"] = limit
+
+    if read_only:
+        # only when it is on: read-write is the default, and a profile that
+        # says so is a line a reader has to work out the meaning of
+        new_profile["read_only"] = read_only
 
     if show_files:
         new_profile["show_files"] = show_files

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -57,6 +57,8 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
+    adapter_cls = adapters[adapter]
+
     conn_str = questionary.text(
         message="What connection string(s) should this profile use?",
         instruction="Separate items by a space. Quote a single item containing spaces.",
@@ -64,11 +66,15 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
-    read_only = questionary.confirm(
-        message="Should this profile connect read-only?",
-        default=bool(selected_profile.get("read_only", False)),
-        style=HARLEQUIN_QUESTIONARY_STYLE,
-    ).unsafe_ask()
+    # not asked of an adapter that cannot enforce it: the profile that answered
+    # yes is one Harlequin would refuse to start under
+    read_only = False
+    if adapter_cls.IMPLEMENTS_READ_ONLY:
+        read_only = questionary.confirm(
+            message="Should this profile connect read-only?",
+            default=bool(selected_profile.get("read_only", False)),
+            style=HARLEQUIN_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     theme = questionary.select(
         message="What theme should this profile use?",
@@ -138,7 +144,6 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
-    adapter_cls = adapters[adapter]
     adapter_option_choices = (
         [
             questionary.Choice(

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -244,9 +244,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         type=click.Choice(installed, case_sensitive=False),
         help="The installed adapter plug-in to connect with.",
     )
-    # hsql owns the spellings an adapter gives its own read-only option, `-r`
-    # and `-readonly` among them, so that the flag means the same thing --
-    # including the refusal -- whichever adapter it is passed with.
+    # `-r` and `-readonly` as well as the long spelling: read-only is core's
+    # to ask for on every adapter, so every spelling of it is core's too.
     @click.option(
         "-r",
         "-readonly",
@@ -426,6 +425,10 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             diagnostics.error(f"on_error takes stop or continue, not {raw_on_error}.")
             ctx.exit(ExitCode.USAGE)
         on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
+        # off the options and into an argument of its own: `read_only` is a
+        # parameter of every adapter's constructor rather than an option any of
+        # them declares, and a bool there whatever a profile wrote.
+        read_only: bool = bool(values.pop("read_only", False))
         stats: bool = bool(values.pop("stats", False))
         tuples_only: bool = bool(values.pop("tuples_only", False))
         no_align: bool = bool(values.pop("no_align", False))
@@ -507,7 +510,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             _refuse_undeclared_read_only(
                 ctx,
                 adapter=adapter,
-                asked=bool(values.get("read_only", False)),
+                asked=read_only,
                 typed="read_only" in explicitly_set,
             )
 
@@ -558,7 +561,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.exit(
                 _report_catalog(
                     ctx,
-                    _connect(ctx, adapter=adapter, conn_str=conn_str, values=values),
+                    _connect(
+                        ctx,
+                        adapter=adapter,
+                        conn_str=conn_str,
+                        read_only=read_only,
+                        values=values,
+                    ),
                     catalog_path,
                     destination=destination,
                     format_name=format_name,
@@ -588,7 +597,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.exit(
                 _report_catalog_search(
                     ctx,
-                    _connect(ctx, adapter=adapter, conn_str=conn_str, values=values),
+                    _connect(
+                        ctx,
+                        adapter=adapter,
+                        conn_str=conn_str,
+                        read_only=read_only,
+                        values=values,
+                    ),
                     catalog_search,
                     search_path,
                     destination=destination,
@@ -635,7 +650,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             detect_overflow=limit is not None,
         )
 
-        connection = _connect(ctx, adapter=adapter, conn_str=conn_str, values=values)
+        connection = _connect(
+            ctx, adapter=adapter, conn_str=conn_str, read_only=read_only, values=values
+        )
 
         run = _Run()
         executed = _execute_all(
@@ -771,11 +788,14 @@ def _connect(
     *,
     adapter: str,
     conn_str: Sequence[str],
+    read_only: bool,
     values: Mapping[str, Any],
 ) -> "HarlequinConnection":
     """The connection this invocation runs on, or exit having said why not."""
     try:
-        adapter_instance = load_adapter(adapter)(conn_str=conn_str, **values)
+        adapter_instance = load_adapter(adapter)(
+            conn_str=conn_str, read_only=read_only, **values
+        )
     except HarlequinConfigError as e:
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
@@ -846,10 +866,10 @@ def _refuse_undeclared_read_only(
 ) -> None:
     """Stop before connecting unless the adapter declares it can be read-only.
 
-    `read_only` is an option core hands the adapter, and an adapter that does
-    not declare the capability drops what it does not recognize -- so a run
-    that believed it was read-only would write. Read off the class, so it costs
-    the adapter's import and never a connection.
+    `read_only` is an argument of every adapter's constructor, and one that an
+    adapter which cannot enforce it is free to ignore -- so a run that believed
+    it was read-only would write. Read off the class, so it costs the adapter's
+    import and never a connection.
     """
     if not asked:
         return

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -118,6 +118,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
+            # click splits an unknown `-readonly` into a cluster of short
+            # options, one of which is this pass's own `-a`
+            click.Option(["-r", "-readonly", "--read-only"], is_flag=True),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -240,6 +243,20 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         metavar="NAME",
         type=click.Choice(installed, case_sensitive=False),
         help="The installed adapter plug-in to connect with.",
+    )
+    # hsql owns the spellings an adapter gives its own read-only option, `-r`
+    # and `-readonly` among them, so that the flag means the same thing --
+    # including the refusal -- whichever adapter it is passed with.
+    @click.option(
+        "-r",
+        "-readonly",
+        "--read-only",
+        "read_only",
+        is_flag=True,
+        help=(
+            "Connect read-only, and refuse to run at all if the adapter cannot. "
+            "Not every adapter can; see --info."
+        ),
     )
     # existence is not click's to check: every mode that reads this path
     # already refuses a file that is not there, naming it, and `--config init`
@@ -480,6 +497,18 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                     format_chosen=format_name != DEFAULT_FORMAT
                     or "format" in explicitly_set,
                 )
+            )
+
+        # everything below this connects with the adapter, or writes a profile
+        # that names it, so this is where a read-only the adapter cannot honor
+        # is refused. The modes that only report are not refused over a flag
+        # they ignore -- `--info` least of all, since it is where this points.
+        if not _reports_config(config_mode):
+            _refuse_undeclared_read_only(
+                ctx,
+                adapter=adapter,
+                asked=bool(values.get("read_only", False)),
+                typed="read_only" in explicitly_set,
             )
 
         if config_mode is not None:
@@ -808,6 +837,32 @@ def _refuse_undeclared_search(ctx: click.Context, *, adapter: str, term: str) ->
             f"{adapter} does not declare catalog search, so --catalog-search "
             f"{term!r} cannot be answered. List one level at a time with "
             f"{PROGRAM} --catalog, or see '{PROGRAM} --info'."
+        )
+        ctx.exit(ExitCode.USAGE)
+
+
+def _refuse_undeclared_read_only(
+    ctx: click.Context, *, adapter: str, asked: bool, typed: bool
+) -> None:
+    """Stop before connecting unless the adapter declares it can be read-only.
+
+    `read_only` is an option core hands the adapter, and an adapter that does
+    not declare the capability drops what it does not recognize -- so a run
+    that believed it was read-only would write. Read off the class, so it costs
+    the adapter's import and never a connection.
+    """
+    if not asked:
+        return
+    try:
+        declares_read_only = load_adapter(adapter).IMPLEMENTS_READ_ONLY
+    except HarlequinConfigError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    if not declares_read_only:
+        spelled = "--read-only" if typed else "read_only in the profile"
+        diagnostics.error(
+            f"{adapter} does not declare read-only support, so {spelled} "
+            f"cannot be honored. See '{PROGRAM} --info'."
         )
         ctx.exit(ExitCode.USAGE)
 

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -516,6 +516,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                         color=_use_color(color_when, destination),
                     )
                 )
+            # `init` imports the adapter to write the options it declares, so
+            # it can read what it declares too: a profile saying read-only to
+            # an adapter that cannot is a profile no run will start under
+            _refuse_undeclared_read_only(
+                ctx,
+                adapter=adapter,
+                asked=read_only,
+                typed="read_only" in explicitly_set,
+            )
             ctx.exit(
                 _write_config(
                     ctx,
@@ -531,9 +540,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 )
             )
 
-        # below every mode that reads or writes a file rather than a database:
-        # those cannot write whatever they are told, and `--info` and
-        # `--config show` are where a caller finds out where read-only came from
+        # below the modes that only report: those write nothing, and `--info`
+        # and `--config show` are where a caller finds out where a read-only
+        # they did not expect came from
         _refuse_undeclared_read_only(
             ctx,
             adapter=adapter,

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -118,9 +118,6 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
-            # click splits an unknown `-readonly` into a cluster of short
-            # options, one of which is this pass's own `-a`
-            click.Option(["-r", "-readonly", "--read-only"], is_flag=True),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -244,11 +241,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         type=click.Choice(installed, case_sensitive=False),
         help="The installed adapter plug-in to connect with.",
     )
-    # `-r` and `-readonly` as well as the long spelling: read-only is core's
-    # to ask for on every adapter, so every spelling of it is core's too.
     @click.option(
         "-r",
-        "-readonly",
         "--read-only",
         "read_only",
         is_flag=True,

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -248,7 +248,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         is_flag=True,
         help=(
             "Connect read-only, and refuse to run at all if the adapter cannot. "
-            "Not every adapter can; see --info."
+            "To check an adapter's capabilities, use --info."
         ),
     )
     # existence is not click's to check: every mode that reads this path
@@ -516,9 +516,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                         color=_use_color(color_when, destination),
                     )
                 )
-            # `init` imports the adapter to write the options it declares, so
-            # it can read what it declares too: a profile saying read-only to
-            # an adapter that cannot is a profile no run will start under
+            # only `--config init` reaches this line
             _refuse_undeclared_read_only(
                 ctx,
                 adapter=adapter,
@@ -540,9 +538,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 )
             )
 
-        # below the modes that only report: those write nothing, and `--info`
-        # and `--config show` are where a caller finds out where a read-only
-        # they did not expect came from
+        # every mode below this connects to the database
         _refuse_undeclared_read_only(
             ctx,
             adapter=adapter,
@@ -862,13 +858,7 @@ def _refuse_undeclared_search(ctx: click.Context, *, adapter: str, term: str) ->
 def _refuse_undeclared_read_only(
     ctx: click.Context, *, adapter: str, asked: bool, typed: bool
 ) -> None:
-    """Stop before connecting unless the adapter declares it can be read-only.
-
-    `read_only` is an argument of every adapter's constructor, and one that an
-    adapter which cannot enforce it is free to ignore -- so a run that believed
-    it was read-only would write. Read off the class, so it costs the adapter's
-    import and never a connection.
-    """
+    """Exit with an error if read-only was asked for and the adapter cannot."""
     if not asked:
         return
     try:

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -419,9 +419,6 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             diagnostics.error(f"on_error takes stop or continue, not {raw_on_error}.")
             ctx.exit(ExitCode.USAGE)
         on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
-        # off the options and into an argument of its own: `read_only` is a
-        # parameter of every adapter's constructor rather than an option any of
-        # them declares, and a bool there whatever a profile wrote.
         read_only: bool = bool(values.pop("read_only", False))
         stats: bool = bool(values.pop("stats", False))
         tuples_only: bool = bool(values.pop("tuples_only", False))
@@ -496,18 +493,6 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 )
             )
 
-        # everything below this connects with the adapter, or writes a profile
-        # that names it, so this is where a read-only the adapter cannot honor
-        # is refused. The modes that only report are not refused over a flag
-        # they ignore -- `--info` least of all, since it is where this points.
-        if not _reports_config(config_mode):
-            _refuse_undeclared_read_only(
-                ctx,
-                adapter=adapter,
-                asked=read_only,
-                typed="read_only" in explicitly_set,
-            )
-
         if config_mode is not None:
             # a shorthand flag and a profile's `format` key are choices too, and
             # both modes read this: the reporting ones to explain a format that
@@ -545,6 +530,16 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                     config_path=config_path,
                 )
             )
+
+        # below every mode that reads or writes a file rather than a database:
+        # those cannot write whatever they are told, and `--info` and
+        # `--config show` are where a caller finds out where read-only came from
+        _refuse_undeclared_read_only(
+            ctx,
+            adapter=adapter,
+            asked=read_only,
+            typed="read_only" in explicitly_set,
+        )
 
         if catalog:
             catalog_path = _catalog_path(ctx, path)

--- a/src/harlequin/hsql/modes/config.py
+++ b/src/harlequin/hsql/modes/config.py
@@ -64,6 +64,7 @@ from harlequin.hsql.modes import CONFIG_MODES
 if TYPE_CHECKING:
     from tomlkit.items import Item, Table
 
+    from harlequin.adapter import HarlequinAdapter
     from harlequin.config import Config
     from harlequin.layout import LayoutOptions
     from harlequin.options import AbstractOption
@@ -262,12 +263,17 @@ def _redacted(config: Config) -> Config:
 
     from harlequin.redact import redact_profile
 
-    options = _adapter_options(
+    adapter_class = _adapter_class(
         on_error=lambda name: diagnostics.note(
             f"could not import {name}, so its profiles were masked by option "
             "name alone; run --config validate for the reason."
         )
     )
+
+    def options(name: str) -> Sequence[AbstractOption] | None:
+        adapter_cls = adapter_class(name)
+        return None if adapter_cls is None else adapter_cls.ADAPTER_OPTIONS
+
     return msgspec.structs.replace(
         config,
         profiles={
@@ -421,7 +427,7 @@ def _write_problems(
     provenance = Provenance()
     problems = validate_config_files(
         config_path,
-        adapter_options=_adapter_options(),
+        adapter_class=_adapter_class(),
         command_options=_command_options(),
         provenance=provenance,
     )
@@ -449,10 +455,10 @@ def _write_problems(
     return ExitCode.USAGE if problems else ExitCode.OK
 
 
-def _adapter_options(
+def _adapter_class(
     on_error: Callable[[str], None] | None = None,
-) -> Callable[[str], Sequence[AbstractOption] | None]:
-    """A way to ask what one adapter declares, importing each of them once.
+) -> Callable[[str], type[HarlequinAdapter] | None]:
+    """A way to ask what one adapter is, importing each of them once.
 
     The cache is per invocation rather than per process: four profiles naming
     duckdb is one import, and a second call in the same interpreter -- which is
@@ -464,20 +470,20 @@ def _adapter_options(
     """
     from harlequin.plugins import load_adapter
 
-    declared: dict[str, Sequence[AbstractOption] | None] = {}
+    loaded: dict[str, type[HarlequinAdapter] | None] = {}
 
-    def options(name: str) -> Sequence[AbstractOption] | None:
-        if name not in declared:
+    def adapter_class(name: str) -> type[HarlequinAdapter] | None:
+        if name not in loaded:
             try:
-                declared[name] = load_adapter(name).ADAPTER_OPTIONS
+                loaded[name] = load_adapter(name)
             except HarlequinConfigError:
                 if on_error is None:
                     raise
                 on_error(name)
-                declared[name] = None
-        return declared[name]
+                loaded[name] = None
+        return loaded[name]
 
-    return options
+    return adapter_class
 
 
 def _command_options() -> set[str]:

--- a/src/harlequin/hsql/modes/config.py
+++ b/src/harlequin/hsql/modes/config.py
@@ -458,15 +458,11 @@ def _write_problems(
 def _adapter_class(
     on_error: Callable[[str], None] | None = None,
 ) -> Callable[[str], type[HarlequinAdapter] | None]:
-    """A way to ask what one adapter is, importing each of them once.
+    """Returns a callable that loads an adapter as cheaply as possible: from a
+    cache, and otherwise by loading the plug-in.
 
-    The cache is per invocation rather than per process: four profiles naming
-    duckdb is one import, and a second call in the same interpreter -- which is
-    every test, and no `hsql` -- gets to see whatever is installed then.
-
-    An adapter that will not import raises, which is what `validate` records
-    against the profile that named it. A caller that would rather carry on
-    passes `on_error`: it is called once per adapter, and the answer is None.
+    Raises if the plug-in will not import, unless `on_error` is passed, which
+    is called instead, once per adapter, and the answer is None.
     """
     from harlequin.plugins import load_adapter
 

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -175,6 +175,11 @@
           "description": "The installed adapter plug-in to connect with.",
           "default": "duckdb"
         },
+        "read_only": {
+          "type": "boolean",
+          "description": "Connect read-only, and refuse to run at all if the adapter cannot. Not every adapter can; see --info.",
+          "default": false
+        },
         "config_path": {
           "type": "string",
           "description": "Use this config file instead of the ones hsql discovers."

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -177,7 +177,7 @@
         },
         "read_only": {
           "type": "boolean",
-          "description": "Connect read-only, and refuse to run at all if the adapter cannot. Not every adapter can; see --info.",
+          "description": "Connect read-only, and refuse to run at all if the adapter cannot. To check an adapter's capabilities, use --info.",
           "default": false
         },
         "config_path": {

--- a/src/harlequin_duckdb/adapter.py
+++ b/src/harlequin_duckdb/adapter.py
@@ -415,6 +415,8 @@ class DuckDbAdapter(HarlequinAdapter):
     COPY_FORMATS = None
     IMPLEMENTS_CANCEL = True
     IMPLEMENTS_CATALOG_SEARCH = True
+    IMPLEMENTS_READ_ONLY = True
+    IMPLEMENTS_VALIDATE_SQL = True
     ADAPTER_DETAILS = "This is a DuckDB adapter part of Harlequin core."
 
     def __init__(

--- a/src/harlequin_duckdb/cli_options.py
+++ b/src/harlequin_duckdb/cli_options.py
@@ -26,12 +26,6 @@ no_init = FlagOption(
     description="Start Harlequin without executing the initialization script.",
 )
 
-read_only = FlagOption(
-    name="read-only",
-    short_decls=["-readonly", "-r"],
-    description="Open the database file in read-only mode.",
-)
-
 unsigned = FlagOption(
     name="allow-unsigned-extensions",
     description="Allow loading unsigned extensions",
@@ -79,7 +73,6 @@ md_saas = FlagOption(
 DUCKDB_OPTIONS = [
     init,
     no_init,
-    read_only,
     unsigned,
     extensions,
     force_extensions,

--- a/src/harlequin_sqlite/adapter.py
+++ b/src/harlequin_sqlite/adapter.py
@@ -416,6 +416,7 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
     COPY_FORMATS: list[HarlequinCopyFormat] | None = None
     IMPLEMENTS_CANCEL = True
     IMPLEMENTS_CATALOG_SEARCH = True
+    IMPLEMENTS_READ_ONLY = True
     ADAPTER_DETAILS = "This is an SQLite adapter part of Harlequin core."
 
     def __init__(

--- a/src/harlequin_sqlite/adapter.py
+++ b/src/harlequin_sqlite/adapter.py
@@ -425,7 +425,7 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
         init_path: Path | str | None = None,
         no_init: bool | str = False,
         read_only: bool = False,
-        connection_mode: Literal["ro", "rw", "rwc", "memory"] | None = None,
+        mode: Literal["ro", "rw", "rwc", "memory"] | None = None,
         timeout: str | float = 5.0,
         detect_types: str | int = 0,
         isolation_level: Literal["DEFERRED", "EXCLUSIVE", "IMMEDIATE"] = "DEFERRED",
@@ -436,7 +436,7 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
         try:
             self.conn_str = (
                 conn_str
-                if conn_str and conn_str != ("",) and connection_mode != "memory"
+                if conn_str and conn_str != ("",) and mode != "memory"
                 else IN_MEMORY_CONN_STR
             )
             self.init_path = (
@@ -446,7 +446,7 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
             )
             self.no_init = bool(no_init)
             self.read_only = bool(read_only)
-            self.connection_mode = connection_mode
+            self.mode = mode
             self.timeout = float(timeout)
             self.detect_types = int(detect_types)
             self.isolation_level = isolation_level
@@ -480,18 +480,14 @@ class HarlequinSqliteAdapter(HarlequinAdapter):
         )
 
     def connect(self) -> HarlequinSqliteConnection:
-        if (
-            self.read_only
-            and self.connection_mode is not None
-            and self.connection_mode != "ro"
-        ):
+        if self.read_only and self.mode is not None and self.mode != "ro":
             raise HarlequinConnectionError(
                 "Cannot specify readonly flag and a connection mode."
             )
         elif self.read_only:
             mode_str = "?mode=ro"
-        elif self.connection_mode is not None:
-            mode_str = f"?mode={self.connection_mode}"
+        elif self.mode is not None:
+            mode_str = f"?mode={self.mode}"
         else:
             mode_str = ""
 

--- a/src/harlequin_sqlite/cli_options.py
+++ b/src/harlequin_sqlite/cli_options.py
@@ -11,11 +11,6 @@ from harlequin.options import (
     TextOption,
 )
 
-read_only = FlagOption(
-    name="read-only",
-    short_decls=["-readonly", "-r"],
-    description="Open the database file in read-only mode.",
-)
 connection_mode = SelectOption(
     name="mode",
     short_decls=["-mode", "-m"],
@@ -137,7 +132,6 @@ extensions = ListOption(
 SQLITE_OPTIONS = [
     init,
     no_init,
-    read_only,
     connection_mode,
     timeout,
     detect_types,

--- a/tests/adapter_tests/test_sqlite.py
+++ b/tests/adapter_tests/test_sqlite.py
@@ -23,7 +23,7 @@ def test_connect(tiny_sqlite: Path, small_sqlite: Path) -> None:
     assert HarlequinSqliteAdapter([":memory:"]).connect()
     assert HarlequinSqliteAdapter([tiny], read_only=False).connect()
     assert HarlequinSqliteAdapter([tiny], read_only=True).connect()
-    assert HarlequinSqliteAdapter([tiny], connection_mode="ro").connect()
+    assert HarlequinSqliteAdapter([tiny], mode="ro").connect()
     assert HarlequinSqliteAdapter([tiny, small, ":memory:"], read_only=False).connect()
     assert HarlequinSqliteAdapter(
         [],
@@ -45,7 +45,7 @@ def test_cannot_connect(tmp_path: Path, tiny_sqlite: Path) -> None:
         ).connect()
     with pytest.raises(HarlequinConnectionError):
         HarlequinSqliteAdapter(
-            (str(tiny_sqlite),), read_only=True, connection_mode="rwc"
+            (str(tiny_sqlite),), read_only=True, mode="rwc"
         ).connect()
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -574,7 +574,7 @@ def test_sqlite_extension_not_supported(
 # --- read-only ---------------------------------------------------------------
 
 
-@pytest.mark.parametrize("harlequin_args", ["--read-only", "-r", "-readonly"])
+@pytest.mark.parametrize("harlequin_args", ["--read-only", "-r"])
 def test_read_only_reaches_the_adapter_however_it_is_spelled(
     mock_harlequin: MagicMock,
     mock_adapter: MagicMock,

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -127,7 +127,7 @@ def test_default(
     res = invoke(runner, harlequin_args)
     assert res.exit_code == 0
     expected_conn_str = (harlequin_args,) if harlequin_args else tuple()
-    mock_adapter.assert_called_once_with(conn_str=expected_conn_str)
+    mock_adapter.assert_called_once_with(conn_str=expected_conn_str, read_only=False)
     mock_harlequin.assert_called_once_with(
         adapter=mock_adapter.return_value,
         profile_name=None,
@@ -569,6 +569,51 @@ def test_sqlite_extension_not_supported(
     res = invoke(runner, f"-a sqlite --extension {extension_path.as_posix()}")
     assert res.exit_code == 2
     assert "No such option" in res.stderr
+
+
+# --- read-only ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harlequin_args", ["--read-only", "-r", "-readonly"])
+def test_read_only_reaches_the_adapter_however_it_is_spelled(
+    mock_harlequin: MagicMock,
+    mock_adapter: MagicMock,
+    harlequin_args: str,
+    mock_empty_config: None,
+) -> None:
+    """It is an argument of the adapter's constructor rather than an option any
+    adapter declares, so every adapter takes it under the same name."""
+    runner = CliRunner()
+    res = invoke(runner, harlequin_args)
+    assert res.exit_code == 0
+    assert mock_adapter.call_args
+    assert mock_adapter.call_args.kwargs["read_only"] is True
+
+
+def test_read_only_from_a_profile_reaches_the_adapter(
+    mock_harlequin: MagicMock, mock_adapter: MagicMock, data_dir: Path
+) -> None:
+    """`read_only` is the command's key in a profile, whatever adapter it names."""
+    config_path = data_dir / "unit_tests" / "config" / "good_config.toml"
+    runner = CliRunner()
+    res = invoke(runner, f"--config-path {config_path.as_posix()}")
+    assert res.exit_code == 0
+    assert mock_adapter.call_args
+    assert mock_adapter.call_args.kwargs["read_only"] is False
+
+
+def test_read_only_refuses_an_adapter_that_does_not_declare_it(
+    mock_harlequin: MagicMock, mock_adapter: MagicMock, mock_empty_config: None
+) -> None:
+    """Before the app starts, and before the adapter is constructed: an adapter
+    that cannot enforce read-only is free to ignore the argument, and a session
+    that believed it was read-only would write."""
+    mock_adapter.IMPLEMENTS_READ_ONLY = False
+    runner = CliRunner()
+    res = invoke(runner, "--read-only")
+    assert res.exit_code == 2
+    mock_adapter.assert_not_called()
+    mock_harlequin.assert_not_called()
 
 
 # --- pointing at the other command -------------------------------------------

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -630,7 +630,7 @@ def test_what_this_command_reads_off_the_other_one(mock_empty_config: None) -> N
     """
     assert "--csv" in hsql_spellings()
     assert "--theme" not in hsql_spellings()
-    assert "--read-only" not in hsql_spellings(), "an adapter's option, not hsql's"
+    assert "--no-init" not in hsql_spellings(), "an adapter's option, not hsql's"
 
     assert {"format", "stats", "on_error"} <= hsql_profile_keys()
-    assert "read_only" not in hsql_profile_keys()
+    assert "no_init" not in hsql_profile_keys()

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 import pytest
 
+from harlequin.adapter import HarlequinAdapter, HarlequinConnection
 from harlequin.config import (
     TUI_ONLY_KEYS,
     Config,
@@ -973,6 +974,28 @@ class TestProvenance:
         )
 
 
+def adapter_declaring(
+    options: Sequence[AbstractOption] | None, *, read_only: bool = True
+) -> type[HarlequinAdapter]:
+    """An adapter class for the seam `validate_config_files()` reads.
+
+    The class rather than its options, because a profile can be wrong about
+    what its adapter can do as well as about what it takes.
+    """
+
+    class FakeAdapter(HarlequinAdapter):
+        ADAPTER_OPTIONS = None if options is None else list(options)
+        IMPLEMENTS_READ_ONLY = read_only
+
+        def __init__(self, conn_str: Sequence[str], **options: Any) -> None:
+            raise NotImplementedError
+
+        def connect(self) -> HarlequinConnection:
+            raise NotImplementedError
+
+    return FakeAdapter
+
+
 class TestValidatingEveryConfigFile:
     """`validate_config_files()`: the reader a problem does not stop.
 
@@ -989,11 +1012,11 @@ class TestValidatingEveryConfigFile:
 
     def validate(
         self,
-        adapter_options: Callable[[str], Sequence[AbstractOption] | None] | None = None,
+        adapter_class: Callable[[str], type[HarlequinAdapter] | None] | None = None,
     ) -> list[ConfigProblem]:
         return validate_config_files(
             None,
-            adapter_options=adapter_options or (lambda _: self.OPTIONS),
+            adapter_class=adapter_class or (lambda _: adapter_declaring(self.OPTIONS)),
             command_options=self.COMMAND_OPTIONS,
         )
 
@@ -1005,6 +1028,30 @@ class TestValidatingEveryConfigFile:
             'default_profile = "prod"\n[profiles.prod]\nread_only = true\nlimit = 10\n'
         )
         (cwd / ".harlequin.toml").write_text("[profiles.dev]\nport = 5432\n")
+
+        assert self.validate() == []
+
+    def test_a_read_only_the_adapter_cannot_do_is_a_problem(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        """The one key a profile can be wrong about without misspelling
+        anything: every command refuses to connect under it."""
+        cwd, _ = config_dirs
+        (cwd / ".harlequin.toml").write_text("[profiles.prod]\nread_only = true\n")
+
+        (problem,) = self.validate(
+            adapter_class=lambda _: adapter_declaring(self.OPTIONS, read_only=False)
+        )
+        assert problem.key == "profiles.prod.read_only"
+        assert "read-only" in problem.message
+
+    def test_a_read_only_the_adapter_can_do_is_not(
+        self, config_dirs: tuple[Path, Path]
+    ) -> None:
+        cwd, _ = config_dirs
+        (cwd / ".harlequin.toml").write_text(
+            "[profiles.prod]\nread_only = true\n[profiles.dev]\nread_only = false\n"
+        )
 
         assert self.validate() == []
 
@@ -1088,12 +1135,12 @@ class TestValidatingEveryConfigFile:
             "[profiles.fine]\nread_only = true\n"
         )
 
-        def options(name: str) -> Sequence[AbstractOption] | None:
+        def adapter_class(name: str) -> type[HarlequinAdapter] | None:
             if name == "no-such-adapter":
                 raise HarlequinConfigError("No installed plug-in provides one.")
-            return self.OPTIONS
+            return adapter_declaring(self.OPTIONS)
 
-        (problem,) = self.validate(adapter_options=options)
+        (problem,) = self.validate(adapter_class=adapter_class)
         assert problem.key == "profiles.gone.adapter"
 
     def test_a_default_that_names_no_profile_belongs_to_the_merge(
@@ -1326,10 +1373,12 @@ class TestInterpolatingEnvironmentVariables:
 
         unset, misspelled = validate_config_files(
             None,
-            adapter_options=lambda _: [
-                FlagOption(name="read_only", description="x"),
-                TextOption(name="password", description="x"),
-            ],
+            adapter_class=lambda _: adapter_declaring(
+                [
+                    FlagOption(name="read_only", description="x"),
+                    TextOption(name="password", description="x"),
+                ]
+            ),
             command_options={"adapter", *TUI_ONLY_KEYS},
         )
         assert unset.path == cwd / ".harlequin.toml"

--- a/tests/unit_tests/test_config_schema.py
+++ b/tests/unit_tests/test_config_schema.py
@@ -228,17 +228,14 @@ def test_a_key_a_command_reads_is_not_read_as_an_adapters(
 
 
 def test_an_option_a_command_owns_is_described_once() -> None:
-    """Both bundled adapters declare `read-only`, and hsql owns the spelling.
-
-    So the key is described where the command's keys are, with the command's
-    type, rather than twice under an adapter that would never be handed it.
-    """
+    """`read_only` is a parameter every adapter's constructor takes, so it is
+    described among the command's keys -- and stays there even for an adapter
+    that declares an option by the same name."""
+    declared = [*FAKE_OPTIONS, FlagOption(name="read-only", description="Read only.")]
     profile_keys = schema_for(None)["$defs"]["profile"]["properties"]
     assert profile_keys["read_only"]["type"] == "boolean"
-    for name in adapter_names():
-        declared = load_adapter(name).ADAPTER_OPTIONS
-        options = schema_for({name: declared})["$defs"][f"{name}_options"]
-        assert "read_only" not in options["properties"]
+    options = schema_for({"faux": declared})["$defs"]["faux_options"]["properties"]
+    assert "read_only" not in options
 
 
 def test_a_profile_takes_the_keys_the_ide_reads(fake: Draft202012Validator) -> None:

--- a/tests/unit_tests/test_config_schema.py
+++ b/tests/unit_tests/test_config_schema.py
@@ -44,7 +44,7 @@ FAKE_OPTIONS: list[AbstractOption] = [
         choices=["disable", ("verify-full", "Verify the certificate")],
         default="disable",
     ),
-    FlagOption(name="read-only", description="Connect read-only."),
+    FlagOption(name="no-verify", description="Skip certificate verification."),
 ]
 """One of every option type an adapter can declare, including the two shapes a
 `SelectOption`'s choices come in."""
@@ -137,7 +137,7 @@ def test_a_profile_takes_the_options_of_the_adapter_it_names(
         host="db.example.com",
         extension=["postgis"],
         sslmode="verify-full",
-        read_only=True,
+        no_verify=True,
     )
 
 
@@ -225,6 +225,20 @@ def test_a_key_a_command_reads_is_not_read_as_an_adapters(
     options = schema_for({"faux": FAKE_OPTIONS})["$defs"]["faux_options"]["properties"]
     assert "limit" not in options
     assert profile(fake, adapter="faux", limit=True)
+
+
+def test_an_option_a_command_owns_is_described_once() -> None:
+    """Both bundled adapters declare `read-only`, and hsql owns the spelling.
+
+    So the key is described where the command's keys are, with the command's
+    type, rather than twice under an adapter that would never be handed it.
+    """
+    profile_keys = schema_for(None)["$defs"]["profile"]["properties"]
+    assert profile_keys["read_only"]["type"] == "boolean"
+    for name in adapter_names():
+        declared = load_adapter(name).ADAPTER_OPTIONS
+        options = schema_for({name: declared})["$defs"][f"{name}_options"]
+        assert "read_only" not in options["properties"]
 
 
 def test_a_profile_takes_the_keys_the_ide_reads(fake: Draft202012Validator) -> None:

--- a/tests/unit_tests/test_config_wizard.py
+++ b/tests/unit_tests/test_config_wizard.py
@@ -52,8 +52,10 @@ def run_wizard(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
     def nothing_checked(**_: Any) -> list[Any]:
         return []
 
-    def yes(**_: Any) -> bool:
-        return True
+    def yes(default: bool = True, **_: Any) -> bool:
+        # the default it offered, which is what an unanswered prompt takes: a
+        # confirm that offers none means yes, as questionary's does
+        return bool(default)
 
     def run(config_path: Path, answers: dict[str, Any]) -> None:
         fallbacks: tuple[tuple[str, Callable[..., Any]], ...] = (
@@ -185,6 +187,72 @@ class TestSecrets:
             load_profile(config_path=path, profile_name="one")["md_token"]
             == self.SECRET
         )
+
+
+class TestReadOnly:
+    """The prompt for the one core option that decides what a session may do."""
+
+    def test_saying_yes_writes_the_key(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\ntheme = "fruity"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "connect read-only": True,
+            },
+        )
+
+        assert load_config(config_path=path).profiles["one"]["read_only"] is True
+
+    def test_a_profile_that_is_not_read_only_says_nothing(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """Read-write is the default, so the key is a line that says nothing."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\ntheme = "fruity"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "connect read-only": False,
+            },
+        )
+
+        assert "read_only" not in load_config(config_path=path).profiles["one"]
+
+    def test_saying_no_turns_off_a_profile_that_was_read_only(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """Turning it off has to reach the file, or it did not happen."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nread_only = true\ntheme = "fruity"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "connect read-only": False,
+            },
+        )
+
+        assert "read_only" not in load_config(config_path=path).profiles["one"]
+
+    def test_the_prompt_offers_what_the_profile_already_says(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """Unanswered, it takes the default -- so a read-only profile rewritten
+        without touching this question is still read-only."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nread_only = true\ntheme = "fruity"\n')
+
+        run_wizard(path, {"Which profile would you like to update?": "one"})
+
+        assert load_config(config_path=path).profiles["one"]["read_only"] is True
 
 
 class TestProfileWrite:

--- a/tests/unit_tests/test_config_wizard.py
+++ b/tests/unit_tests/test_config_wizard.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Sequence
 
 import pytest
 
+from harlequin.adapter import HarlequinAdapter, HarlequinConnection
 from harlequin.config import load_config, load_profile
 from harlequin.config_wizard import _wizard
 
@@ -237,6 +238,45 @@ class TestReadOnly:
             {
                 "Which profile would you like to update?": "one",
                 "connect read-only": False,
+            },
+        )
+
+        assert "read_only" not in load_config(config_path=path).profiles["one"]
+
+    def test_the_question_is_not_put_to_an_adapter_that_cannot_answer_it(
+        self,
+        tmp_path: Path,
+        run_wizard: Callable[..., None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A profile that said yes is one Harlequin would refuse to start under.
+
+        Answered yes here, so a question that was put would have written the
+        key -- and the profile that had it loses it, which is the same answer
+        `--config validate` gives about the file it was already in.
+        """
+
+        class Undeclared(HarlequinAdapter):
+            ADAPTER_OPTIONS = None
+
+            def __init__(self, conn_str: Sequence[str], **options: Any) -> None:
+                raise NotImplementedError
+
+            def connect(self) -> HarlequinConnection:
+                raise NotImplementedError
+
+        monkeypatch.setattr(
+            "harlequin.config_wizard.load_adapter_plugins",
+            lambda: {"undeclared": Undeclared},
+        )
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "undeclared"\nread_only = true\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "connect read-only": True,
             },
         )
 

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -3357,23 +3357,36 @@ def test_read_only_is_refused_ahead_of_the_mode_that_would_connect(
     assert declares_nothing in res.stderr
 
 
-def test_read_only_is_refused_before_it_is_written_into_a_profile(
+def test_read_only_is_written_into_a_profile_without_being_refused(
     hsql: Hsql, declares_nothing: str, init_dirs: tuple[Path, Path]
 ) -> None:
-    """`--config init` writes a promise rather than keeping one, and a profile
-    saying `read_only = true` to an adapter that cannot is the promise this
-    flag exists to not make."""
+    """`--config init` writes a file rather than connecting with one, so it
+    writes what it was told and leaves the refusal to the run that connects."""
     cwd, _ = init_dirs
     res = hsql("--config", "init", "-P", "prod", "-a", declares_nothing, "--read-only")
-    assert res.exit_code == ExitCode.USAGE
-    assert not (cwd / ".harlequin.toml").exists()
+    assert res.exit_code == ExitCode.OK
+    profile = written(cwd / ".harlequin.toml")["profiles"]["prod"]
+    assert profile["read_only"] is True
 
 
-def test_read_only_does_not_refuse_the_mode_that_would_explain_it(
+@pytest.mark.parametrize(
+    "mode", [["--info"], ["--spec"], ["--config", "show"], ["--config", "validate"]]
+)
+def test_read_only_does_not_refuse_a_mode_that_reads_no_database(
+    hsql: Hsql, declares_nothing: str, mode: list[str], config_dirs: tuple[Path, Path]
+) -> None:
+    """None of them can write whatever they are told -- and two of them are
+    where a caller finds out which adapter they are on and where its read-only
+    came from, which is no use if the flag refuses them."""
+    res = hsql(*mode, "-a", declares_nothing, "--read-only")
+    assert res.exit_code == ExitCode.OK, res.stderr
+
+
+def test_info_reports_an_adapter_that_cannot_be_read_only(
     hsql: Hsql, declares_nothing: str
 ) -> None:
-    """`--info` connects to nothing and promises nothing, and it is where the
-    refusal points, so it answers instead of joining in."""
+    """`--info` is where the refusal points, so it answers rather than joining
+    in."""
     res = hsql("--info", "-a", declares_nothing, "--read-only")
     assert res.exit_code == ExitCode.OK
     capabilities = info_of(res)["adapters"][declares_nothing]["capabilities"]

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -89,7 +89,7 @@ def test_help_is_adapter_agnostic(hsql: Hsql) -> None:
 def test_help_for_one_adapter(hsql: Hsql) -> None:
     res = hsql("--help", "-a", "duckdb")
     assert res.exit_code == ExitCode.OK
-    assert "--read-only" in res.output
+    assert "--no-init" in res.output
     assert "Showing duckdb's connection options." in res.output
 
 
@@ -2138,7 +2138,6 @@ def test_spec_reports_what_the_adapter_declares_now(hsql: Hsql, name: str) -> No
     pins names cannot tell the difference between the two.
     """
     from harlequin.config import sluggify_option_name
-    from harlequin.hsql.cli import bare_command
     from harlequin.plugins import load_adapter
 
     declared = {
@@ -2149,12 +2148,9 @@ def test_spec_reports_what_the_adapter_declares_now(hsql: Hsql, name: str) -> No
         o["name"]
         for o in spec_of(hsql("--spec", "-a", name))["adapters"][name]["options"]
     }
-    # every declaration except the ones hsql's own flags claim, `read_only`
-    # today: an option the command drops is not part of the surface a caller
-    # can type, and this document reports that surface
-    owned = {param.name for param in bare_command().params}
-    assert "read_only" in declared & owned
-    assert reported == declared - owned
+    # equal today, because neither in-tree adapter declares a spelling hsql's
+    # own flags take; a name that goes missing here is one hsql has claimed
+    assert reported == declared
 
 
 def test_spec_narrows_to_one_adapter(hsql: Hsql) -> None:

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -81,7 +81,7 @@ def test_help_is_adapter_agnostic(hsql: Hsql) -> None:
     assert "Installed adapters:" in res.output
     assert "hsql --help -a <adapter>" in res.output
     # no adapter's connection options, and none of the IDE's options either
-    assert "--read-only" not in res.output
+    assert "--no-init" not in res.output
     assert "--theme" not in res.output
     assert "--show-files" not in res.output
 
@@ -1618,7 +1618,7 @@ def test_config_schema_describes_the_adapters_installed_here(hsql: Hsql) -> None
 
 def test_config_schema_describes_an_adapters_own_options(hsql: Hsql) -> None:
     options = schema_of(hsql("--config", "schema"))["$defs"]["duckdb_options"]
-    assert options["properties"]["read_only"]["type"] == "boolean"
+    assert options["properties"]["no_init"]["type"] == "boolean"
     assert options["properties"]["extension"]["type"] == "array"
 
 
@@ -1760,13 +1760,13 @@ def test_config_init_writes_an_adapters_own_options(
     """The half of a profile only the adapter declares.
 
     Which is why this is the one mode that imports an adapter to write a file:
-    `--read-only` is not a flag hsql has until sqlite's options are on it.
+    `--no-init` is not a flag hsql has until sqlite's options are on it.
     """
     cwd, _ = init_dirs
-    res = hsql("--config", "init", "-P", "prod", "-a", "sqlite", "--read-only")
+    res = hsql("--config", "init", "-P", "prod", "-a", "sqlite", "--no-init")
     assert res.exit_code == ExitCode.OK
     profile = written(cwd / ".harlequin.toml")["profiles"]["prod"]
-    assert profile == {"adapter": "sqlite", "read_only": True}
+    assert profile == {"adapter": "sqlite", "no_init": True}
 
 
 def test_config_init_writes_a_shorthand_as_the_format_it_stands_for(
@@ -2098,17 +2098,17 @@ def test_spec_covers_every_installed_adapter(hsql: Hsql) -> None:
 def test_spec_reports_an_adapter_option_the_way_it_is_passed(hsql: Hsql) -> None:
     """The two spellings an adapter option has, and both are needed.
 
-    `--read-only` is what a command line takes; `read_only` is what a profile
+    `--no-init` is what a command line takes; `no_init` is what a profile
     writes, and what the adapter's constructor is handed. A caller that had
     only one of them would write the other wrong.
     """
     duckdb = spec_of(hsql("--spec"))["adapters"]["duckdb"]
-    (read_only,) = [o for o in duckdb["options"] if o["name"] == "read_only"]
-    assert read_only["decls"] == ["--read-only", "-readonly", "-r"]
-    assert read_only["type"] == "boolean"
-    assert read_only["is_flag"] is True
-    assert read_only["default"] is False
-    assert read_only["help"]
+    (no_init,) = [o for o in duckdb["options"] if o["name"] == "no_init"]
+    assert no_init["decls"] == ["--no-init"]
+    assert no_init["type"] == "boolean"
+    assert no_init["is_flag"] is True
+    assert no_init["default"] is False
+    assert no_init["help"]
 
 
 def test_spec_reports_an_adapters_repeatable_and_chosen_options(hsql: Hsql) -> None:
@@ -2138,6 +2138,7 @@ def test_spec_reports_what_the_adapter_declares_now(hsql: Hsql, name: str) -> No
     pins names cannot tell the difference between the two.
     """
     from harlequin.config import sluggify_option_name
+    from harlequin.hsql.cli import bare_command
     from harlequin.plugins import load_adapter
 
     declared = {
@@ -2148,9 +2149,12 @@ def test_spec_reports_what_the_adapter_declares_now(hsql: Hsql, name: str) -> No
         o["name"]
         for o in spec_of(hsql("--spec", "-a", name))["adapters"][name]["options"]
     }
-    # equal today, because neither in-tree adapter declares a spelling hsql's
-    # own flags take; a name that goes missing here is one hsql has claimed
-    assert reported == declared
+    # every declaration except the ones hsql's own flags claim, `read_only`
+    # today: an option the command drops is not part of the surface a caller
+    # can type, and this document reports that surface
+    owned = {param.name for param in bare_command().params}
+    assert "read_only" in declared & owned
+    assert reported == declared - owned
 
 
 def test_spec_narrows_to_one_adapter(hsql: Hsql) -> None:
@@ -3276,6 +3280,179 @@ def test_catalog_search_is_in_the_help(hsql: Hsql) -> None:
     assert f"{PROGRAM} --catalog-search" in res.output
 
 
+# --- `--read-only`, and the capability it needs -------------------------------
+
+
+@pytest.fixture
+def declares_nothing(monkeypatch: pytest.MonkeyPatch) -> str:
+    """The name of an installed adapter that declares no capability at all.
+
+    Which is every adapter the day before it adds a declaration, so this is
+    what a refusal has to be right about -- and `connect()` raising is what
+    proves the refusal came first.
+    """
+    from harlequin.adapter import HarlequinAdapter, HarlequinConnection
+
+    class DeclaresNothing(HarlequinAdapter):
+        ADAPTER_OPTIONS = None
+
+        def __init__(self, conn_str: Sequence[str], **options: Any) -> None:
+            pass
+
+        def connect(self) -> HarlequinConnection:
+            raise AssertionError("connected before checking the declaration")
+
+    entry_point = MagicMock()
+    entry_point.name = "undeclared"
+    entry_point.load.return_value = DeclaresNothing
+    monkeypatch.setattr("harlequin.plugins.entry_points", lambda group: [entry_point])
+    return "undeclared"
+
+
+def test_read_only_refuses_an_adapter_that_does_not_declare_it(
+    hsql: Hsql, declares_nothing: str
+) -> None:
+    """A flag that no-ops is worse than one that is absent.
+
+    An adapter drops an option it does not recognize, so a run that believed it
+    was read-only would write. Refused before it connects, which is the whole
+    of what the flag promises.
+    """
+    res = hsql("-a", declares_nothing, "--read-only", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert declares_nothing in res.stderr
+    assert "--read-only" in res.stderr and "--info" in res.stderr
+
+
+def test_read_only_from_a_profile_is_refused_the_same_way(
+    hsql: Hsql, declares_nothing: str, tmp_path: Path
+) -> None:
+    """The spelling a human is likelier to have used, and to trust.
+
+    `read_only = true` in a profile is a promise made once and relied on by
+    every invocation that loads it, so it is refused where the flag is.
+    """
+    path = tmp_path / ".harlequin.toml"
+    path.write_text("[profiles.prod]\nread_only = true\n")
+    res = hsql(
+        "--config-path",
+        str(path),
+        "-P",
+        "prod",
+        "-a",
+        declares_nothing,
+        "-c",
+        "select 1",
+    )
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert declares_nothing in res.stderr
+    assert "profile" in res.stderr
+
+
+def test_read_only_is_refused_ahead_of_the_mode_that_would_connect(
+    hsql: Hsql, declares_nothing: str
+) -> None:
+    """`--catalog` connects too, so it meets the same refusal."""
+    res = hsql("-a", declares_nothing, "--read-only", "--catalog")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert declares_nothing in res.stderr
+
+
+def test_read_only_is_refused_before_it_is_written_into_a_profile(
+    hsql: Hsql, declares_nothing: str, init_dirs: tuple[Path, Path]
+) -> None:
+    """`--config init` writes a promise rather than keeping one, and a profile
+    saying `read_only = true` to an adapter that cannot is the promise this
+    flag exists to not make."""
+    cwd, _ = init_dirs
+    res = hsql("--config", "init", "-P", "prod", "-a", declares_nothing, "--read-only")
+    assert res.exit_code == ExitCode.USAGE
+    assert not (cwd / ".harlequin.toml").exists()
+
+
+def test_read_only_does_not_refuse_the_mode_that_would_explain_it(
+    hsql: Hsql, declares_nothing: str
+) -> None:
+    """`--info` connects to nothing and promises nothing, and it is where the
+    refusal points, so it answers instead of joining in."""
+    res = hsql("--info", "-a", declares_nothing, "--read-only")
+    assert res.exit_code == ExitCode.OK
+    capabilities = info_of(res)["adapters"][declares_nothing]["capabilities"]
+    assert capabilities["implements_read_only"] is False
+
+
+def test_every_bundled_adapter_declares_read_only(hsql: Hsql) -> None:
+    """`--info` is where a caller learns which adapters can be read-only."""
+    adapters = info_of(hsql("--info"))["adapters"]
+    assert all(
+        adapters[name]["capabilities"]["implements_read_only"]
+        for name in ("duckdb", "sqlite")
+    )
+
+
+def one_row_db(adapter: str, path: Path) -> list[str]:
+    """A database with a table in it, written by the driver itself.
+
+    Built outside hsql because a connection this process still holds is one
+    duckdb will not reopen under a different configuration -- and read-only is
+    a different configuration.
+    """
+    if adapter == "duckdb":
+        import duckdb
+
+        duck = duckdb.connect(str(path))
+        duck.execute("create table t as select 1 as n")
+        duck.close()
+    else:
+        import sqlite3
+
+        lite = sqlite3.connect(str(path))
+        lite.execute("create table t as select 1 as n")
+        lite.commit()
+        lite.close()
+    return ["-a", adapter, "--no-init", str(path)]
+
+
+@pytest.mark.parametrize("adapter", ["duckdb", "sqlite"])
+def test_read_only_stops_a_write_on_every_bundled_adapter(
+    hsql: Hsql, tmp_path: Path, adapter: str
+) -> None:
+    """The flag's whole job, end to end: reads answer, writes fail."""
+    argv = one_row_db(adapter, tmp_path / f"{adapter}.db")
+
+    res = hsql(*argv, "--read-only", "-c", "select n from t", "-tA")
+    assert res.exit_code == ExitCode.OK, res.stderr
+    assert res.stdout == "1\n"
+
+    res = hsql(*argv, "--read-only", "-c", "insert into t values (2)")
+    assert res.exit_code == ExitCode.QUERY
+    assert res.stdout == ""
+    assert res.stderr
+
+
+@pytest.mark.parametrize("spelling", ["-r", "-readonly", "--read-only"])
+def test_read_only_means_the_same_thing_however_it_is_spelled(
+    hsql: Hsql, tmp_path: Path, spelling: str
+) -> None:
+    """The spellings an adapter gives its own read-only option are hsql's, so
+    an invocation that used one of them still connects read-only."""
+    argv = one_row_db("sqlite", tmp_path / "one.db")
+
+    res = hsql(*argv, spelling, "-c", "insert into t values (2)")
+    assert res.exit_code == ExitCode.QUERY
+    assert res.stdout == ""
+
+
+def test_read_only_is_in_the_help(hsql: Hsql) -> None:
+    """On the adapter-agnostic surface, because the refusal is too."""
+    res = hsql("--help")
+    assert res.exit_code == ExitCode.OK
+    assert "--read-only" in res.output
+
+
 # --- secrets, and the promise that none of them is printed -------------------
 
 SECRET = "hunter2-and-then-some"
@@ -3428,7 +3605,7 @@ def test_spec_prints_no_secret_and_says_which_options_are(
         for entry in json.loads(res.stdout)["adapters"]["duckdb"]["options"]
     }
     assert options["md_token"]["secret"] is True
-    assert options["read_only"]["secret"] is False
+    assert options["no_init"]["secret"] is False
     # both halves of the document answer with the same keys
     assert all("secret" in entry for entry in json.loads(res.stdout)["options"])
 

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -3429,16 +3429,24 @@ def test_read_only_stops_a_write_on_every_bundled_adapter(
     assert res.stderr
 
 
-@pytest.mark.parametrize("spelling", ["-r", "-readonly", "--read-only"])
+@pytest.mark.parametrize("spelling", ["-r", "--read-only"])
 def test_read_only_means_the_same_thing_however_it_is_spelled(
     hsql: Hsql, tmp_path: Path, spelling: str
 ) -> None:
-    """The spellings an adapter gives its own read-only option are hsql's, so
-    an invocation that used one of them still connects read-only."""
     argv = one_row_db("sqlite", tmp_path / "one.db")
 
     res = hsql(*argv, spelling, "-c", "insert into t values (2)")
     assert res.exit_code == ExitCode.QUERY
+    assert res.stdout == ""
+
+
+def test_the_single_dash_long_spelling_is_not_one(hsql: Hsql, tmp_path: Path) -> None:
+    """`-readonly` is two spellings' worth of nothing: `-r` and `--read-only`
+    are what a caller has, on both commands and for every adapter."""
+    argv = one_row_db("sqlite", tmp_path / "one.db")
+
+    res = hsql(*argv, "-readonly", "-c", "insert into t values (2)")
+    assert res.exit_code == ExitCode.USAGE
     assert res.stdout == ""
 
 

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -3370,6 +3370,26 @@ def test_read_only_is_refused_before_it_is_written_into_a_profile(
     assert not (cwd / ".harlequin.toml").exists()
 
 
+def test_config_validate_reports_a_read_only_the_adapter_cannot_do(
+    hsql: Hsql, declares_nothing: str, config_dirs: tuple[Path, Path]
+) -> None:
+    """`--config validate` imports an adapter per profile already, so it can
+    say that a profile pairs one with a read-only it cannot honor."""
+    cwd, _ = config_dirs
+    (cwd / ".harlequin.toml").write_text(
+        f"[profiles.prod]\nadapter = '{declares_nothing}'\nread_only = true\n"
+    )
+
+    # `-a` only to satisfy the choice of installed adapters; the mode reads the
+    # adapter each profile names
+    res = hsql("--config", "validate", "-a", declares_nothing, "-tA")
+    assert res.exit_code == ExitCode.USAGE
+    file, key, problem, _ = res.stdout.strip().split("|")
+    assert file == str(cwd / ".harlequin.toml")
+    assert key == "profiles.prod.read_only"
+    assert declares_nothing in problem
+
+
 @pytest.mark.parametrize(
     "mode", [["--info"], ["--spec"], ["--config", "show"], ["--config", "validate"]]
 )

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -3357,16 +3357,17 @@ def test_read_only_is_refused_ahead_of_the_mode_that_would_connect(
     assert declares_nothing in res.stderr
 
 
-def test_read_only_is_written_into_a_profile_without_being_refused(
+def test_read_only_is_refused_before_it_is_written_into_a_profile(
     hsql: Hsql, declares_nothing: str, init_dirs: tuple[Path, Path]
 ) -> None:
-    """`--config init` writes a file rather than connecting with one, so it
-    writes what it was told and leaves the refusal to the run that connects."""
+    """`--config init` imports the adapter to write the options it declares, so
+    it can refuse a profile that names one and a read-only it cannot honor --
+    which is a profile no run would start under."""
     cwd, _ = init_dirs
     res = hsql("--config", "init", "-P", "prod", "-a", declares_nothing, "--read-only")
-    assert res.exit_code == ExitCode.OK
-    profile = written(cwd / ".harlequin.toml")["profiles"]["prod"]
-    assert profile["read_only"] is True
+    assert res.exit_code == ExitCode.USAGE
+    assert declares_nothing in res.stderr
+    assert not (cwd / ".harlequin.toml").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_options.py
+++ b/tests/unit_tests/test_options.py
@@ -211,6 +211,31 @@ def test_nothing_is_secret_unless_it_says_so(option: AbstractOption) -> None:
     assert option.to_dict()["secret"] is False
 
 
+@pytest.mark.parametrize("adapter", ["duckdb", "sqlite"])
+def test_every_declared_option_is_a_parameter_the_constructor_names(
+    adapter: str,
+) -> None:
+    """The name a caller types and the name the adapter is handed are one name.
+
+    An adapter takes supersets of what it declares and drops the rest, so a
+    declaration whose name no parameter matches is an option that parses,
+    validates, and does nothing -- in silence, which is how `--mode ro` opened
+    a writable database.
+    """
+    import inspect
+
+    from harlequin.config import sluggify_option_name
+    from harlequin.plugins import load_adapter
+
+    adapter_cls = load_adapter(adapter)
+    declared = {
+        sluggify_option_name(option.name)
+        for option in adapter_cls.ADAPTER_OPTIONS or []
+    }
+    named = set(inspect.signature(adapter_cls.__init__).parameters)
+    assert declared <= named
+
+
 def test_the_duckdb_adapter_declares_its_token_secret() -> None:
     """The one secret in tree, and the reason the declaration is not theory."""
     from harlequin_duckdb import DUCKDB_OPTIONS

--- a/tests/unit_tests/test_options.py
+++ b/tests/unit_tests/test_options.py
@@ -217,7 +217,7 @@ def test_the_duckdb_adapter_declares_its_token_secret() -> None:
 
     declared = {option.name: option.to_dict() for option in DUCKDB_OPTIONS}
     assert declared["md_token"]["secret"] is True
-    assert declared["read-only"]["secret"] is False
+    assert declared["md_saas"]["secret"] is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of #524 — PR 13 of M2 (`docs/plans/m2-hsql-technical-plan.md`, §3.4 and §3.6).

**What** are the key elements of this solution?

- **Two declarations on the contract**: `IMPLEMENTS_READ_ONLY` and `IMPLEMENTS_VALIDATE_SQL`, both `False` by default. DuckDB and SQLite declare read-only; DuckDB also declares validate-sql (SQLite's raises). `hsql --info` reports them without a second list, since it reads the names off `HarlequinAdapter`.
- **`read_only` is an argument**: `HarlequinAdapter.__init__(self, conn_str, read_only=False, **options)`. Both commands pass it explicitly rather than through the options bag.
- **`--read-only` (also `-r`) on both commands**, and a refusal — before connecting — when the adapter does not declare the capability. Same refusal for `read_only = true` arriving from a profile.
- **The bundled adapters dropped their own `read-only` options.** They already had `read_only` constructor parameters, so they only lost the declaration; the spellings a user types are unchanged apart from `-readonly` (below).
- **`harlequin --config` only asks the read-only question of an adapter that can answer it**, and `hsql --config validate` reports a profile that pairs `read_only = true` with an adapter that cannot: `Profile sets read_only, but its adapter (postgres) does not support read-only connections.`
- **Bug fix found on the way**: the SQLite adapter declares an option named `mode` but its constructor took `connection_mode`, so `**_` swallowed it. `--mode ro` opened a writable database and `--read-only --mode rwc` connected instead of raising the error its own help text describes. Both predate this branch. The parameter is renamed, and a new test asserts every option a bundled adapter declares is a parameter its constructor names.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

A flag that silently no-ops is worse than one that is absent: `--read-only` exists so a human can hand a credential to an agent, and an adapter drops kwargs it does not recognize. So the capability is **declared, not detected** — reflection cannot answer it, since SQLite defines `validate_sql` and raises from it — and an adapter that declares nothing is refused rather than connected to and hoped about.

The first version of this passed `read_only=True` in the options dict, which worked in tree only because DuckDB and SQLite each declare an option that sluggifies to `read_only` — a naming convention, not a contract, and the same convention that would do nothing on an adapter which declares no such option. Making it a documented constructor parameter is additive (existing adapters take it through `**kwargs`), where the same argument on `connect()` would break every adapter at once, since `connect()` takes none today.

Tradeoffs and breaking changes:

- **`-readonly` is gone.** It never parsed on `harlequin` (the first pass read it as a cluster of short options containing its own `-a`), and worked on `hsql` only for the two adapters that declared it. `-r` and `--read-only` are how both commands take it.
- **`HarlequinSqliteAdapter(connection_mode=...)` is now `mode=...`** — breaking for code constructing that adapter directly in Python, and for nobody typing a command.
- **The wizard stops offering read-only for an adapter that cannot do it**, so a profile that already had `read_only = true` for such an adapter loses the key when the wizard rewrites it. That is the same verdict `--config validate` gives about the file.
- **`hsql --config init` refuses** an undeclared read-only rather than writing a profile no run would start under; the modes that only report (`--info`, `--spec`, `--config show|validate|...`) answer normally, since two of them are where a caller finds out which adapter they are on.
- `validate_config_files()` now takes `adapter_class=` instead of `adapter_options=`: a profile can be wrong about what its adapter *can do* as well as about what it *takes*, and only the class says. `--timeout` will want `IMPLEMENTS_CANCEL` through the same hole.

Companion issues are open against the adapters we maintain out of tree: tconbeer/harlequin-postgres#58, tconbeer/harlequin-mysql#46, tconbeer/harlequin-odbc#24.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the safety page M2 plans as PR 17 — `--read-only` on both commands, what it does per adapter, and that an adapter which does not declare the capability is refused rather than silently ignored. Note also that this repo's `packaging/hsql/README.md` shows an `--info` example whose `capabilities` object lists only `implements_cancel`; it was already missing `implements_catalog_search` before this PR and now misses two more.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. (No issue link: #524 is the milestone's tracking issue rather than one this PR closes, and the sibling entries in this release don't link it either.)
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFemUT7LfRtKPDHcPTFu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyFemUT7LfRtKPDHcPTFu4)_