### PR TITLE
Add `-x` short flag for `--vertical` option in hsql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Adds `--read-only` (also `-r`) to both `harlequin` and `hsql`, which connects read-only. If set, Harlequin and hsql will refuse to connect to an adapter that cannot enforce a read-only mode.
 - `hsql --config validate` now reports a profile that sets `read_only` for an adapter that cannot enforce it.
 - Adds `hsql --timeout SECONDS`, which cancels the run when it has taken that long and exits `4`. hsql refuses to start if the adapter cannot cancel a query; `hsql --info` reports which of your adapters can.
+- `hsql --vertical` can now be spelled `-x`, as in psql.
 - Autocompletion now knows about the names in your query: CTEs, aliases, and columns of tables that do not exist yet are offered alongside the catalog, and anything your query already mentions is ranked above everything it does not ([#872](https://github.com/tconbeer/harlequin/issues/872)).
 
 ### Bug Fixes

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -400,12 +400,11 @@ Please see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more information.
 
 ## Differences from psql
 
-`-c`, `-f`, `-t` and `-A` mean what they mean in psql, so `hsql -tAc "select count(*) from orders"` prints a bare number, exactly as it would there. These do not:
+`-c`, `-f`, `-t`, `-A` and `-x` mean what they mean in psql, so `hsql -tAc "select count(*) from orders"` prints a bare number, exactly as it would there. These do not:
 
 | | psql | hsql |
 |---|---|---|
 | `-P` | `--pset`, an output setting | `--profile`, a config-file profile |
-| Expanded output | `-x` | `--vertical` |
 | Field separator | `-F` | `--csv`, `--tsv`, or any other `--format` |
 | Listing databases | `-l` | `--catalog` |
 | Describing an object | `\d`, `\dt` | `--catalog --path`, `--catalog-search` |

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -213,7 +213,12 @@ def build_cli(argv: Sequence[str]) -> click.Command:
     @click.option("--json", is_flag=True, help="Shorthand for --format json.")
     @click.option("--jsonl", is_flag=True, help="Shorthand for --format jsonl.")
     @click.option("--markdown", is_flag=True, help="Shorthand for --format markdown.")
-    @click.option("--vertical", is_flag=True, help="Shorthand for --format vertical.")
+    @click.option(
+        "-x",
+        "--vertical",
+        is_flag=True,
+        help="Shorthand for --format vertical. As in psql.",
+    )
     @click.option(
         "-t",
         "--tuples-only",

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -139,7 +139,7 @@
         },
         "vertical": {
           "type": "boolean",
-          "description": "Shorthand for --format vertical.",
+          "description": "Shorthand for --format vertical. As in psql.",
           "default": false
         },
         "tuples_only": {

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -171,6 +171,7 @@ def test_every_format_runs(hsql: Hsql, duck: list[str], format_name: str) -> Non
         ("--jsonl", "jsonl"),
         ("--markdown", "markdown"),
         ("--vertical", "vertical"),
+        ("-x", "vertical"),
     ],
 )
 def test_format_shorthands(


### PR DESCRIPTION
**What** are the key elements of this solution?

This PR adds the `-x` short flag as an alias for the `--vertical` option in `hsql`, matching the behavior of `psql`. The changes include:

- Added `-x` short flag to the `--vertical` CLI option
- Updated help text to clarify the psql compatibility ("As in psql")
- Updated documentation to reflect that `-x` now means the same thing in both `hsql` and `psql`
- Added test coverage for the new `-x` flag
- Updated the config schema description for consistency
- Added changelog entry documenting the new feature

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The `-x` flag is the standard way to enable expanded/vertical output in `psql`, so adding it to `hsql` improves compatibility and reduces friction for users switching between the two tools. This is a straightforward addition with no tradeoffs—it's purely additive and doesn't change existing behavior.

The implementation follows the existing pattern used for other psql-compatible flags like `-c`, `-f`, `-t`, and `-A`.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

https://claude.ai/code/session_01UkagDT9uYfiAHqppEK2MzE