### PR TITLE
fix: don't split statements inside dollar-quoted bodies (#1019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- A semicolon inside a dollar-quoted function body (e.g. `create function f() as $$ select 1; $$`) is no longer treated as a statement separator, in the Query Editor or in scripts ([#1019](https://github.com/tconbeer/harlequin/issues/1019)).
+
 ## [2.12.0] - 2026-08-29
 
 ### Features

--- a/src/harlequin/statements.py
+++ b/src/harlequin/statements.py
@@ -1,9 +1,11 @@
 """Locating statement boundaries in SQL text.
 
 Both front ends split a script here, through the same tree-sitter grammar and
-the same one-line query the Query Editor has always used, so a script run with
-`-f` and the same script in the editor cannot disagree about where a statement
-ends.
+the same query the Query Editor has always used, so a script run with `-f` and
+the same script in the editor cannot disagree about where a statement ends. A
+semicolon inside a dollar-quoted body is body content, not a separator: the
+query also captures the body's `$tag$` delimiters, and `_separator_offsets()`
+drops semicolons between a matching pair.
 
 This module also owns the grammar itself: `captures()` runs a tree-sitter query
 over parsed SQL, so the grammar is loaded and each query compiled exactly once,
@@ -25,11 +27,16 @@ from dataclasses import dataclass
 import tree_sitter_sql
 from tree_sitter import Language, Node, Parser, Query, QueryCursor
 
-SEMICOLON_QUERY = '(";" @semicolon)'
-"""Capture every semicolon the grammar considers a statement separator.
+SPLITTER_QUERY = """
+(";" @semicolon)
+(dollar_quote) @dollar_quote
+"""
+"""Capture semicolons, and the `$tag$` delimiters of dollar-quoted bodies.
 
 Semicolons inside string literals, comments and quoted identifiers are part of
-those nodes, so they are not captured.
+those nodes, so they are not captured. A semicolon inside a dollar-quoted body
+is captured -- the grammar parses the body's SQL -- so `_separator_offsets()`
+drops it by pairing the delimiters it also captures here.
 """
 
 Point = tuple[int, int]
@@ -78,14 +85,43 @@ def captures(text: str, pattern: str) -> dict[str, list[Node]]:
     return QueryCursor(query).captures(tree.root_node)
 
 
+def _dollar_quoted_regions(tags: list[Node]) -> list[tuple[int, int]]:
+    """Return byte spans between matching dollar-quote delimiters.
+
+    Differently named delimiters are content while a body is open.
+    """
+    regions: list[tuple[int, int]] = []
+    opening_tag: Node | None = None
+    for tag in sorted(tags, key=lambda node: node.start_byte):
+        if opening_tag is None:
+            opening_tag = tag
+        elif tag.text == opening_tag.text:
+            regions.append((opening_tag.end_byte, tag.start_byte))
+            opening_tag = None
+    return regions
+
+
 def _separator_offsets(text: str) -> list[int]:
     """Character offsets in `text` just past each statement separator."""
     if ";" not in text:
         # cheap, and the common case for a single statement.
         return []
 
