### PR TITLE
Make the skill a plugin this repo can host (#524)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "harlequin",
+  "owner": {
+    "name": "Ted Conbeer",
+    "url": "https://github.com/tconbeer"
+  },
+  "metadata": {
+    "description": "Plugins for Harlequin, the SQL IDE for your terminal, and hsql, your agent's favorite SQL client."
+  },
+  "plugins": [
+    {
+      "name": "hsql",
+      "source": "./src/harlequin/hsql/skill"
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           uv version --project packaging/hsql --frozen ${{ github.event.inputs.newVersion }}
           uv add --project packaging/hsql --frozen "harlequin==${{ github.event.inputs.newVersion }}"
 
+      - name: Bump the plugin manifest
+        # the plugin is the skill for one release of hsql, so it carries that
+        # release's number. It is the only version `uv version` cannot reach.
+        run: python scripts/bump_plugin_version.py ${{ github.event.inputs.newVersion }}
+
       - name: Ensure packages can be built
         run: |
           uv build --all-packages

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -50,3 +50,33 @@ jobs:
             uv run --no-sync python scripts/cold_start.py
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  plugin:
+    name: Validate Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Repo
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.5"
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        id: setup-python
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install python dependencies
+        run: uv sync --locked --group test
+
+      # `claude plugin validate` is what reads the marketplace entry and the
+      # plugin manifest; the tests that call it skip where it is not installed,
+      # which is everywhere but here.
+      - name: Install the Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@2.1.251
+
+      - name: Validate the marketplace entry and the plugin it names
+        run: uv run --no-sync pytest tests/unit_tests/test_plugin.py -n0

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 !tests/data/**/*.json
 # the packaged base JSON Schema, written by scripts/write_config_schema.py
 !src/harlequin/schemas/*.json
+# the marketplace entry, and the manifest that makes the skill a plugin
+!.claude-plugin/*.json
+!src/harlequin/hsql/skill/.claude-plugin/*.json
 !tests/data/**/*.parquet
 !tests/data/**/*.sql
 # Snapshots are named after the format they hold, so several of them collide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ That last sentence is `config.merge_profile_with_cli()`, and it belongs to every
 - `stubs/` holds type stubs for untyped dependencies (`mypy_path = "stubs,src"`).
 - Styles are Textual CSS: `global.tcss`, `app.tcss`, `keys_app.tcss`.
 - `packaging/hsql/` is a metapackage reserving the `hsql` name on PyPI; `docs/plans/` holds the design docs behind the headless CLI.
+- `src/harlequin/hsql/skill/` is both the skill `hsql --skill` prints and a single-skill plugin: `.claude-plugin/plugin.json` inside it, and `.claude-plugin/marketplace.json` at the repo root naming the directory as the source, so `/plugin install hsql@harlequin` installs the whole tree — `SKILL.md` and `references/` — as `hsql --skill -o` does. Moving that directory moves the marketplace's source too, and hatchling skips dot-directories, so both build targets name the manifest in `force-include`.
 - `scripts/` has the screenshot exporter used for marketing SVGs, pyinstrument profiling entrypoints (`make profiles`), and two generators: `write_config_schema.py`, which regenerates the packaged base JSON Schema at `src/harlequin/schemas/config-v1.json`, and `write_cli_reference.py`, which regenerates hsql's CLI reference at `docs/generated/hsql-reference.md` from `--spec`'s own vocabulary, for no adapters. Both artifacts are committed and pinned by a test that regenerates and compares.
 
 ## Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Adds `hsql --skill`, which writes the Agent Skill for driving hsql. `hsql --skill -o ~/.claude/skills/hsql/` installs it — the standing guidance plus four references, on running queries and reading the catalog, config files and profiles, hsql inside a shell script, and what to do about each exit code. It matches the version of hsql you have, and needs no network.
+- The same skill is now a Claude Code plugin: `/plugin marketplace add tconbeer/harlequin`, then `/plugin install hsql@harlequin`.
 
 ### Bug Fixes
 

--- a/packaging/hsql/README.md
+++ b/packaging/hsql/README.md
@@ -382,9 +382,14 @@ $ hsql --skill -o .claude/skills/hsql/            # for this repo, committed wit
 note: wrote 5 files to .claude/skills/hsql: SKILL.md, references/config.md, references/queries.md, references/scripting.md, references/troubleshooting.md
 ```
 
-`SKILL.md` is the standing guidance; the four references beside it cover running queries and reading the catalog, config files and profiles, hsql inside a shell script, and what to do about each exit code. An agent reads one when the work reaches it.
-
 With no `-o`, `hsql --skill` writes `SKILL.md` to stdout, so you can read it before you install it.
+
+In Claude Code, the same skill is a plugin in Harlequin's repository:
+
+```
+/plugin marketplace add tconbeer/harlequin
+/plugin install hsql@harlequin
+```
 
 ## Keep Reading at [harlequin.sh](https://harlequin.sh/docs/getting-started/hsql)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 
+# The plugin manifest that makes the skill directory a plugin. hatchling skips
+# dot-directories, and `.claude-plugin/` is where the plugin tooling looks.
+force-include = { "src/harlequin/hsql/skill/.claude-plugin/plugin.json" = "harlequin/hsql/skill/.claude-plugin/plugin.json" }
+
 packages = [
     "src/harlequin",
     "src/harlequin_duckdb",
@@ -174,6 +178,8 @@ packages = [
 ]
 
 [tool.hatch.build.targets.sdist]
+
+force-include = { "src/harlequin/hsql/skill/.claude-plugin/plugin.json" = "src/harlequin/hsql/skill/.claude-plugin/plugin.json" }
 
 only-include = [
     "src",

--- a/scripts/bump_plugin_version.py
+++ b/scripts/bump_plugin_version.py
@@ -1,0 +1,52 @@
+"""Set the plugin manifest's version, the way a release does.
+
+The plugin is the skill for one release of hsql, so `plugin.json` carries that
+release's number -- and it is the only version `uv version` cannot reach. So
+`release.yml` runs this beside the two it does.
+
+Usage:
+    python scripts/bump_plugin_version.py 2.12.0
+
+`tests/unit_tests/test_plugin.py` is what fails when the committed manifest and
+this disagree, whether that is a version a release left behind or a hand edit
+this would reformat.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "harlequin"
+    / "hsql"
+    / "skill"
+    / ".claude-plugin"
+    / "plugin.json"
+)
+
+
+def write_version(version: str, path: Path = PLUGIN_PATH) -> None:
+    """Rewrite the manifest with `version`, and nothing else changed.
+
+    Key order survives the round trip, so a release's diff is the one line.
+    """
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    path.write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: python scripts/bump_plugin_version.py VERSION")
+    write_version(sys.argv[1])
+    print(f"wrote {PLUGIN_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/harlequin/hsql/skill/.claude-plugin/plugin.json
+++ b/src/harlequin/hsql/skill/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "hsql",
+  "description": "The Agent Skill for hsql, the best SQL client for automations and agents.",
+  "version": "2.11.0",
+  "author": {
+    "name": "Ted Conbeer",
+    "url": "https://github.com/tconbeer"
+  },
+  "homepage": "https://harlequin.sh/docs/getting-started/hsql",
+  "repository": "https://github.com/tconbeer/harlequin",
+  "license": "MIT",
+  "keywords": [
+    "sql",
+    "database",
+    "duckdb",
+    "sqlite",
+    "postgres",
+    "mysql",
+    "cli"
+  ]
+}

--- a/tests/unit_tests/test_plugin.py
+++ b/tests/unit_tests/test_plugin.py
@@ -1,0 +1,172 @@
+"""The marketplace entry, and the plugin it makes of the skill directory.
+
+`hsql --skill -o …` is the install that needs no network; this is the one that
+needs no hsql. `.claude-plugin/marketplace.json` at the repo root names
+`src/harlequin/hsql/skill` as a plugin, and the `.claude-plugin/plugin.json`
+inside that directory is what makes it one -- no second repo, no copied file,
+no build step.
+
+What that costs is three manifests that have to go on agreeing, and none of
+them fails loudly: a source path left behind by a move, or a version left
+behind by a release, is a broken install for everyone who has already added
+the marketplace.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from importlib.metadata import version
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+
+from harlequin.hsql.modes import skill as skill_mode
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MARKETPLACE_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_PATH = skill_mode.SKILL_DIR / ".claude-plugin" / "plugin.json"
+
+BUMP_SCRIPT_PATH = REPO_ROOT / "scripts" / "bump_plugin_version.py"
+
+PACKAGED_PLUGIN_MANIFEST = "src/harlequin/hsql/skill/.claude-plugin/plugin.json"
+"""The manifest's path from the repo root, as the build targets spell it."""
+
+
+def skill_name() -> str:
+    """The name in `SKILL.md`'s frontmatter, which is the skill's own."""
+    match = re.match(
+        r"^---\n(.*?)\n---\n", skill_mode.text().decode("utf-8"), re.DOTALL
+    )
+    assert match is not None
+    name: str = yaml.safe_load(match.group(1))["name"]
+    return name
+
+
+@pytest.fixture(scope="module")
+def marketplace() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(MARKETPLACE_PATH.read_text(encoding="utf-8"))
+    return data
+
+
+@pytest.fixture(scope="module")
+def plugin() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(PLUGIN_PATH.read_text(encoding="utf-8"))
+    return data
+
+
+@pytest.fixture(scope="module")
+def bumper() -> ModuleType:
+    """The release script, loaded from `scripts/`, which is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "bump_plugin_version", BUMP_SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def entry(marketplace: dict[str, Any]) -> dict[str, Any]:
+    """The one plugin the marketplace offers."""
+    plugins = marketplace["plugins"]
+    assert len(plugins) == 1
+    offered: dict[str, Any] = plugins[0]
+    return offered
+
+
+# --- the manifests -----------------------------------------------------------
+
+
+def test_the_marketplace_entry_names_a_source_that_exists(
+    entry: dict[str, Any],
+) -> None:
+    """The source is a path inside this repo, which is what saves a second one."""
+    source = (REPO_ROOT / entry["source"]).resolve()
+    assert source == skill_mode.SKILL_DIR
+    assert (source / skill_mode.FILENAME).is_file()
+
+
+def test_the_plugin_manifest_sits_inside_the_source_directory() -> None:
+    """`.claude-plugin/` beside `SKILL.md` is what makes the directory a plugin
+    rather than a folder the marketplace points at."""
+    assert PLUGIN_PATH.parent.parent == skill_mode.SKILL_DIR
+    assert PLUGIN_PATH.is_file()
+
+
+def test_one_name_names_the_plugin_everywhere(
+    entry: dict[str, Any], plugin: dict[str, Any]
+) -> None:
+    """`/plugin install hsql@harlequin` is the entry's name and the manifest's,
+    and the skill it installs answers to the same one."""
+    assert entry["name"] == plugin["name"] == skill_name() == "hsql"
+
+
+def test_the_plugin_version_is_the_version_it_ships_with(
+    plugin: dict[str, Any],
+) -> None:
+    """The plugin is the skill for one release of hsql, so it carries that
+    release's number -- and `release.yml` is what keeps this true."""
+    assert plugin["version"] == version("harlequin")
+
+
+def test_a_release_bumps_the_version_and_rewrites_nothing_else(
+    bumper: ModuleType, tmp_path: Path
+) -> None:
+    """A manifest the release script would reformat is one nobody can read a
+    version change out of."""
+    assert bumper.PLUGIN_PATH == PLUGIN_PATH
+    committed = PLUGIN_PATH.read_bytes()
+    manifest = tmp_path / "plugin.json"
+    manifest.write_bytes(committed)
+    bumper.write_version("9.9.9", manifest)
+    assert manifest.read_bytes() == committed.replace(
+        f'"version": "{version("harlequin")}"'.encode(), b'"version": "9.9.9"'
+    )
+
+
+def test_the_plugin_manifest_ships_in_the_wheel_and_the_sdist() -> None:
+    """hatchling skips dot-directories, so the manifest is included by name in
+    both targets. Losing either is silent: the build succeeds without it."""
+    targets = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "tool"
+    ]["hatch"]["build"]["targets"]
+    for target in ("wheel", "sdist"):
+        assert PACKAGED_PLUGIN_MANIFEST in targets[target]["force-include"]
+
+
+# --- what the plugin tooling makes of them -----------------------------------
+
+
+@pytest.mark.skipif(
+    shutil.which("claude") is None, reason="the claude CLI is what reads these"
+)
+@pytest.mark.parametrize("target", [".", "src/harlequin/hsql/skill"])
+def test_claude_plugin_validate_passes(target: str, tmp_path: Path) -> None:
+    """The marketplace and the plugin, checked by the tool that installs them.
+
+    `--strict` because a warning here -- an unrecognized field, or metadata
+    that is missing -- is a manifest some of the tooling reads differently.
+    """
+    proc = subprocess.run(
+        ["claude", "plugin", "validate", target, "--strict"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CLAUDE_CONFIG_DIR": str(tmp_path)},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
Closes #524 (in part — M3 PR 4 of [`docs/plans/m3-hsql-technical-plan.md`](https://github.com/tconbeer/harlequin/blob/main/docs/plans/m3-hsql-technical-plan.md), §3.5 tier 2)

**What** are the key elements of this solution?

- `.claude-plugin/marketplace.json` at the repo root names `./src/harlequin/hsql/skill` as a plugin, and `.claude-plugin/plugin.json` inside that directory is what makes it one. So `/plugin marketplace add tconbeer/harlequin` then `/plugin install hsql@harlequin` installs the same skill `hsql --skill` prints — no second repo, no copied file, no build step.
- Verified end to end rather than only validated: installing from a local clone into a throwaway config dir lays down `SKILL.md` **and** `references/`, and `claude plugin details hsql` reports one skill at ~200 always-on tokens and ~1.4k on invoke. `SKILL.md` at the plugin root does register as the single skill.
- `claude plugin validate --strict` runs over both manifests in CI, as a `Validate Plugin` job in `static.yml` that installs the CLI. The tests that call it skip where it is not installed, rather than passing silently.
- The rest of `tests/unit_tests/test_plugin.py` pins what the three files have to go on agreeing about: one name across the marketplace entry, the manifest and the skill's frontmatter; a source path that resolves to the skill directory; and the version of the hsql the plugin is the skill for.
- `scripts/bump_plugin_version.py` is what keeps that version true, run by `release.yml` beside the two `uv version` reaches. A test runs it against the committed manifest and asserts the bump changes the one line and reformats nothing.
- A packaged-README section with the two `/plugin` lines, a Features changelog entry, and an AGENTS.md line.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

**The version is the part that can rot silently, so it is the part with a script and a test.** A plugin manifest carries its own version, `uv version` cannot reach it, and nothing about a stale one fails: `/plugin` just shows a number that was true a release ago. Reading the version out of the wheel at install time is not available to a manifest, so the alternatives were a hardcoded number nobody bumps or a bump in the release workflow. The script makes that bump a thing that can be run and read; the test is what fails on the release PR if it ever stops running, which is where it is cheapest to fix.

**Two silent packaging traps, both closed.** hatchling skips dot-directories, so the manifest was dropped from the wheel *and* the sdist — and the sdist omission broke `uv build` outright, because building the wheel from that sdist fails the force-include. Both targets now name it, and a test asserts both, because losing either is invisible: the build succeeds without it. Separately, `.gitignore`'s blanket `*.json` was refusing to track either manifest, with `git add` reporting success — two negations, next to the existing one for the packaged schema.

**The marketplace entry stays minimal** — a name and a source. It may also carry a description and a version, but both resolve from `plugin.json` when absent, and a second copy of either is a second thing to keep in step.

Tier 3 in the plan (the community marketplace) is a submission form that depends on this being live, so it is a follow-up to file rather than anything in this PR.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the `skill.md` page in the Headless & Agents topic should carry the `/plugin` install lines beside `hsql --skill -o`. That is M3's PR 12.

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qz5TP2bXLBEScmtT11Ahh2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz5TP2bXLBEScmtT11Ahh2)_