### PR TITLE
Guard the flags the packaged README documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- The `hsql` README no longer documents `--parquet` and `--tsv` flags, which do not exist and exit `2`. Both formats are written as `--format parquet` and `--format tsv`.
+
 ## [2.11.0] - 2026-08-27
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Bug Fixes
-
-- The `hsql` README no longer documents `--parquet` and `--tsv` flags, which do not exist and exit `2`. Both formats are written as `--format parquet` and `--format tsv`.
-
 ## [2.11.0] - 2026-08-27
 
 ### Breaking Changes

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -132,7 +132,7 @@ hsql supports a number of options for setting the query limit, configuring outpu
 ```bash
 $ hsql -P prod -c "select count(*) from orders" --csv
 $ hsql -P dev -c "select * from users" --vertical --limit 5
-$ hsql -P warehouse -c "..." --parquet -o invoices.pq
+$ hsql -P warehouse -c "..." --format parquet -o invoices.pq
 ```
 
 hsql reads the same config files as Harlequin, and merges them one profile at a time, nearest file first; pass `--config-path PATH` to read a single file instead, or `-P None` to skip them entirely.
@@ -286,7 +286,7 @@ Note: not all adapters support catalog search at this time.
 hsql can write data to files, either with the `-o` option or by piping output (hsql only writes data to stdout; other messages go to stderr):
 
 ```bash
-$ hsql -P prod --limit -1 -c "select * from users" --parquet -o "users.pq"
+$ hsql -P prod --limit -1 -c "select * from users" --format parquet -o "users.pq"
 $ hsql -P prod --limit -1 -c "select * from users" --csv > users.csv
 ```
 
@@ -405,7 +405,7 @@ Please see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more information.
 | | psql | hsql |
 |---|---|---|
 | `-P` | `--pset`, an output setting | `--profile`, a config-file profile |
-| Field separator | `-F` | `--csv`, `--tsv`, or any other `--format` |
+| Field separator | `-F` | `--csv`, `--format tsv`, or any other `--format` |
 | Listing databases | `-l` | `--catalog` |
 | Describing an object | `\d`, `\dt` | `--catalog --path`, `--catalog-search` |
 | Stopping on the first error | `-v ON_ERROR_STOP=1` | `--on-error stop`, which is the default |

