### PR TITLE
Add `hsql --skill`, and the skill it installs (#524)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@ tests/**/__snapshots__/** text eol=lf
 
 # Generated artifacts, compared to what the generator writes on every platform.
 docs/generated/** text eol=lf
+
+# `hsql --skill` copies these out byte for byte, so a CRLF checkout would ship
+# a CRLF skill and make the same hsql print different bytes on Windows.
+src/harlequin/hsql/skill/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Adds `hsql --skill`, which writes the Agent Skill for driving hsql. `hsql --skill -o ~/.claude/skills/hsql/` installs it — the standing guidance plus four references, on running queries and reading the catalog, config files and profiles, hsql inside a shell script, and what to do about each exit code. It matches the version of hsql you have, and needs no network.
+
 ### Bug Fixes
 
 - `hsql --spec` now reports `--timeout` as a `number` and `--config-path` as a `path`, instead of click's internal names for those types.

--- a/docs/generated/hsql-reference.md
+++ b/docs/generated/hsql-reference.md
@@ -55,6 +55,7 @@ Alphabetical by name. Flags are off by default.
 | `-P`, `--profile` | text |  |  |  | Load a profile from an available config file. Options passed here take precedence over the profile's. Use the profile named None for Harlequin's defaults instead of the config file's default profile. |
 | `-r`, `--read-only` | boolean |  |  |  | Connect read-only, and refuse to run at all if the adapter cannot. To check an adapter's capabilities, use --info. |
 | `--result` | text | `all\|last\|N` | `all` |  | Which result set(s) to emit. |
+| `--skill` | boolean |  |  |  | Write the Agent Skill for driving hsql, as markdown. -o installs it: 'hsql --skill -o ~/.claude/skills/hsql/'. |
 | `--spec` | boolean |  |  |  | Every option here, plus every installed adapter's, as JSON. -a narrows it to one adapter. |
 | `--stats` | boolean |  |  |  | Write a one-line JSON summary to stderr. |
 | `--timeout` | number | `SECONDS` |  |  | Cancel the run after SECONDS and exit 4. Refused if the adapter cannot cancel a query; to check, use --info. |

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -374,7 +374,7 @@ Neither connects to a database, both write JSON to stdout, and `-a NAME` narrows
 
 ## Installing the Agent Skill
 
-hsql ships an [Agent Skill](https://agentskills.io) that teaches an agent how to drive it: ask before you assume, keep credentials off the command line, read the catalog before writing SQL, check the row limit, branch on the exit code, and hand off to `harlequin` when a human should drive. `hsql --skill` installs it, with no network and matched to the version you have:
+hsql ships an [Agent Skill](https://agentskills.io) that teaches an agent how to drive it: ask before you assume, keep credentials off the command line, read the catalog before writing SQL, watch the 500-row limit, branch on the exit code, and hand off to `harlequin` when a human should drive. `hsql --skill` installs it, with no network and matched to the version you have:
 
 ```bash
 $ hsql --skill -o ~/.claude/skills/hsql/          # for you, in every project

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -372,6 +372,20 @@ $ hsql --info -a sqlite | jq '.adapters.sqlite'
 
 Neither connects to a database, both write JSON to stdout, and `-a NAME` narrows either one to a single adapter, which is much faster than importing them all.
 
+## Installing the Agent Skill
+
+hsql ships an [Agent Skill](https://agentskills.io) that teaches an agent how to drive it: ask before you assume, keep credentials off the command line, read the catalog before writing SQL, check the row limit, branch on the exit code, and hand off to `harlequin` when a human should drive. `hsql --skill` installs it, with no network and matched to the version you have:
+
+```bash
+$ hsql --skill -o ~/.claude/skills/hsql/          # for you, in every project
+$ hsql --skill -o .claude/skills/hsql/            # for this repo, committed with it
+note: wrote 5 files to .claude/skills/hsql: SKILL.md, references/config.md, references/queries.md, references/scripting.md, references/troubleshooting.md
+```
+
+`SKILL.md` is the standing guidance; the four references beside it cover running queries and reading the catalog, config files and profiles, hsql inside a shell script, and what to do about each exit code. An agent reads one when the work reaches it.
+
+With no `-o`, `hsql --skill` writes `SKILL.md` to stdout, so you can read it before you install it.
+
 ## Keep Reading at [harlequin.sh](https://harlequin.sh/docs/getting-started/hsql)
 
 Visit [harlequin.sh](https://harlequin.sh/docs/getting-started/hsql) for an overview of features and full documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,8 @@ static = [
     "import-linter>=2.5",
     # jsonschema ships no py.typed, and the config-schema tests call it
     "types-jsonschema>=4.26.0.20260518",
+    # nor does pyyaml, which the skill's frontmatter tests call
+    "types-pyyaml>=6",
 ]
 test = [
     "pytest>=9.1.1,<9.2.0",
@@ -117,6 +119,9 @@ test = [
     # files, so a schema that is not a schema fails here rather than in an
     # editor. Not a runtime dependency: nothing in the package reads one.
     "jsonschema>=4.20",
+    # parses the skill's frontmatter the way a harness loading it would. Not a
+    # runtime dependency either: `--skill` prints the file and reads nothing.
+    "pyyaml>=6",
 ]
 
 

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -16,9 +16,10 @@ one is the default.
 
 A **mode** is the third shape. `--config MODE` reports on the config files --
 or, under `init`, writes a profile into one -- `--spec` reports on the command
-itself and `--info` on the installation, rather than any of them running SQL, so
-the first pass skips the profile. None of them names an adapter either, and the
-command carries no connection options at all, except for `--config init`: the
+itself, `--info` on the installation, and `--skill` writes the Agent Skill that
+ships in the wheel, rather than any of them running SQL, so the first pass skips
+the profile. None of them names an adapter either, and the command carries no
+connection options at all, except for `--config init`: the
 options it writes into a profile are the ones an adapter declares. `--catalog`
 and `--catalog-search` are the modes that do connect, so they take a profile and an
 adapter exactly as a run does. Modes are options rather than subcommands
@@ -131,6 +132,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--config"]),
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
+            click.Option(["--skill"], is_flag=True),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -144,6 +146,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 params.get("config") is not None
                 or params.get("spec")
                 or params.get("info")
+                or params.get("skill")
             )
         ),
         # `--config init` is the mode that needs an adapter without a profile:
@@ -155,6 +158,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 _reports_config(params.get("config"))
                 or params.get("spec")
                 or params.get("info")
+                or params.get("skill")
             )
         ),
         # bare `hsql` renders help, so it names no adapter either
@@ -345,6 +349,14 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         ),
     )
     @click.option(
+        "--skill",
+        is_flag=True,
+        help=(
+            "Write the Agent Skill for driving hsql, as markdown. -o installs "
+            "it: 'hsql --skill -o ~/.claude/skills/hsql/'."
+        ),
+    )
+    @click.option(
         "--limit",
         default=DEFAULT_LIMIT,
         show_default=True,
@@ -393,6 +405,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         config_mode: str | None,
         spec: bool,
         info: bool,
+        skill: bool,
         catalog: bool,
         catalog_search: str | None,
         path: str | None,
@@ -471,6 +484,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             config_mode=config_mode,
             spec=spec,
             info=info,
+            skill=skill,
         )
         if path is not None and not catalog and catalog_search is None:
             diagnostics.error("--path must be used with --catalog or --catalog-search.")
@@ -490,6 +504,17 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             # ahead of the modes as well as the connection: `-t nord` does not
             # reliably fail, so there may be no error for this to explain.
             diagnostics.report_theme_confusion(conn_str)
+
+        if skill:
+            ctx.exit(
+                _report_skill(
+                    ctx,
+                    destination=destination,
+                    format_name=format_name,
+                    format_chosen=format_name != DEFAULT_FORMAT
+                    or "format" in explicitly_set,
+                )
+            )
 
         if info:
             ctx.exit(
@@ -834,6 +859,7 @@ def _one_mode(
     config_mode: str | None,
     spec: bool,
     info: bool,
+    skill: bool,
 ) -> str | None:
     """The one mode this invocation chose, or exit having named the two it did.
 
@@ -847,6 +873,7 @@ def _one_mode(
         (f"--config {config_mode}", config_mode is not None),
         ("--spec", spec),
         ("--info", info),
+        ("--skill", skill),
     )
     chosen = [name for name, was_asked in asked if was_asked]
     if len(chosen) > 1:
@@ -1159,6 +1186,43 @@ def _report_info(
     except (HarlequinConfigError, OSError) as e:
         # a `--config-path` naming no file, or a `-o PATH` it could not write.
         # Both are the caller's to fix, and both are usage errors.
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    return code
+
+
+def _report_skill(
+    ctx: click.Context,
+    *,
+    destination: _Destination,
+    format_name: str,
+    format_chosen: bool,
+) -> ExitCode:
+    """Answer `--skill` and return its code, or exit having said why not.
+
+    stdout gets `SKILL.md` alone; a `-o` installs the skill, so the references
+    go beside wherever the file landed. Both spellings of `-o` reach the same
+    place -- `-o DIR/` names the directory and `-o DIR/SKILL.md` names the file
+    in it -- because either is how a caller says "put the skill here".
+    """
+    # here rather than at module scope, for the reason the mode exists in its
+    # own module -- though this is the one mode that would have cost nothing,
+    # since it imports no adapter and reads no config
+    from harlequin.hsql.modes import skill as skill_mode
+
+    try:
+        with _sink(destination, filename=skill_mode.FILENAME, announce=False) as out:
+            code = skill_mode.report(
+                out, format_name=format_name, format_chosen=format_chosen
+            )
+            out.flush()
+        written = destination.file(skill_mode.FILENAME)
+        if written is not None and format_name != skill_mode.NONE:
+            diagnostics.report_written(
+                [written, *skill_mode.install_references(written.parent)]
+            )
+    except OSError as e:
+        # a `-o PATH` it could not write, which is the caller's to fix
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
     return code
@@ -1778,7 +1842,9 @@ def _use_color(when: str, destination: _Destination) -> bool:
 
 
 @contextlib.contextmanager
-def _sink(destination: _Destination, *, filename: str) -> Iterator[BinaryIO]:
+def _sink(
+    destination: _Destination, *, filename: str, announce: bool = True
+) -> Iterator[BinaryIO]:
     """Where one document or one run of result sets goes: a path, or stdout.
 
     Binary in both cases. duckdb writes `\\n` and the layouts write `\\n`, and
@@ -1787,6 +1853,9 @@ def _sink(destination: _Destination, *, filename: str) -> Iterator[BinaryIO]:
 
     The directory the file is in is created if it is not there, so that a path
     a caller has not made yet is a path they can write to.
+
+    `announce=False` is for a caller that writes more than this one file, and
+    so has to name them all in one line rather than this one on its own.
     """
     path = destination.file(filename)
     if path is None:
@@ -1795,7 +1864,7 @@ def _sink(destination: _Destination, *, filename: str) -> Iterator[BinaryIO]:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("wb") as f:
         yield f
-    if destination.is_directory:
+    if destination.is_directory and announce:
         diagnostics.report_written([path])
 
 

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -19,6 +19,7 @@ Nothing written here carries a secret, either: every line goes through
 from __future__ import annotations
 
 import json
+import os
 import sys
 from enum import IntEnum
 from pathlib import Path
@@ -217,6 +218,15 @@ def report_document_format_ignored(mode: str, format_name: str) -> None:
     )
 
 
+def report_fixed_format_ignored(mode: str, format_name: str, *, written: str) -> None:
+    """Say that `--format` does not reach a mode whose output is one fixed file.
+
+    `--skill` prints a file that ships in the wheel, so there is nothing for a
+    format to select. Silence would read as a format that was applied.
+    """
+    note(f"{mode} writes {written}, so --format {format_name} had no effect")
+
+
 def report_written(paths: Sequence[Path]) -> None:
     """Name the files a directory `-o` wrote, since the caller did not name them.
 
@@ -228,8 +238,12 @@ def report_written(paths: Sequence[Path]) -> None:
     if len(paths) == 1:
         note(f"wrote {paths[0]}")
     else:
-        listed = ", ".join(path.name for path in paths)
-        note(f"wrote {len(paths)} files to {paths[0].parent}: {listed}")
+        # named relative to the folder they share, so that a caller writing into
+        # subdirectories -- `--skill`, whose references sit one level down --
+        # gets paths that resolve rather than bare file names that collide
+        base = Path(os.path.commonpath([str(path.parent) for path in paths]))
+        listed = ", ".join(path.relative_to(base).as_posix() for path in paths)
+        note(f"wrote {len(paths)} files to {base}: {listed}")
 
 
 def report_stats(

--- a/src/harlequin/hsql/modes/skill.py
+++ b/src/harlequin/hsql/modes/skill.py
@@ -1,0 +1,89 @@
+"""`--skill`: the Agent Skill for driving hsql, straight out of the wheel.
+
+The skill an agent installs is the skill for the `hsql` on that machine, which
+is the one place "which version am I reading about" cannot be got wrong -- and
+it needs no network, which is the environment a CLI-driving agent is most often
+in. So the text ships as package data and this mode prints it.
+
+**The skill is a directory, not a file.** `SKILL.md` is the standing guidance
+that enters an agent's context whole, and it is kept small enough to be worth
+that; the four references beside it are the depth, read only when the work
+reaches one. So stdout gets `SKILL.md` -- the document, for a caller who wants
+to read or pipe it -- and `-o` installs the whole tree, wherever it names.
+
+It imports nothing: no adapter, no config file, no database. Printing a
+packaged file should cost what printing a packaged file costs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import BinaryIO
+
+from harlequin.hsql import diagnostics
+from harlequin.hsql.diagnostics import ExitCode
+
+SKILL_DIR = Path(__file__).resolve().parent.parent / "skill"
+"""Where the text lives, read the way the help screen reads its markdown."""
+
+FILENAME = "SKILL.md"
+"""What this document is called, on stdout's behalf and in a folder `-o` names.
+
+Named by the Agent Skills spec rather than by us: a directory holding a file
+called anything else is not a skill.
+"""
+
+REFERENCES = "references"
+"""The subdirectory `SKILL.md` points at, and so the name it must keep."""
+
+MARKDOWN = "markdown"
+"""What this mode writes, whatever `--format` says. `none` writes nothing."""
+
+NONE = "none"
+
+
+def text() -> bytes:
+    """`SKILL.md` exactly as it ships, bytes and all.
+
+    Read in binary so that what `-o` writes and what stdout carries cannot
+    differ by a line ending on the way through.
+    """
+    return (SKILL_DIR / FILENAME).read_bytes()
+
+
+def reference_paths() -> list[Path]:
+    """Every reference file, sorted, as paths inside the skill directory."""
+    return sorted((SKILL_DIR / REFERENCES).glob("*.md"))
+
+
+def report(out: BinaryIO, *, format_name: str, format_chosen: bool) -> ExitCode:
+    """Write `SKILL.md` and return the code it exits with.
+
+    Always 0: this mode reads one packaged file, and there is nothing about the
+    installation it could find wrong.
+    """
+    if format_name == NONE:
+        return ExitCode.OK
+    if format_name != MARKDOWN and format_chosen:
+        diagnostics.report_fixed_format_ignored(
+            "--skill", format_name, written=MARKDOWN
+        )
+    out.write(text())
+    return ExitCode.OK
+
+
+def install_references(directory: Path) -> list[Path]:
+    """Copy the references into `directory/references/`, and say what was written.
+
+    Beside `SKILL.md` wherever `-o` put it, because a `SKILL.md` whose pointers
+    dangle is worse than one that never had them: the agent reading it has no
+    way to tell a reference that is missing from one that does not exist.
+    """
+    target = directory / REFERENCES
+    target.mkdir(parents=True, exist_ok=True)
+    written = []
+    for source in reference_paths():
+        destination = target / source.name
+        destination.write_bytes(source.read_bytes())
+        written.append(destination)
+    return written

--- a/src/harlequin/hsql/skill/SKILL.md
+++ b/src/harlequin/hsql/skill/SKILL.md
@@ -16,29 +16,30 @@ metadata:
 
 # hsql
 
-`hsql` runs SQL against every database Harlequin has an adapter for, with one set of
+`hsql` runs SQL against any database Harlequin has an adapter for, with one set of
 flags and one output contract. `harlequin` is the same engine as a full-screen terminal
 IDE, for when a human should drive.
 
 These are standing rules for the rest of the session, not a checklist to run once.
 
-Four references sit in `references/` beside this file. Read one when you get to its job:
-`queries.md` (running SQL and reading the catalog), `config.md` (config files and
-profiles, for hsql and for harlequin), `scripting.md` (hsql inside a shell script or
-pipeline), `troubleshooting.md` (a run that failed, by exit code).
+Four references sit in `references/` beside this file; read one when you reach its job:
+`queries.md` (running SQL, reading the catalog), `config.md` (config files and profiles,
+for hsql and harlequin), `scripting.md` (hsql in a shell script), `troubleshooting.md`
+(a failed run, by exit code).
 
 ## 1. Ask before you assume
 
 Never guess at an installation. `hsql --info` reports versions, the config files this
 machine has, the profile an invocation would use, and what each adapter declares it
-supports. `hsql --help -a NAME` lists one adapter's connection options, and `hsql --spec` is
-that same surface as JSON. None of the three opens a connection.
+supports. `hsql --help -a NAME` lists one adapter's connection options, and
+`hsql --spec` is that same surface as JSON. None of the three opens a connection.
 
-## 2. Never put a credential on a command line
+## 2. Avoid putting credentials on the command line
 
-Shell history and the process table are both readable by other people. Put connection
-settings in a profile and select it with `-P NAME`; write `${VAR}` in the config file so
-the secret itself lives in the environment. `references/config.md` has the shapes.
+Shell history and the process table are both readable by other people, so a password — or
+a connection string carrying one — belongs in a profile you select with `-P NAME`, with
+`${VAR}` in the config file for the secret itself; `references/config.md` has the shapes.
+A local database file is not a credential: pass it on the command line and move on.
 
 ## 3. Orient in the catalog before writing SQL
 
@@ -57,16 +58,16 @@ result set reaches stdout, and `--on-error stop|continue` what happens after a f
 ## 5. Pick a format on purpose
 
 `-tAc "SQL"` for a single value going into a shell variable; `--csv` for a pipe;
-`--markdown` when the output is going into your own reply to the user; `--format parquet
--o PATH` for anything large. `--format` takes the name of any format; only `csv`, `json`,
-`jsonl`, `markdown` and `vertical` also have a shorthand flag.
+`--markdown` when the output goes into your own reply; `--format parquet -o PATH` for
+anything large. `--format` takes any format's name; only `csv`, `json`, `jsonl`,
+`markdown` and `vertical` also have a shorthand flag.
 
-## 6. The row limit is real
+## 6. There is a 500-row limit by default
 
-hsql fetches 500 rows per result set by default, and the database applies the limit.
-`--limit -1` removes it; do that before counting or aggregating client-side. `--stats`
-writes a one-line JSON summary to stderr carrying `"truncated"` — read it every time, and
-never run hsql with `2>/dev/null`: truncation notices and errors both go there.
+hsql fetches 500 rows per result set unless told otherwise, and the database applies the
+limit. `--limit -1` removes it; do that before counting or aggregating client-side.
+`--stats` writes a one-line JSON summary to stderr carrying `"truncated"` — read it every
+time, and never run hsql with `2>/dev/null`: truncation notices and errors both go there.
 
 ## 7. Branch on the exit code
 

--- a/src/harlequin/hsql/skill/SKILL.md
+++ b/src/harlequin/hsql/skill/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: hsql
+description: Run SQL against any database from the command line with hsql, Harlequin's headless SQL client — execute a query or a .sql file, inspect a database's schemas, tables and columns, export results as CSV/JSON/Parquet, and read or write harlequin.toml profiles. Covers DuckDB, SQLite, Postgres, MySQL and other Harlequin adapters. Use whenever the work involves running SQL, finding out what is in a database, checking a connection string or DSN, a .sql file, or a config file for a database connection — including when the user never says "hsql" or "harlequin".
+license: MIT
+allowed-tools:
+  - Bash(hsql --help*)
+  - Bash(hsql --version)
+  - Bash(hsql --info*)
+  - Bash(hsql --spec*)
+  - Bash(hsql --catalog*)
+  - Bash(hsql --catalog-search*)
+metadata:
+  project: harlequin
+  homepage: https://harlequin.sh
+---
+
+# hsql
+
+`hsql` runs SQL against every database Harlequin has an adapter for, with one set of
+flags and one output contract. `harlequin` is the same engine as a full-screen terminal
+IDE, for when a human should drive.
+
+These are standing rules for the rest of the session, not a checklist to run once.
+
+Four references sit in `references/` beside this file. Read one when you get to its job:
+`queries.md` (running SQL and reading the catalog), `config.md` (config files and
+profiles, for hsql and for harlequin), `scripting.md` (hsql inside a shell script or
+pipeline), `troubleshooting.md` (a run that failed, by exit code).
+
+## 1. Ask before you assume
+
+Never guess at an installation. `hsql --info` reports versions, the config files this
+machine has, the profile an invocation would use, and what each adapter declares it
+supports. `hsql --help -a NAME` lists one adapter's connection options, and `hsql --spec` is
+that same surface as JSON. None of the three opens a connection.
+
+## 2. Never put a credential on a command line
+
+Shell history and the process table are both readable by other people. Put connection
+settings in a profile and select it with `-P NAME`; write `${VAR}` in the config file so
+the secret itself lives in the environment. `references/config.md` has the shapes.
+
+## 3. Orient in the catalog before writing SQL
+
+`hsql --catalog` lists the top level, `--path db.schema` lists that schema's relations,
+and `--path db.schema.table` lists that table's columns. `--catalog-search TERM` finds an
+object when you do not know where it lives — check `--info` first, because searching is a
+capability not every adapter has. Every row carries the path that lists its own children
+and the correctly-quoted name to paste into a query.
+
+## 4. Run it
+
+`-c "SQL"` runs a statement and `-f PATH` runs a file (`-f -` reads stdin); both repeat,
+and both take several statements separated by `;`. `--result all|last|N` picks which
+result set reaches stdout, and `--on-error stop|continue` what happens after a failure.
+
+## 5. Pick a format on purpose
+
+`-tAc "SQL"` for a single value going into a shell variable; `--csv` for a pipe;
+`--markdown` when the output is going into your own reply to the user; `--format parquet
+-o PATH` for anything large. `--format` takes the name of any format; only `csv`, `json`,
+`jsonl`, `markdown` and `vertical` also have a shorthand flag.
+
+## 6. The row limit is real
+
+hsql fetches 500 rows per result set by default, and the database applies the limit.
+`--limit -1` removes it; do that before counting or aggregating client-side. `--stats`
+writes a one-line JSON summary to stderr carrying `"truncated"` — read it every time, and
+never run hsql with `2>/dev/null`: truncation notices and errors both go there.
+
+## 7. Branch on the exit code
+
+`0` success, `1` the database rejected the SQL, `2` a bad flag or a config problem, `3`
+could not connect, `4` `--timeout` ran out, `130` interrupted. A `2` is your bug, a `1`
+is the SQL's, a `3` the environment's — and stdout is empty on all of them, so read the
+code before the output. `references/troubleshooting.md` goes code by code.
+
+## 8. Ask before you write
+
+Prefer `-r`/`--read-only`, which connects in a mode the database itself refuses writes
+in. `hsql --info` reports `implements_read_only` per adapter, and hsql refuses to connect
+rather than pretend when an adapter cannot enforce it. Before running any DDL or DML, say
+plainly what the statement will change, and get agreement first.
+
+## 9. Know when to hand off
+
+Schema you cannot disambiguate, a query the human will want to iterate on, anything
+destructive, anything wanting a human eye on ten thousand rows: stop, and tell them to
+run `harlequin -P <profile>` — the same profile, adapter and engine, with a query editor
+and a results viewer around it.

--- a/src/harlequin/hsql/skill/references/config.md
+++ b/src/harlequin/hsql/skill/references/config.md
@@ -1,0 +1,96 @@
+# Config files and profiles
+
+Read this before you put a connection setting on a command line. `hsql` and `harlequin`
+read the same files, so a profile written once serves both — which is what makes "hand
+this off to a human" in section 9 of the skill a one-liner.
+
+## Where the files are, and which one wins
+
+`hsql --info` reports the ones this machine actually has, highest priority first. The
+search order is: the file `--config-path PATH` names, then the working directory, then
+the user config directory, then the home directory. Within a directory,
+`harlequin.toml` beats `.harlequin.toml`, which beats a `pyproject.toml`'s
+`[tool.harlequin]` table.
+
+Files merge **per profile**, nearest first: a project-local file that defines one profile
+leaves every other profile, and the `default_profile` naming one of them, alone.
+
+## What a profile looks like
+
+```toml
+default_profile = "dev"
+
+[profiles.dev]
+adapter = "duckdb"
+conn_str = [ "./dev.db" ]
+
+[profiles.prod]
+adapter = "postgres"
+host = "${PGHOST:-localhost}"     # ${VAR:-default} supplies a default
+port = 5432                       # written as TOML makes natural; hsql coerces
+user = "reporting"
+password = "${PGPASSWORD}"        # ${VAR} is required; hsql exits 2 if unset
+read_only = true
+timeout = 30
+limit = -1
+```
+
+Keys are the long option names with the dashes turned into underscores: `--read-only`
+becomes `read_only`, `-P`'s own `--profile` is not a key (it names the profile). Two
+groups of keys live here: hsql's own, and the connection options the adapter declares.
+`hsql --help -a postgres` lists the second group; `hsql --spec` gives both as JSON.
+
+Write `$${` if a value really has to start with a literal `${`.
+
+Values an adapter declares as secret are masked wherever hsql prints them —
+`--config show`, `--info`, and error messages — as is the password inside a connection
+string.
+
+Select a profile with `-P NAME`. `-P None` skips the config files entirely and runs on
+Harlequin's own defaults. A CLI flag beats the profile only when you actually typed it.
+
+## The five `--config` modes
+
+None of them connects to a database.
+
+```bash
+hsql --config list-profiles     # the names -P takes, each one's adapter, which is default
+hsql --config show              # the merged config, with the file each value came from
+hsql --config show --json       # the same, for a parser
+hsql --config validate          # every problem in every file; exits 2 if it found any
+hsql --config schema            # a JSON Schema covering the adapters you have installed
+hsql --config init -P prod -a sqlite ./app.db --read-only --limit -1
+```
+
+`init` is the one that writes. It takes the options you typed — hsql's and the
+adapter's alike — writes them into `[profiles.prod]` in the nearest config file, prompts
+for nothing, and leaves the other profiles and the file's comments untouched. It is the right way to create a profile
+non-interactively; `harlequin --config` is the interactive wizard for a human.
+
+`list-profiles` and `validate` are result sets, so `--csv`, `-t`, `-A` and `-o` work on
+them the way they work on a query.
+
+Point an editor at the schema for completion as you type:
+
+```bash
+hsql --config schema -o ./harlequin-schema.json
+```
+
+## Writing a config file by hand
+
+1. `hsql --info` — see which files exist and which would win.
+2. `hsql --help -a NAME` — see what that adapter's connection options are called.
+3. Write the profile, with `${VAR}` for anything secret.
+4. `hsql --config validate` — it names the file and the key for anything wrong,
+   including a misspelled key that an adapter would otherwise have silently ignored.
+5. `hsql -P NAME --catalog` — the cheapest proof that the profile connects.
+
+## The same profile in the IDE
+
+```bash
+harlequin -P prod
+```
+
+`harlequin` reads these files identically. Keys that only mean something to the IDE — a
+theme, a keymap — sit in the same profile and are ignored by hsql, and hsql's own keys
+are ignored by the IDE, so one profile can carry both.

--- a/src/harlequin/hsql/skill/references/config.md
+++ b/src/harlequin/hsql/skill/references/config.md
@@ -1,7 +1,7 @@
 # Config files and profiles
 
-Read this before you put a connection setting on a command line. `hsql` and `harlequin`
-read the same files, so a profile written once serves both — which is what makes "hand
+Read this before you put a credential on a command line, and whenever you need to write
+or repair a profile. `hsql` and `harlequin` read the same files, so one profile serves both — which is what makes "hand
 this off to a human" in section 9 of the skill a one-liner.
 
 ## Where the files are, and which one wins

--- a/src/harlequin/hsql/skill/references/queries.md
+++ b/src/harlequin/hsql/skill/references/queries.md
@@ -1,0 +1,106 @@
+# Running queries and reading the catalog
+
+Read this when you are about to run SQL, or when you need to know what is in a database.
+
+## Finding out what is there
+
+`--catalog` and `--catalog-search` exit without running SQL, and both are rows, so every
+format and output option applies to them.
+
+```bash
+hsql -P prod --catalog                            # databases
+hsql -P prod --catalog --path mydb                # that database's schemas
+hsql -P prod --catalog --path mydb.analytics      # that schema's tables and views
+hsql -P prod --catalog --path mydb.analytics.orders   # that table's columns and types
+hsql -P prod --catalog --path 'mydb.analytics.ord*'   # a trailing * filters a listing
+hsql -P prod --catalog-search customer_id         # every level at once, by name
+hsql -P prod --catalog-search order --path mydb.analytics  # narrowed to a subtree
+```
+
+Each row has five columns: `path` (what lists that object's own children), `name`,
+`query_name` (already quoted correctly for this database — paste this into SQL, do not
+build the identifier yourself), `type`, and `type_label`.
+
+Not every adapter implements search. Check before you rely on it:
+
+```bash
+hsql --info -a postgres    # look at .adapters.postgres.capabilities
+```
+
+An adapter that cannot search says so and exits rather than walking its whole catalog.
+
+## Running statements
+
+```bash
+hsql -P prod -c "select * from orders limit 10"
+hsql -P prod -f ./report.sql
+cat report.sql | hsql -P prod -f -
+hsql -P prod -f ./setup.sql -c "select count(*) from staged" -f ./build.sql
+```
+
+`-c` and `-f` both repeat, both accept several statements separated by `;`, and they run
+in the order they were typed. `--result` picks what reaches stdout when there is more
+than one result set:
+
+- `--result all` (the default) emits every result set. Only the layouts and `jsonl`
+  can hold more than one; `csv`, `json` and `parquet` exit `2` rather than silently
+  concatenating.
+- `--result last` emits only the final one — the usual choice for a setup script that
+  ends in a `select`.
+- `--result 2` emits the second.
+
+`--on-error stop` (the default) stops at the first failure; `--on-error continue` runs
+the rest and still exits non-zero.
+
+## Choosing a format
+
+`--format NAME` takes `table`, `markdown` (`md`), `vertical`, `csv`, `tsv`, `json`,
+`jsonl` (`ndjson`), `parquet`, `orc`, `feather` (`arrow`), or `none`. Five have a
+shorthand flag: `--csv`, `--json`, `--jsonl`, `--markdown`, `--vertical` (also `-x`).
+
+| you want | use |
+| --- | --- |
+| one value for a shell variable | `-tAc "select …"` |
+| a few rows you will read yourself | the default `table` |
+| rows to paste into your reply | `--markdown` |
+| a wide row you need to read field by field | `-x` |
+| input for another program | `--csv`, or `--jsonl` |
+| more rows than you want in a terminal | `--format parquet -o out.parquet` |
+| the run's side effects, not its rows | `--format none` |
+
+Layout switches are independent: `-t` drops the header and footer, `-A` drops the column
+alignment, `--no-header` / `--no-footer` drop one apiece, `--null-string TEXT` sets how
+NULL prints. `-tAc` is those first two plus `-c`, and prints a bare value.
+
+## Limits, and the two kinds
+
+`--limit N` is the hard one: the database returns at most N rows. It defaults to `500`.
+`--limit -1` is unlimited, and is what you want before any aggregate you compute
+yourself.
+
+`--display-rows N` is soft: hsql fetched the rows and prints N of them. It only applies
+to the text layouts (`table` and `md` print 40, `vertical` prints 10) and never changes
+a file format's contents.
+
+`--stats` reports both, on stderr, as one line of JSON:
+
+```bash
+$ hsql -c "select 1" --stats --format none
+{"status":"ok","statements":1,"rows":1,"truncated":false,"limit":500,"elapsed_ms":1,"columns":[{"name":"1","type":"#"}]}
+```
+
+`"truncated": true` means the limit cut the result short and the numbers you are about
+to report are wrong. Re-run with `--limit -1`, or aggregate in SQL instead.
+
+## Writing to a file
+
+`-o PATH` writes to a file; `-o DIR/` writes one file per result set, named for you, and
+says on stderr what it called them. The bytes are identical to a shell redirect, so
+`-o out.csv` and `> out.csv` agree.
+
+```bash
+hsql -P prod --limit -1 -c "select * from users" --format parquet -o users.parquet
+hsql -P prod --limit -1 -f ./three_reports.sql --csv -o ./out/
+```
+
+stdout carries data and nothing else. Every note, warning and error goes to stderr.

--- a/src/harlequin/hsql/skill/references/scripting.md
+++ b/src/harlequin/hsql/skill/references/scripting.md
@@ -19,12 +19,14 @@ Four habits, in order of how often they matter:
 2. `-P prod` rather than a connection string, so no credential is in the file, the shell
    history or the process table.
 3. `--read-only` unless the script is meant to write.
-4. `--limit -1` whenever the script computes something from the rows. The default 500
-   would give a wrong answer silently as far as the script is concerned.
+4. `--limit -1` whenever the script computes something from the rows, or writes them
+   anywhere. The default 500 gives a wrong answer, or a short file, and as far as the
+   script can tell it succeeded.
 
 Never write `2>/dev/null`. hsql puts truncation notices, warnings and errors on stderr
 and *only* data on stdout, so suppressing stderr is exactly the thing that turns a
-detected problem into a wrong number. Redirect it to a log if it is noisy.
+detected problem into a wrong number. Redirect it to a log if it is noisy — and then
+have something read the log; a log nobody reads is `2>/dev/null` with extra steps.
 
 ## One value into a variable
 

--- a/src/harlequin/hsql/skill/references/scripting.md
+++ b/src/harlequin/hsql/skill/references/scripting.md
@@ -1,0 +1,120 @@
+# hsql inside a script
+
+Read this when hsql is going into a shell script, a Makefile, a CI job or a pipeline —
+anywhere the output is consumed by a program rather than read by you.
+
+## The shape of a safe script
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+hsql -P prod --read-only --timeout 60 --limit -1 \
+    -c "select count(*) from orders" -tAc
+```
+
+Four habits, in order of how often they matter:
+
+1. `set -euo pipefail`, so a non-zero exit from hsql actually stops the script.
+2. `-P prod` rather than a connection string, so no credential is in the file, the shell
+   history or the process table.
+3. `--read-only` unless the script is meant to write.
+4. `--limit -1` whenever the script computes something from the rows. The default 500
+   would give a wrong answer silently as far as the script is concerned.
+
+Never write `2>/dev/null`. hsql puts truncation notices, warnings and errors on stderr
+and *only* data on stdout, so suppressing stderr is exactly the thing that turns a
+detected problem into a wrong number. Redirect it to a log if it is noisy.
+
+## One value into a variable
+
+```bash
+row_count=$(hsql -P prod -tAc "select count(*) from orders")
+```
+
+`-t` drops the header and footer, `-A` drops the alignment padding, so what comes back is
+the bare value with a trailing newline. This is the idiom; do not parse the `table`
+layout.
+
+## Rows into another program
+
+```bash
+hsql -P prod --limit -1 --csv -c "select * from users" | your-loader
+hsql -P prod --limit -1 --jsonl -c "select * from events" | jq -r '.id'
+```
+
+`jsonl` is the format to reach for when several result sets have to travel down one pipe;
+`csv`, `json` and `parquet` hold exactly one and exit `2` rather than concatenating.
+
+## Files, and one file per query
+
+```bash
+hsql -P prod --limit -1 --format parquet -o ./out/users.parquet -c "select * from users"
+hsql -P prod --limit -1 --csv -o ./out/ -f ./three_reports.sql
+```
+
+A directory `-o` writes one file per result set and names them itself, reporting the
+names on stderr. `-o PATH` and `> PATH` produce identical bytes, so pick whichever reads
+better.
+
+## Several statements in one invocation
+
+```bash
+hsql -P prod --limit -1 --format md --result last --on-error stop \
+    -f ./setup.sql \
+    -c "select count(*) from raw_table" \
+    -f ./build_models.sql \
+    -c "select count(*) from modeled_table"
+```
+
+One connection, one transaction context, in the order typed. `--result last` keeps stdout
+to the final answer while the earlier statements still run. For a single transaction,
+write `begin` and `commit` into the script yourself — hsql has no `-1`.
+
+## Checking the outcome
+
+Branch on the exit code first; it is the reliable signal.
+
+```bash
+if ! hsql -P prod --read-only -c "select 1" --format none; then
+    echo "database is not reachable" >&2
+    exit 1
+fi
+```
+
+For truncation, `--stats` and `jq` together:
+
+```bash
+hsql -P prod --limit -1 --csv -o data.csv --stats \
+    -c "select * from big_table" 2>&1 \
+    | jq -e '.truncated | not' > /dev/null
+```
+
+`--stats` writes one line of JSON to stderr with `status`, `statements`, `rows`,
+`truncated`, `limit`, `elapsed_ms` and `columns`. It is the machine-readable summary of
+a run; the exit code is the verdict.
+
+## Bounding a run
+
+`--timeout SECONDS` cancels the run and exits `4`. It covers executing *and* fetching,
+and hsql refuses to start if the adapter cannot cancel a query, so it is a real bound
+rather than a hope. In a scheduled job, set it: an unbounded query holds a connection
+until something else kills it.
+
+Both `--read-only` and `--timeout` are also profile keys, so a profile meant for
+automation can carry them and no invocation has to remember:
+
+```toml
+[profiles.agent]
+adapter = "postgres"
+read_only = true
+timeout = 30
+limit = -1
+```
+
+## Portability
+
+The same script runs against another database by changing the profile. hsql's own flags,
+output layouts and exit codes do not vary by adapter; what varies is the SQL and the
+connection options. `hsql --info` is how a script checks that an adapter is installed and
+can do what the script needs before depending on it.

--- a/src/harlequin/hsql/skill/references/troubleshooting.md
+++ b/src/harlequin/hsql/skill/references/troubleshooting.md
@@ -1,0 +1,95 @@
+# When a run fails
+
+Read this when hsql exited non-zero, printed nothing, or printed something you did not
+expect. Work the exit code first: stdout is empty on every failure, so the code and
+stderr are the whole of the evidence.
+
+Errors are one line, prefixed `hsql: error:`. Notes are prefixed `note:`. Both are on
+stderr; if you cannot see them, something in the pipeline is discarding that stream.
+
+## `2` — usage or config: your bug
+
+The most common code, and the one that never means the database is unhappy. hsql never
+opened a connection.
+
+| stderr says | what happened |
+| --- | --- |
+| `No such option` | a flag hsql does not have. `hsql --spec` lists every real spelling, including each installed adapter's. |
+| `... does not run SQL; drop -c/--command and -f/--file` | a mode (`--catalog`, `--info`, `--spec`, `--config`) was passed beside a query. Run them as two invocations. |
+| `--path must be used with --catalog or --catalog-search` | `--path` only means something to those two modes. |
+| `... are two modes; pass one of them` | two mode flags in one invocation. |
+| a profile name, and "not defined" | `-P` named a profile no file defines. `hsql --config list-profiles` lists the real names. |
+| an environment variable name | a `${VAR}` in the config file that is unset. Export it, or give it a `${VAR:-default}`. |
+| a config file path and a parse error | that TOML does not parse. `hsql --config validate` names the file and the key. |
+| `... cannot be honored` | `--read-only` or `--timeout` was asked of an adapter that does not implement it. `hsql --info -a NAME` reports which. |
+| a format complaint about several result sets | `csv`, `json` and `parquet` hold one result set. Use `--result last`, or `--jsonl`. |
+
+`-t` is *tuples only*, as in psql, and not the IDE's theme flag. `hsql -t nord -c "..."`
+parses, and `nord` becomes a connection string; hsql says so on stderr.
+
+## `3` — could not connect
+
+hsql got as far as the adapter and no further. The message is the driver's, with any
+password in it masked.
+
+1. `hsql --info -a NAME` — is the adapter even installed, and did it import?
+2. `hsql --config show` — what host, port and user is the profile actually supplying?
+   Values are redacted, but you can see whether a `${VAR}` resolved to something.
+3. `hsql -P NAME --catalog` — the cheapest end-to-end check once you have changed
+   something.
+
+An adapter that is installed but will not import is reported by `--info` with
+`"capabilities": "unknown"` and the import error beside it. That is a broken
+installation, not a broken config.
+
+## `1` — the database rejected the SQL
+
+The message is the database's own, verbatim. hsql connected fine.
+
+- A missing relation or column: you guessed at a name. `hsql --catalog-search NAME` finds
+  where it really lives, and every catalog row carries a `query_name` already quoted
+  correctly for this database. Do not build identifiers by hand.
+- A syntax error: the SQL dialect is the database's, not hsql's. hsql normalizes flags
+  and output, never SQL.
+- A permission error under `--read-only`: expected, and working as intended.
+
+With `--on-error continue`, later statements still ran, and the exit code is still `1`.
+
+## `4` — the timeout ran out
+
+`--timeout` cancelled the run. hsql attributes it explicitly, because a cancelled cursor
+comes back empty and error-free — exactly like a query that matched nothing — so an
+empty result is never silently reported as success.
+
+Either the query is slower than the bound, or the bound is too tight. Do not simply raise
+it: check the query with `explain`, add the filter you forgot, or aggregate in SQL rather
+than fetching rows to count them.
+
+## `130` — interrupted
+
+Someone or something sent an interrupt. Nothing to fix.
+
+## `0`, but the output is wrong
+
+- **Fewer rows than the table has.** The 500-row default. Run with `--stats` and look at
+  `"truncated"`; `--limit -1` removes the limit.
+- **All the rows, but not all printed.** `--display-rows` caps what the text layouts
+  print (40 for `table` and `md`, 10 for `vertical`) without changing what was fetched.
+  File formats ignore it.
+- **Nothing at all on stdout.** `--format none` writes nothing by design, and `-o` sends
+  the output to a file. Check both before assuming the query matched nothing.
+- **A column of `NULL` you expected empty, or the reverse.** `--null-string TEXT` sets
+  it; text formats default to `NULL` and csv to empty.
+- **Misaligned columns.** Widths are measured in terminal cells, so CJK text and emoji
+  are counted correctly — if it still looks wrong, the terminal font is the suspect, not
+  hsql.
+
+## Nothing here fits
+
+```bash
+hsql --info > info.json
+```
+
+`--info` connects to nothing, redacts the profile it reports, and answers even when the
+config is broken — so it is safe to paste into a bug report. Issues go to
+<https://github.com/tconbeer/harlequin/issues>.

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -222,6 +222,11 @@
           "description": "Versions, config files, the active profile, and what each installed adapter declares it supports, as JSON. Connects to nothing. -a narrows it to one adapter.",
           "default": false
         },
+        "skill": {
+          "type": "boolean",
+          "description": "Write the Agent Skill for driving hsql, as markdown. -o installs it: 'hsql --skill -o ~/.claude/skills/hsql/'.",
+          "default": false
+        },
         "limit": {
           "type": "integer",
           "description": "Maximum rows fetched per result set. -1 for no limit.",

--- a/tests/skill_evals/README.md
+++ b/tests/skill_evals/README.md
@@ -1,0 +1,26 @@
+# Skill trigger evals
+
+`trigger_queries.json` is the eval set for the `hsql` skill's `description`, which is the
+only part of a skill always in context and the whole of what decides whether it loads.
+
+Run it with the description-optimization loop in the `skill-creator` skill, which needs
+the `claude` CLI. It is a pre-merge exercise on a change to the description, not a CI
+check: scoring it costs model calls, and the answer is a rate rather than a pass or fail.
+
+Ten positives and ten negatives, split train/test so a description tuned on one half is
+scored on turns it was never tuned against. The positives include turns that never say
+"hsql" or "harlequin", because under-triggering is the failure mode; the negatives are
+near misses — SQL-shaped work that is not a query, and database-shaped work that belongs
+to another tool.
+
+It lives here rather than beside the skill because
+`src/harlequin/hsql/skill/` is what ships in the wheel, and is the directory a
+marketplace entry points at as a plugin.
+
+## Last run
+
+2026-08-28, against the description as it ships: 10/10 positives and 10/10 negatives on
+both splits. The description was not tuned against this set — it scored at ceiling on the
+first pass — so the set's value now is as a regression check on the next edit to the
+description, and it will need harder near misses before it can distinguish one good
+description from another.

--- a/tests/unit_tests/test_documented_flags.py
+++ b/tests/unit_tests/test_documented_flags.py
@@ -1,10 +1,11 @@
-"""Every long flag the packaged README types is a flag hsql actually has.
+"""Every long flag the packaged README and the skill type is a flag hsql has.
 
-The README is the first thing an agent reads about hsql, and a command line in
-it is one an agent will run verbatim. Nothing else in this repo reads it: the
-CLI is tested thoroughly and its documentation is not, so a flag that was
-renamed, or one that never existed, sits in a fenced code block until someone
-pastes it and gets `No such option` and exit 2.
+The README is the first thing a person reads about hsql and the skill is the
+first thing an agent reads; a command line in either is one that gets run
+verbatim. Nothing else in this repo reads them: the CLI is tested thoroughly and
+its documentation is not, so a flag that was renamed, or one that never existed,
+sits in a fenced code block until someone pastes it and gets `No such option`
+and exit 2.
 
 So: pull every `--long-flag` out of the prose and the fences alike, and check
 each one against the document hsql writes about itself. Long spellings only --
@@ -20,18 +21,28 @@ import re
 from io import BytesIO
 from pathlib import Path
 
+import pytest
+
 from harlequin.hsql.modes import spec
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HSQL_README = REPO_ROOT / "packaging" / "hsql" / "README.md"
+SKILL_DIR = REPO_ROOT / "src" / "harlequin" / "hsql" / "skill"
+
+DOCUMENTS = [
+    HSQL_README,
+    SKILL_DIR / "SKILL.md",
+    *sorted(SKILL_DIR.glob("references/*.md")),
+]
+"""Every file in this repo that types an hsql command line at a reader."""
 
 LONG_FLAG = re.compile(r"--[a-zA-Z][a-zA-Z0-9_-]*")
 """A long option as a command line spells one, underscores included, since an
 adapter may declare `--md_token`. Stops at `=`, so `--format=csv` is `--format`."""
 
 OTHER_PROGRAMS = {
-    "--with": "uv, in the install lines",
-    "--pset": "psql, in the differences table",
+    "--with": "uv, in the README's install lines",
+    "--pset": "psql, in the README's differences table",
 }
 """Flags the README types that belong to another program. Named one at a time,
 with the reason, so that excusing a flag is a decision someone made rather than
@@ -66,13 +77,22 @@ def hsql_flags() -> set[str]:
     }
 
 
-def test_every_flag_the_packaged_readme_documents_exists() -> None:
+@pytest.mark.parametrize("document", DOCUMENTS, ids=lambda path: path.name)
+def test_every_flag_a_document_types_exists(document: Path) -> None:
     """The one that fails when a documented command line would exit 2."""
-    missing = documented_flags(HSQL_README.read_text(encoding="utf-8")) - hsql_flags()
+    missing = documented_flags(document.read_text(encoding="utf-8")) - hsql_flags()
     assert not missing, (
-        f"{HSQL_README.name} documents flags hsql does not have: "
+        f"{document.name} documents flags hsql does not have: "
         f"{', '.join(sorted(missing))}. Run `hsql --spec` for the real spellings."
     )
+
+
+def test_the_skill_is_covered() -> None:
+    """The parametrization reads the skill off the disk, so an empty glob would
+    have passed silently -- and the references are where the flags are."""
+    names = {path.name for path in DOCUMENTS}
+    assert "SKILL.md" in names
+    assert len(DOCUMENTS) >= 4
 
 
 def test_the_allowlist_names_only_flags_hsql_does_not_have() -> None:
@@ -80,9 +100,13 @@ def test_the_allowlist_names_only_flags_hsql_does_not_have() -> None:
     assert not set(OTHER_PROGRAMS) & hsql_flags()
 
 
-def test_the_allowlist_names_only_flags_the_readme_still_types() -> None:
+def test_the_allowlist_names_only_flags_a_document_still_types() -> None:
     """So an entry outlives the line it was written for by one PR at most."""
-    typed = set(LONG_FLAG.findall(HSQL_README.read_text(encoding="utf-8")))
+    typed = {
+        flag
+        for document in DOCUMENTS
+        for flag in LONG_FLAG.findall(document.read_text(encoding="utf-8"))
+    }
     assert set(OTHER_PROGRAMS) <= typed
 
 

--- a/tests/unit_tests/test_skill.py
+++ b/tests/unit_tests/test_skill.py
@@ -86,6 +86,24 @@ def body() -> str:
 # --- the file, as a skill ----------------------------------------------------
 
 
+def test_the_shipped_skill_has_lf_line_endings() -> None:
+    """`--skill` copies these bytes out verbatim, so their line endings are part
+    of what it promises, and a CRLF checkout is what takes them away: the same
+    hsql would print different bytes on Windows, and the frontmatter would stop
+    parsing. `.gitattributes` pins the directory to LF, and this is what fails,
+    naming the cause, if that pin goes missing.
+    """
+    shipped = [
+        skill_mode.SKILL_DIR / skill_mode.FILENAME,
+        *skill_mode.reference_paths(),
+    ]
+    for path in shipped:
+        assert b"\r" not in path.read_bytes(), (
+            f"{path.name} has CRLF line endings; check the .gitattributes pin on "
+            "src/harlequin/hsql/skill/"
+        )
+
+
 def test_the_frontmatter_uses_only_the_portable_fields(
     frontmatter: dict[str, Any],
 ) -> None:

--- a/tests/unit_tests/test_skill.py
+++ b/tests/unit_tests/test_skill.py
@@ -1,0 +1,256 @@
+"""The Agent Skill hsql ships, and the properties that keep it loadable.
+
+The skill is the first thing an agent reads about hsql, and unlike the CLI it
+has no way to fail loudly: a frontmatter key the standard does not define makes
+the file unloadable in half the harnesses that read it, and a body that has
+grown into a manual still loads and still costs every session that triggers it.
+Neither shows up in a test of what hsql does, so they are asserted here.
+
+The flag guard in `test_documented_flags.py` covers the other half -- that every
+command line the skill types is one hsql would accept.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import yaml
+from click.testing import CliRunner, Result
+
+from harlequin.hsql.cli import build_cli
+from harlequin.hsql.diagnostics import ExitCode
+from harlequin.hsql.modes import skill as skill_mode
+
+Hsql = Callable[..., Result]
+
+PORTABLE_FIELDS = {
+    "name",
+    "description",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+}
+"""The six fields the Agent Skills standard defines.
+
+Claude Code accepts extension keys on top of these; the claude.ai upload and the
+Skills API reject an unknown key outright. A skill whose whole argument is that
+it works in any harness does not get to use one.
+"""
+
+MAX_BODY_BYTES = 4096
+MAX_BODY_LINES = 200
+"""What the skill's text costs every session that triggers it, capped.
+
+The references are not capped the same way: they are read on demand, by the
+agent that needed one, and never enter a context that did not ask for them.
+"""
+
+REFERENCE_NAMES = {"config.md", "queries.md", "scripting.md", "troubleshooting.md"}
+
+
+@pytest.fixture
+def hsql(no_discovered_config: None) -> Hsql:
+    runner = CliRunner()
+
+    def _run(*args: str, **kwargs: Any) -> Result:
+        argv = [str(arg) for arg in args]
+        return runner.invoke(build_cli(argv), argv, catch_exceptions=False, **kwargs)
+
+    return _run
+
+
+def _split(text: str) -> tuple[dict[str, Any], str]:
+    """One skill file as its frontmatter and its body."""
+    match = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.DOTALL)
+    assert match is not None, "SKILL.md must open with a YAML frontmatter block"
+    frontmatter = yaml.safe_load(match.group(1))
+    assert isinstance(frontmatter, dict)
+    return frontmatter, match.group(2)
+
+
+@pytest.fixture
+def frontmatter() -> dict[str, Any]:
+    return _split(skill_mode.text().decode("utf-8"))[0]
+
+
+@pytest.fixture
+def body() -> str:
+    return _split(skill_mode.text().decode("utf-8"))[1]
+
+
+# --- the file, as a skill ----------------------------------------------------
+
+
+def test_the_frontmatter_uses_only_the_portable_fields(
+    frontmatter: dict[str, Any],
+) -> None:
+    """What keeps the file loadable outside Claude Code."""
+    unknown = sorted(set(frontmatter) - PORTABLE_FIELDS)
+    assert not unknown, f"not in the Agent Skills standard: {unknown}"
+
+
+def test_the_frontmatter_names_and_describes_the_skill(
+    frontmatter: dict[str, Any],
+) -> None:
+    """The description is the only part always in context, and it is what
+    decides whether the skill loads at all."""
+    assert frontmatter["name"] == "hsql"
+    assert frontmatter["description"].strip()
+
+
+def test_the_description_names_the_contexts_as_well_as_the_capability(
+    frontmatter: dict[str, Any],
+) -> None:
+    """The failure mode is under-triggering, so a description that says only
+    what hsql is will not fire on the queries that should reach it."""
+    description = frontmatter["description"].lower()
+    for context in ("sql", "database", ".sql", "connection string", "export"):
+        assert context in description, f"the description never mentions {context}"
+
+
+def test_the_granted_tools_are_the_ones_that_only_read(
+    frontmatter: dict[str, Any],
+) -> None:
+    """Deciding whether to run a query is the human's; deciding whether to read
+    a catalog is not. A blanket `Bash(hsql *)` would pre-approve both."""
+    granted = frontmatter["allowed-tools"]
+    assert "Bash(hsql *)" not in granted
+    for grant in granted:
+        mode = grant.removeprefix("Bash(hsql ").split()[0].rstrip("*)")
+        assert mode in {
+            "--help",
+            "--version",
+            "--info",
+            "--spec",
+            "--catalog",
+            "--catalog-search",
+        }, f"{grant} pre-approves more than introspection"
+
+
+def test_the_body_stays_a_skill_rather_than_a_manual(body: str) -> None:
+    assert len(body.encode("utf-8")) <= MAX_BODY_BYTES
+    assert body.count("\n") <= MAX_BODY_LINES
+
+
+def test_the_body_points_at_every_reference_that_ships(body: str) -> None:
+    """A pointer the shipped tree cannot satisfy is worse than no pointer: the
+    agent reading it cannot tell a missing file from one that never existed."""
+    shipped = {path.name for path in skill_mode.reference_paths()}
+    assert shipped == REFERENCE_NAMES
+    for name in shipped:
+        assert name in body, f"SKILL.md never mentions references/{name}"
+
+
+def test_every_reference_is_reachable_from_the_skill_directory() -> None:
+    """`references/` is the name SKILL.md types, so it is the name it keeps."""
+    for path in skill_mode.reference_paths():
+        assert path.parent == skill_mode.SKILL_DIR / skill_mode.REFERENCES
+
+
+# --- the mode ----------------------------------------------------------------
+
+
+def test_skill_writes_the_packaged_file_verbatim(hsql: Hsql) -> None:
+    """The bytes are the contract, applied to the one output that is not rows."""
+    res = hsql("--skill")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.encode("utf-8") == skill_mode.text()
+
+
+def test_a_file_output_installs_the_whole_skill(hsql: Hsql, tmp_path: Path) -> None:
+    """The documented one-liner, and it has to leave a skill rather than a file:
+    `SKILL.md` alone would ship four pointers that resolve to nothing."""
+    destination = tmp_path / "skills" / "hsql" / "SKILL.md"
+    res = hsql("--skill", "-o", str(destination))
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+    assert destination.read_bytes() == skill_mode.text()
+    installed = {path.name for path in (destination.parent / "references").iterdir()}
+    assert installed == REFERENCE_NAMES
+
+
+def test_a_directory_output_installs_the_whole_skill(
+    hsql: Hsql, tmp_path: Path
+) -> None:
+    """The other spelling of the same intent, and it lands in the same place."""
+    destination = tmp_path / "skills" / "hsql"
+    res = hsql("--skill", "-o", f"{destination}/")
+    assert res.exit_code == ExitCode.OK
+    assert (destination / "SKILL.md").read_bytes() == skill_mode.text()
+    installed = {path.name for path in (destination / "references").iterdir()}
+    assert installed == REFERENCE_NAMES
+
+
+def test_the_install_names_every_file_it_wrote(hsql: Hsql, tmp_path: Path) -> None:
+    """The caller named one path and got five files; the other four are the one
+    thing about the run that stdout cannot carry."""
+    res = hsql("--skill", "-o", f"{tmp_path}/hsql/")
+    assert "SKILL.md" in res.stderr
+    for name in REFERENCE_NAMES:
+        assert f"references/{name}" in res.stderr
+
+
+def test_writing_it_produces_the_same_bytes_as_printing_it(
+    hsql: Hsql, tmp_path: Path
+) -> None:
+    destination = tmp_path / "SKILL.md"
+    hsql("--skill", "-o", str(destination))
+    assert destination.read_bytes() == hsql("--skill").stdout.encode("utf-8")
+
+
+def test_format_none_writes_nothing(hsql: Hsql, tmp_path: Path) -> None:
+    res = hsql("--skill", "--format", "none")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+
+
+def test_a_format_it_cannot_honor_says_so(hsql: Hsql) -> None:
+    """Silence would read as a format that was applied."""
+    res = hsql("--skill", "--csv")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout.encode("utf-8") == skill_mode.text()
+    assert "had no effect" in res.stderr
+
+
+def test_skill_does_not_run_sql(hsql: Hsql) -> None:
+    res = hsql("--skill", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "--skill does not run SQL" in res.stderr
+
+
+def test_skill_is_one_mode(hsql: Hsql) -> None:
+    res = hsql("--skill", "--info")
+    assert res.exit_code == ExitCode.USAGE
+    assert "two modes" in res.stderr
+
+
+def test_skill_imports_no_adapter_and_reads_no_config(
+    run_python: Callable[[str], subprocess.CompletedProcess[str]],
+) -> None:
+    """Printing a packaged file should cost what printing a packaged file costs.
+
+    It is the one mode with nothing to look up: no adapter to ask about its
+    options, no config file to resolve a profile from, no database.
+    """
+    proc = run_python(
+        "import sys\n"
+        "sys.argv = ['hsql', '--skill']\n"
+        "from harlequin.hsql import main\n"
+        "try:\n"
+        "    main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "print(','.join(sorted({m.split('.')[0] for m in sys.modules "
+        "if m.startswith('harlequin_')})), file=sys.stderr)\n"
+        "print(','.join(m for m in ('duckdb', 'pyarrow', 'tomlkit') "
+        "if m in sys.modules), file=sys.stderr)\n"
+    )
+    adapters, forbidden = proc.stderr.split("\n")[:2]
+    assert not adapters
+    assert not forbidden

--- a/uv.lock
+++ b/uv.lock
@@ -787,7 +787,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1377,6 +1377,7 @@ static = [
     { name = "mypy" },
     { name = "ruff" },
     { name = "types-jsonschema" },
+    { name = "types-pyyaml" },
 ]
 test = [
     { name = "boto3" },
@@ -1387,6 +1388,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-textual-snapshot" },
     { name = "pytest-xdist" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -1435,6 +1437,7 @@ static = [
     { name = "mypy", specifier = "==2.3.1,<3" },
     { name = "ruff", specifier = ">=0.14.1" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
+    { name = "types-pyyaml", specifier = ">=6" },
 ]
 test = [
     { name = "boto3", specifier = "==1.43.72" },
@@ -1445,6 +1448,7 @@ test = [
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-textual-snapshot", git = "https://github.com/tconbeer/pytest-textual-snapshot.git?rev=a2c6763b45283f76757a123342900accefcf04e8" },
     { name = "pytest-xdist", specifier = ">=3.6" },
+    { name = "pyyaml", specifier = ">=6" },
 ]
 
 [[package]]
@@ -4317,6 +4321,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260815"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/72/b56089aeee6c496d969bac42376bedb6e3eeab4682e1018fa3137122f94b/types_pyyaml-6.0.12.20260815.tar.gz", hash = "sha256:28764110c9cf35846e733da32d8d734df7473c5dde9ef67c3b7332ec0e819858", size = 18545, upload-time = "2026-08-15T02:41:51.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/52/eefeba09be4ef2a1eb989eb92934561e8e502a6ee3c32654996e4be7e399/types_pyyaml-6.0.12.20260815-py3-none-any.whl", hash = "sha256:6f332212b7e191f3afd5016a713c510b6340593b7ebec573c7d5d20aa5386d3b", size = 21148, upload-time = "2026-08-15T02:41:50.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #524 (in part — M3 PR 3 of [`docs/plans/m3-hsql-technical-plan.md`](https://github.com/tconbeer/harlequin/blob/main/docs/plans/m3-hsql-technical-plan.md), §3.5)

**What** are the key elements of this solution?

- The skill ships as package data at `src/harlequin/hsql/skill/`: `SKILL.md`, nine sections of standing guidance in a 3.9KB body, plus four references beside it in `references/`.
- `hsql --skill` is a mode option like `--info` and `--spec`, in `hsql/modes/skill.py`. Bare, it writes `SKILL.md` to stdout. `-o` **installs the skill** — `SKILL.md` at the path named, and `references/` beside it — so both `-o ~/.claude/skills/hsql/` and `-o ~/.claude/skills/hsql/SKILL.md` leave a complete, loadable skill.
- Guards, per the plan's §5: the frontmatter uses only the six portable Agent Skills fields and parses as YAML; `allowed-tools` names the read-only modes and a test rejects a blanket `Bash(hsql *)`; the body stays under 4KB and 200 lines; stdout is byte-identical to the packaged file and to what `-o` writes; every reference that ships is pointed at from `SKILL.md`; and a subprocess test proves the mode imports no adapter, no tomlkit and no pyarrow.
- The flag guard from PR 1 now runs over the skill and its references as well as the packaged README. It caught two flags I had typed as illustrations of flags that don't exist, which is exactly its job.
- Regenerated `docs/generated/hsql-reference.md` and `src/harlequin/schemas/config-v1.json`, both of which `--skill` changes; a README section and a Features changelog entry.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**The references are the deliberate departure from the plan.** §3.5 says the skill's third layer is the CLI, not bundled files, so that it cannot rot. I kept that principle and added the files anyway, because the four jobs an agent actually arrives with — run a query, write a config file, put hsql in a script, work out why a run failed — each need a page of prose that `--info` and `--spec` cannot supply, and cramming them into `SKILL.md` would have cost every triggered session what only one of them needs. The rot argument holds because the references stay commands-first: each points at `--info` / `--spec` / `--catalog` rather than restating what those would say, and none of them lists adapters, adapter options, or the full format table. The alternative — four separate skills — puts four descriptions permanently in context and breaks PR 4's single-skill-plugin trick, where `SKILL.md` sits at the plugin root.

**`-o` installs rather than writes one file** because a `SKILL.md` whose four pointers dangle is worse than one that never had them: the agent reading it cannot tell a reference that is missing from one that does not exist. That means `-o` writes files the caller did not name, which is new for a document mode — so `report_written()` names all five, and it now names them relative to the folder they share, so `references/config.md` reads as a path rather than a bare filename that could be anywhere.

**stdout stays `SKILL.md` alone.** It is the document, for a caller reading or piping it; the tree is what an install produces. That is what keeps the plan's byte-identity property ("the bytes are the contract") pointed at one file.

`_sink()` grew an `announce=False`, for the one caller that writes more than the file `_sink` opened and so has to name them all in one line.

**The description got its optimization pass**, with the eval set committed at `tests/skill_evals/` — twenty realistic first turns, half of them near-miss negatives, split train/test, scored with the `claude` CLI. It came back 10/10 and 10/10 on both splits on the first pass, including five positives that never say "hsql" or "harlequin", so nothing was tuned. That also means the set cannot yet distinguish one good description from another, and its README says so. It lives under `tests/` rather than beside the skill because `src/harlequin/hsql/skill/` is the directory PR 4 points a marketplace entry at as a plugin root, and an `evals/` folder does not belong in a plugin.

`pyyaml` and `types-pyyaml` are new test-only dependencies, used in one place: parsing the frontmatter the way a harness loading the skill would. A hand-rolled parser would have avoided the dependency and could happily accept frontmatter a real loader rejects, which is the failure those tests exist to catch.

Section 9 is the M3 version, not the finished one — the plan is explicit that `hsql open query.sql` in M4 turns "tell them to open Harlequin" into "hand them the query, loaded and unexecuted."

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the site needs the `skill.md` page in the Headless & Agents topic — what the skill is and the ways to install it. That is M3's PR 12, and the release workflow that vendors `SKILL.md` alongside the other artifacts is PR 5.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLdE4gKduxbNbpA5PjcsYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLdE4gKduxbNbpA5PjcsYb)_