-    matched = captures(text, SEMICOLON_QUERY)
-    byte_offsets = sorted(node.end_byte for node in matched.get("semicolon", []))
+    matched = captures(text, SPLITTER_QUERY)
+    semicolons = sorted(
+        (node.start_byte, node.end_byte) for node in matched.get("semicolon", [])
+    )
+    regions = _dollar_quoted_regions(matched.get("dollar_quote", []))
+    byte_offsets: list[int] = []
+    region_index = 0
+    for semi_start, semi_end in semicolons:
+        while region_index < len(regions) and regions[region_index][1] <= semi_start:
+            region_index += 1
+        if region_index < len(regions):
+            region_start, region_end = regions[region_index]
+            if region_start <= semi_start and semi_end <= region_end:
+                continue  # inside a dollar-quoted body
+        byte_offsets.append(semi_end)
 
     if text.isascii():
         return byte_offsets

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -440,6 +440,30 @@ async def test_selected_queries_split_on_character_columns(
 
 
 @pytest.mark.asyncio
+async def test_selected_queries_do_not_split_dollar_quoted_bodies(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """Regression test for #1019: the editor and `harlequin.statements` agree,
+    and neither treats a semicolon inside `$$ ... $$` as a separator."""
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+
+        while app.editor is None:
+            await pilot.pause()
+
+        script = "create function f() as $$ select 1; $$; select 2"
+        app.editor.text = script
+        await pilot.pause()
+        app.editor.selection = Selection((0, 0), (0, len(script)))
+        assert app.editor.selected_queries() == [
+            "create function f() as $$ select 1; $$;",
+            "select 2",
+        ]
+        assert app.editor.selected_queries() == [s.sql for s in split(app.editor.text)]
+
+
+@pytest.mark.asyncio
 async def test_buffer_symbols_reach_the_completers(
     app: Harlequin,
     wait_for_workers: Callable[[Harlequin], Awaitable[None]],

--- a/tests/unit_tests/test_statements.py
+++ b/tests/unit_tests/test_statements.py
@@ -1,8 +1,8 @@
 """The tricky-SQL corpus.
 
-`tests/functional_tests/test_query_editor.py` runs the same fixtures through
-the Query Editor, so a divergence between the two front ends fails here or
-there rather than in a user's buffer.
+`tests/functional_tests/test_query_editor.py` exercises the same splitter
+through the Query Editor, so a divergence between the two front ends fails
+here or there rather than in a user's buffer.
 """
 
 from __future__ import annotations
@@ -97,6 +97,75 @@ CORPUS: list[tuple[str, str, list[str]]] = [
         "select 1;select 2;select 3",
         ["select 1;", "select 2;", "select 3"],
     ),
+    # a semicolon inside a dollar-quoted body is body content, not a
+    # separator. The grammar exposes the body's `$tag$` delimiters either way:
+    # as function_body tags when it parses, and as bare tokens during error
+    # recovery when it cannot (a missing `returns` clause). See #1019.
+    (
+        "dollar-quoted body with returns",
+        "create function f() returns int as $$ select 1; $$; select 2",
+        ["create function f() returns int as $$ select 1; $$;", "select 2"],
+    ),
+    (
+        "dollar-quoted body, semicolon flush with delimiters",
+        "create function f() as $$;$$; select 2",
+        ["create function f() as $$;$$;", "select 2"],
+    ),
+    (
+        "labeled dollar-quoted body",
+        "create function f() returns int as $body$ select 1; $body$; select 2",
+        ["create function f() returns int as $body$ select 1; $body$;", "select 2"],
+    ),
+    (
+        "differently labeled delimiter inside a body",
+        "create function f() as $a$ select 1; $b$ 2; $a$; select 3",
+        ["create function f() as $a$ select 1; $b$ 2; $a$;", "select 3"],
+    ),
+    (
+        "two dollar-quoted bodies",
+        "create function f() as $$ a; $$; create function g() as $$ b; $$;",
+        ["create function f() as $$ a; $$;", "create function g() as $$ b; $$;"],
+    ),
+    (
+        "unmatched dollar-quote delimiter",
+        "select $tag$; select 2",
+        ["select $tag$;", "select 2"],
+    ),
+    (
+        "dollar-quote tag in a string literal",
+        "select '$$'; select 2",
+        ["select '$$';", "select 2"],
+    ),
+    (
+        "dollar-quote tag in a comment",
+        "select 1 -- $$ ; select 2",
+        ["select 1 -- $$ ; select 2"],
+    ),
+    (
+        "dollar-quoted literal in an expression",
+        "select $$a;b$$; select 2",
+        ["select $$a;b$$;", "select 2"],
+    ),
+    (
+        "transaction",
+        "begin; select 1; commit;",
+        ["begin;", "select 1;", "commit;"],
+    ),
+    (
+        "multiline dollar-quoted body",
+        "create function f() as $$\n select 1;\n$$;\nselect 2",
+        ["create function f() as $$\n select 1;\n$$;", "select 2"],
+    ),
+    (
+        "non-ascii inside a dollar-quoted body",
+        "create function f() as $$ select 'café'; $$; select 2",
+        ["create function f() as $$ select 'café'; $$;", "select 2"],
+    ),
+    (
+        "multiline dollar-quoted body with non-ascii",
+        "create function f() as $$\n select 'café';\n$$;\nselect 2",
+        ["create function f() as $$\n select 'café';\n$$;", "select 2"],
+    ),
 ]
 
 
@@ -167,17 +236,22 @@ def test_statements_are_indexed_in_order() -> None:
     assert [s.index for s in statements] == [0, 1, 2]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "https://github.com/tconbeer/harlequin/issues/1019 -- the grammar "
-        "splits inside a dollar-quoted body. The Query Editor has the same bug, "
-        "for the same reason: it is the grammar's, not ours."
-    ),
-    strict=True,
-)
 def test_dollar_quoted_body_is_not_split() -> None:
+    """Regression test for #1019: a semicolon inside `$$ ... $$` is body content."""
     script = "create function f() as $$ select 1; $$; select 2"
     assert split(script) == [
         Statement(sql="create function f() as $$ select 1; $$;", index=0),
         Statement(sql="select 2", index=1),
     ]
+
+
+def test_find_separators_after_dollar_quoted_body() -> None:
+    """The separator after a dollar-quoted body is still a character column.
+
+    The fix pairs the body's delimiters on byte offsets, and a multiline body
+    puts non-ASCII before the separator that ends the statement -- so the
+    (row, col) point must come out of the same character conversion as any
+    other separator, not off by one per extra byte.
+    """
+    script = "create function f() as $$\n select 'café';\n$$;\nselect 2"
+    assert find_separators(script) == [(2, 3)]


### PR DESCRIPTION
Closes #1019 (an existing open issue)

This fixes statement splitting inside dollar-quoted function bodies. Semicolons inside `$$ ... $$` were being treated as query separators, which caused one function definition to be split into multiple invalid statements.

**What** are the key elements of this solution?

The splitter now captures dollar-quote delimiters along with semicolons. It pairs matching delimiters and ignores semicolons found inside the quoted body.

The Query Editor and scripts share the same splitter, so the fix applies to both. Tests cover the original issue, labeled delimiters, delimiter boundary cases, unmatched delimiters, multiple bodies, Unicode text, and the Query Editor path.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Using the delimiters reported by tree-sitter avoids adding a separate SQL lexer just for dollar quoting. This also keeps the existing handling of strings, comments, and quoted identifiers unchanged.

Unmatched delimiters do not hide any semicolons, so invalid or incomplete SQL keeps its existing recovery behaviour. The change is limited to dollar-quoted bodies. Other function body formats are unchanged.

Does this PR require a change to Harlequin's docs?

* [x] No.
* [ ] Yes, and I have opened a PR at https://github.com/tconbeer/harlequin-web.
* [ ] Yes, but I have not opened a PR yet. The required change is: ...

Did you add or update tests for this change?

* [x] Yes.
* [ ] No, I believe tests are not necessary.
* [ ] No, I need help with testing this change.

Please complete the following checklist:

* [x] I have added an entry to `CHANGELOG.md` under the `[Unreleased]` section. That entry references the issue closed by this PR.
* [x] I acknowledge Harlequin's MIT license. I do not own my contribution.