--- a/tests/unit_tests/test_documented_flags.py
+++ b/tests/unit_tests/test_documented_flags.py
@@ -1,0 +1,102 @@
+"""Every long flag the packaged README types is a flag hsql actually has.
+
+The README is the first thing an agent reads about hsql, and a command line in
+it is one an agent will run verbatim. Nothing else in this repo reads it: the
+CLI is tested thoroughly and its documentation is not, so a flag that was
+renamed, or one that never existed, sits in a fenced code block until someone
+pastes it and gets `No such option` and exit 2.
+
+So: pull every `--long-flag` out of the prose and the fences alike, and check
+each one against the document hsql writes about itself. Long spellings only --
+`-tAc` is a bundle of three, and taking single-dash tokens apart is guesswork
+this does not need to do. What it cannot check is a flag spelled correctly that
+the prose then describes wrongly; that stays a review problem.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from io import BytesIO
+from pathlib import Path
+
+from harlequin.hsql.modes import spec
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HSQL_README = REPO_ROOT / "packaging" / "hsql" / "README.md"
+
+LONG_FLAG = re.compile(r"--[a-zA-Z][a-zA-Z0-9_-]*")
+"""A long option as a command line spells one, underscores included, since an
+adapter may declare `--md_token`. Stops at `=`, so `--format=csv` is `--format`."""
+
+OTHER_PROGRAMS = {
+    "--with": "uv, in the install lines",
+    "--pset": "psql, in the differences table",
+}
+"""Flags the README types that belong to another program. Named one at a time,
+with the reason, so that excusing a flag is a decision someone made rather than
+a pattern that quietly swallowed the next typo."""
+
+
+def documented_flags(text: str) -> set[str]:
+    """Every long flag a document types, minus the ones another program owns."""
+    return set(LONG_FLAG.findall(text)) - set(OTHER_PROGRAMS)
+
+
+def hsql_flags() -> set[str]:
+    """Every long flag `hsql --spec` reports: hsql's own, and each adapter's.
+
+    Read out of the document rather than off the click command, so that this
+    checks the surface hsql advertises -- an adapter option whose spelling
+    collides with one of hsql's is dropped from both.
+    """
+    document = BytesIO()
+    spec.report(document, adapter=None, format_name=spec.JSON, format_chosen=False)
+    reported = json.loads(document.getvalue())
+    declared = [
+        *reported["options"],
+        *(
+            option
+            for adapter in reported["adapters"].values()
+            for option in adapter["options"] or []
+        ),
+    ]
+    return {
+        decl for option in declared for decl in option["decls"] if decl.startswith("--")
+    }
+
+
+def test_every_flag_the_packaged_readme_documents_exists() -> None:
+    """The one that fails when a documented command line would exit 2."""
+    missing = documented_flags(HSQL_README.read_text(encoding="utf-8")) - hsql_flags()
+    assert not missing, (
+        f"{HSQL_README.name} documents flags hsql does not have: "
+        f"{', '.join(sorted(missing))}. Run `hsql --spec` for the real spellings."
+    )
+
+
+def test_the_allowlist_names_only_flags_hsql_does_not_have() -> None:
+    """An entry that shadowed a real flag would hide the next rename of it."""
+    assert not set(OTHER_PROGRAMS) & hsql_flags()
+
+
+def test_the_allowlist_names_only_flags_the_readme_still_types() -> None:
+    """So an entry outlives the line it was written for by one PR at most."""
+    typed = set(LONG_FLAG.findall(HSQL_README.read_text(encoding="utf-8")))
+    assert set(OTHER_PROGRAMS) <= typed
+
+
+def test_the_extractor_reads_flags_out_of_prose_and_out_of_fences() -> None:
+    """A guard whose extractor finds nothing passes everything.
+
+    So the cases it has to get right are pinned here: a flag in prose and one
+    in a code block, backticks and trailing punctuation off, a value not read
+    as a flag, and the single-dash spellings left alone.
+    """
+    assert documented_flags(
+        "Pass `--read-only`, or `--limit -1`.\n"
+        "```bash\n"
+        "$ hsql -tAc 'select 1' --format=csv --md_token TOKEN -o out.csv\n"
+        "```\n"
+        "A negative number -- like -1 -- is unlimited.\n"
+    ) == {"--read-only", "--limit", "--format", "--md_token"}

--- a/tests/unit_tests/test_documented_flags.py
+++ b/tests/unit_tests/test_documented_flags.py
@@ -87,12 +87,6 @@ def test_the_allowlist_names_only_flags_the_readme_still_types() -> None:
 
 
 def test_the_extractor_reads_flags_out_of_prose_and_out_of_fences() -> None:
-    """A guard whose extractor finds nothing passes everything.
-
-    So the cases it has to get right are pinned here: a flag in prose and one
-    in a code block, backticks and trailing punctuation off, a value not read
-    as a flag, and the single-dash spellings left alone.
-    """
     assert documented_flags(
         "Pass `--read-only`, or `--limit -1`.\n"
         "```bash\n"


### PR DESCRIPTION
No issue; this is M3 PR 1, from [`docs/plans/m3-hsql-technical-plan.md`](https://github.com/tconbeer/harlequin/blob/main/docs/plans/m3-hsql-technical-plan.md) §3.1a and §4.

**What** are the key elements of this solution?

`tests/unit_tests/test_documented_flags.py` extracts every `--long-flag` from `packaging/hsql/README.md` and asserts each one appears in the document `hsql --spec` writes — hsql's own options, plus every installed adapter's — with a two-entry allowlist for the flags that belong to `uv` and `psql`.

It fails on `main`, and this PR fixes what it caught:

- `--parquet`, twice (README lines 135 and 289) → `--format parquet`
- `--tsv`, in the psql differences table (line 408) → `--format tsv`

Neither exists. Both exit `2` with `No such option`; `--format parquet` and `--format tsv` have always been the real spellings. (`--results`, the third flag §1.4 of the plan measured, had already been corrected in the packaged README — it survives on the site, see the docs question below.)

Four tests, because a guard is only as good as its extractor:

- the guard itself, whose failure message names the missing flags and points at `hsql --spec`;
- the allowlist names nothing hsql has, so an entry can never hide a rename of a real flag;
- the allowlist names nothing the README still types, so an entry outlives its line by one PR at most;
- the extractor, over a sample with a flag in prose and one in a fence, `--format=csv`, `--md_token`, and an em-dash `-- like -1 --` that must not read as a flag.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The check reads the `--spec` document rather than click's parameters directly, so it checks the surface hsql actually advertises: an adapter option whose spelling collides with one of hsql's is dropped from both, and a second source of truth here would be the same mistake as a second normalizer. It calls `spec.report()` in process rather than shelling out — same document, no subprocess in the unit suite.

Long spellings only. `-tAc` is a bundle of three, and taking single-dash tokens apart is guesswork the guard does not need to do; the flags that get documented wrongly are the long ones.

The allowlist is a dict of flag → owning program, asserted by name in both directions, rather than a regex or a skip-list. Excusing a flag should be a decision someone made and can read back, not a pattern that quietly swallows the next typo — which is why `--with` (uv, in the install lines) and `--pset` (psql, in the differences table) each carry their reason.

What this cannot catch is a flag spelled correctly that the surrounding prose then describes wrongly. That stays a review problem, and the plan says so.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [x] Yes, and I have opened a PR at [tconbeer/harlequin-web#153](https://github.com/tconbeer/harlequin-web/pull/153). The site carried the same bug in five places — `--parquet` twice and `--results` twice on the hsql page, and `--results` in the homepage terminal mock-up — and this PR does not reach them.
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [ ] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. No entry: this fixes a README, which is not a change to Harlequin users' software.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsKz7zf2oB5cGmLUviuRLv