### PR TITLE
Document read-only, timeouts, and the psql differences in hsql's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ $ hsql -P dev -c "select * from users"
 
 hsql can also explore the catalog without writing SQL: `hsql --catalog --path mydb.analytics` lists a schema's relations (and `--path mydb.analytics.orders` lists that table's columns), while `hsql --catalog-search customer_id` searches every level at once.
 
+To bound what an agent can do, `--read-only` connects in a mode the database refuses writes in, and `hsql --timeout 30` cancels a run that takes longer than that. Both are also profile keys, and both refuse to start if the adapter cannot enforce them. Harlequin takes `--read-only` too.
+
 For more information on hsql, see the [getting started docs](https://harlequin.sh/docs/getting-started/hsql).
 
 ## Using Harlequin with Django

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -322,7 +322,7 @@ hsql --limit -1 -c "select 1" --csv -o data.csv --stats 2>&1 | jq -e '.truncated
 
 ## Running Safely
 
-Two options bound what an invocation can do, and hsql refuses to run at all if the adapter cannot enforce them, rather than reporting a guarantee it did not get.
+Two options bound what an invocation can do, and hsql refuses to run at all if the adapter cannot enforce them.
 
 `--read-only` (or `-r`) connects in a mode the database itself refuses writes in:
 
@@ -331,14 +331,14 @@ $ hsql -r "path/to/duck.db" -c "insert into orders values (1)"
 hsql: error: Invalid Input Error: Cannot execute statement of type "INSERT" on database "duck" which is attached in read-only mode!
 ```
 
-`--timeout SECONDS` is a wall clock over the whole invocation — executing and fetching both — and exits `4` when it runs out:
+`--timeout SECONDS` limits the duration of executing and fetching a query, and exits `4` when it runs out:
 
 ```bash
 $ hsql --timeout 0.5 -c "select count(*) from range(100000000000) t(i)"
 hsql: error: timed out after 0.5s
 ```
 
-Both are also profile keys, so the line that makes an agent's profile safe is one you can point at:
+Both are also profile keys:
 
 ```toml
 [profiles.agent]
@@ -347,35 +347,9 @@ read_only = true
 timeout = 30
 ```
 
-Not every adapter can connect read-only, and not every adapter can cancel a running query. Where one cannot, hsql exits `2` before it opens a connection:
+hsql refuses to open a connection with an adapter that cannot enforce `--read-only` or `--timeout`.
 
-```bash
-$ hsql -a myadapter -r -c "select 1"
-hsql: error: myadapter does not declare read-only support, so --read-only cannot be honored. See 'hsql --info'.
-```
-
-`hsql --info` reports `implements_read_only` and `implements_cancel` for every installed adapter, so a script can check before it depends on either one.
-
-Harlequin takes `--read-only` too, so the same profile opens the IDE the same way.
-
-## Differences from psql
-
-`-c`, `-f`, `-t` and `-A` mean what they mean in psql, so `hsql -tAc "select count(*) from orders"` prints a bare number, exactly as it would there. These do not:
-
-| | psql | hsql |
-|---|---|---|
-| `-P` | `--pset`, an output setting | `--profile`, a config-file profile |
-| Expanded output | `-x` | `--vertical` |
-| Field separator | `-F` | `--csv`, `--tsv`, or any other `--format` |
-| Listing databases | `-l` | `--catalog` |
-| Describing an object | `\d`, `\dt` | `--catalog --path`, `--catalog-search` |
-| Stopping on the first error | `-v ON_ERROR_STOP=1` | `--on-error stop`, which is the default |
-| One transaction | `-1` | write `begin` and `commit` in your script |
-| `-o` | a file for query output | a file, or a directory that gets one file per result set |
-| Connection flags | `-h`, `-p`, `-U`, built in | the adapter's, so `hsql --help -a postgres` lists them |
-| Row limits | none | 500 rows by default; `--limit -1` removes it |
-| Suppressing chatter | `-q` | nothing to suppress: stdout is only ever results |
-| Exit codes | `1` its own error, `2` connection, `3` script error | `1` query error, `2` usage/config, `3` connection, `4` timeout |
+`hsql --info` reports `implements_read_only` and `implements_cancel` for every installed adapter.
 
 ## Describing hsql to an Agent
 
@@ -423,3 +397,22 @@ Please consider [sponsoring Harlequin's author](https://github.com/sponsors/tcon
 Thanks for your interest in Harlequin! Harlequin and hsql are primarily maintained by [Ted Conbeer](https://github.com/tconbeer), but he welcomes all contributions!
 
 Please see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more information.
+
+## Differences from psql
+
+`-c`, `-f`, `-t` and `-A` mean what they mean in psql, so `hsql -tAc "select count(*) from orders"` prints a bare number, exactly as it would there. These do not:
+
+| | psql | hsql |
+|---|---|---|
+| `-P` | `--pset`, an output setting | `--profile`, a config-file profile |
+| Expanded output | `-x` | `--vertical` |
+| Field separator | `-F` | `--csv`, `--tsv`, or any other `--format` |
+| Listing databases | `-l` | `--catalog` |
+| Describing an object | `\d`, `\dt` | `--catalog --path`, `--catalog-search` |
+| Stopping on the first error | `-v ON_ERROR_STOP=1` | `--on-error stop`, which is the default |
+| One transaction | `-1` | write `begin` and `commit` in your script |
+| `-o` | a file for query output | a file, or a directory that gets one file per result set |
+| Connection flags | `-h`, `-p`, `-U`, built in | the adapter's, so `hsql --help -a postgres` lists them |
+| Row limits | none | 500 rows by default; `--limit -1` removes it |
+| Suppressing chatter | `-q` | nothing to suppress: stdout is only ever results |
+| Exit codes | `1` its own error, `2` connection, `3` script error | `1` query error, `2` usage/config, `3` connection, `4` timeout |

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -294,12 +294,12 @@ hsql can execute multiple statements in one invocation, and supports several met
 - Pass `-c` multiple times
 - Include multiple queries, separated by `;`, in one `-c` option
 - Pass one or more .sql files with `-f`, with multiple statements in each
-- Use `--results` to define which queries output data to stdout
+- Use `--result` to define which queries output data to stdout
 - Use `--on-error` to either `stop` or `continue` if one or more queries produces an error.
 
 In other words, this works:
 ```bash
-$ hsql -P prod --limit -1 --format md --results all --on-error stop \
+$ hsql -P prod --limit -1 --format md --result all --on-error stop \
     -f ./setup.sql \
     -c "select count(*) from raw_table" \
     -f ./build-models.sql \
@@ -320,6 +320,63 @@ You can also use `--stats` and `jq` together to error on a truncated query:
 hsql --limit -1 -c "select 1" --csv -o data.csv --stats 2>&1 | jq -e '.truncated | not' > /dev/null
 ```
 
+## Running Safely
+
+Two options bound what an invocation can do, and hsql refuses to run at all if the adapter cannot enforce them, rather than reporting a guarantee it did not get.
+
+`--read-only` (or `-r`) connects in a mode the database itself refuses writes in:
+
+```bash
+$ hsql -r "path/to/duck.db" -c "insert into orders values (1)"
+hsql: error: Invalid Input Error: Cannot execute statement of type "INSERT" on database "duck" which is attached in read-only mode!
+```
+
+`--timeout SECONDS` is a wall clock over the whole invocation — executing and fetching both — and exits `4` when it runs out:
+
+```bash
+$ hsql --timeout 0.5 -c "select count(*) from range(100000000000) t(i)"
+hsql: error: timed out after 0.5s
+```
+
+Both are also profile keys, so the line that makes an agent's profile safe is one you can point at:
+
+```toml
+[profiles.agent]
+adapter = "postgres"
+read_only = true
+timeout = 30
+```
+
+Not every adapter can connect read-only, and not every adapter can cancel a running query. Where one cannot, hsql exits `2` before it opens a connection:
+
+```bash
+$ hsql -a myadapter -r -c "select 1"
+hsql: error: myadapter does not declare read-only support, so --read-only cannot be honored. See 'hsql --info'.
+```
+
+`hsql --info` reports `implements_read_only` and `implements_cancel` for every installed adapter, so a script can check before it depends on either one.
+
+Harlequin takes `--read-only` too, so the same profile opens the IDE the same way.
+
+## Differences from psql
+
+`-c`, `-f`, `-t` and `-A` mean what they mean in psql, so `hsql -tAc "select count(*) from orders"` prints a bare number, exactly as it would there. These do not:
+
+| | psql | hsql |
+|---|---|---|
+| `-P` | `--pset`, an output setting | `--profile`, a config-file profile |
+| Expanded output | `-x` | `--vertical` |
+| Field separator | `-F` | `--csv`, `--tsv`, or any other `--format` |
+| Listing databases | `-l` | `--catalog` |
+| Describing an object | `\d`, `\dt` | `--catalog --path`, `--catalog-search` |
+| Stopping on the first error | `-v ON_ERROR_STOP=1` | `--on-error stop`, which is the default |
+| One transaction | `-1` | write `begin` and `commit` in your script |
+| `-o` | a file for query output | a file, or a directory that gets one file per result set |
+| Connection flags | `-h`, `-p`, `-U`, built in | the adapter's, so `hsql --help -a postgres` lists them |
+| Row limits | none | 500 rows by default; `--limit -1` removes it |
+| Suppressing chatter | `-q` | nothing to suppress: stdout is only ever results |
+| Exit codes | `1` its own error, `2` connection, `3` script error | `1` query error, `2` usage/config, `3` connection, `4` timeout |
+
 ## Describing hsql to an Agent
 
 `hsql --help` is written for a person; two flags answer the same questions as JSON, so an agent can find its way around an installation it has never seen. `--spec` is a machine-readable `--help`: every option on the command, plus the connection options every installed adapter declares, each with its type, choices, default and help text. `--info` describes the installation instead — versions, platform, the config files hsql found, the profile that would be active, and what each installed adapter declares it supports — so a script can check that an adapter is there, and what it can do, before depending on it.
@@ -328,9 +385,12 @@ hsql --limit -1 -c "select 1" --csv -o data.csv --stats 2>&1 | jq -e '.truncated
 $ hsql --info -a sqlite | jq '.adapters.sqlite'
 {
   "distribution": "harlequin",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "capabilities": {
-    "implements_cancel": true
+    "implements_cancel": true,
+    "implements_catalog_search": true,
+    "implements_read_only": true,
+    "implements_validate_sql": false
   },
   "error": null
 }


### PR DESCRIPTION
Part of #524. This is the harlequin-repo half of PR 17 in `docs/plans/m2-hsql-technical-plan.md` — the docs PR for Release C, which the plan describes as "Safety page and the psql differences table."

**What** are the key elements of this solution?

- A **"Running Safely"** section in `packaging/hsql/README.md`: `--read-only` (`-r`) and `--timeout SECONDS`, the fact that both are profile keys as well as flags, that hsql refuses to open a connection with an adapter that cannot enforce either, and that `hsql --info` reports `implements_read_only` and `implements_cancel`. Both examples are real output — the DuckDB read-only error and `hsql: error: timed out after 0.5s` with its exit 4.
- A **"Differences from psql"** table at the end of the file, covering `-P`, `-x`, `-F`, `-l`, `\d`, `ON_ERROR_STOP`, `-1`, `-o`, connection flags, the 500-row default, `-q`, and the exit codes — opening with the note that `-c`, `-f`, `-t` and `-A` do *not* diverge, so `hsql -tAc` reads as the psql idiom it is.
- Two corrections found while checking claims against the real command: the scripting section spelled the option `--results`, but it is `--result`; and the `--info` example still showed 2.9.0 with `implements_cancel` alone, which is stale in the one section that points at `--info` for capabilities.
- One sentence in the root `README.md` on both flags, in the agents section.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The plan's PR 17 is a `harlequin-web` PR for the pages themselves; what lands in this repo is the README, which carries a subset of the docs. That follows the shape of the earlier docs PRs in this milestone (#1071, #1081), which did the same thing for the config modes and the catalog.

The refusal path is stated rather than demonstrated: every adapter installed here declares both capabilities, so an example would have had to be invented for an adapter that does not exist.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the other half of plan PR 17 — a "Safety: read-only and timeouts" page and a "Differences from psql" page in the Headless & Agents topic, of which the two sections added here are the subset.

Did you add or update tests for this change?
- [ ] Yes.
- [x] No, I believe tests aren't necessary. Docs only; no code changed, and nothing under `tests/` reads either README.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [ ] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. — Not added: `--read-only` and `--timeout` already have entries under `[Unreleased]` from #1083 and #1084, and a README edit is not itself a user-facing change.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJc7qJxyJBCjJVZCgJK5vc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJc7qJxyJBCjJVZCgJK5vc)_