### PR TITLE
Bump textual-fastdatatable to 0.19.1 to fix UUID column crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Harlequin no longer crashes when a query returns a UUID column (or another Arrow extension type), like a Postgres `uuid` ([tconbeer/textual-fastdatatable#176](https://github.com/tconbeer/textual-fastdatatable/issues/176)).
+
 ## [2.12.1] - 2026-08-30
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     # textual and component libraries
     "textual==8.2.8",
-    "textual-fastdatatable==0.19.0",
+    "textual-fastdatatable==0.19.1",
     "textual-textarea==0.18.1",
 
     # click

--- a/uv.lock
+++ b/uv.lock
@@ -1413,7 +1413,7 @@ requires-dist = [
     { name = "rich-click", specifier = "==1.9.8" },
     { name = "shandy-sqlfmt", specifier = ">=0.28.2" },
     { name = "textual", specifier = "==8.2.8" },
-    { name = "textual-fastdatatable", specifier = "==0.19.0" },
+    { name = "textual-fastdatatable", specifier = "==0.19.1" },
     { name = "textual-textarea", specifier = "==0.18.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "tomlkit", specifier = ">=0.15.1,<0.16.0" },
@@ -3843,7 +3843,7 @@ wheels = [
 
 [[package]]
 name = "textual-fastdatatable"
-version = "0.19.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -3852,9 +3852,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/a4/e3f2834ed4393afda3b66a4a8133e1b42e1269dd547d5f2064818d814273/textual_fastdatatable-0.19.0.tar.gz", hash = "sha256:c9ffa17978e68886be3462c980fece81d21a5d0d5957d9eef2e5c6dae649606f", size = 46345, upload-time = "2026-08-20T04:13:55.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7b/79a2c566bf0a7e087c2b29738fdec807d2457b3553bf44b8fa034bfa1f1e/textual_fastdatatable-0.19.1.tar.gz", hash = "sha256:c546de625c193b21431140c3e312c12d8cfdbefb61a5c9550b3dde7715c1d7a9", size = 48547, upload-time = "2026-08-31T20:25:46.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/e8/0d6ed7f40908ff0ca53651e5617861bf7bebadfb526030c9735f3e0c410f/textual_fastdatatable-0.19.0-py3-none-any.whl", hash = "sha256:1ba54ca17de1d03ded54e8ab92ba6e2aa07c4d9765006bad1deba3923a38618d", size = 43348, upload-time = "2026-08-20T04:13:54.314Z" },
+    { url = "https://files.pythonhosted.org/packages/78/70/04137f5a99729571075762432a15ce2c6149d3888d1a67f6adfe551c7f84/textual_fastdatatable-0.19.1-py3-none-any.whl", hash = "sha256:a5d610dc8814435b165bdadf7ac12d5f92df32dd24bffb61a7bd85deb560d07b", size = 45399, upload-time = "2026-08-31T20:25:45.094Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes [tconbeer/textual-fastdatatable#176](https://github.com/tconbeer/textual-fastdatatable/issues/176). There is no open Harlequin issue for this one; the bug and its fix both live upstream.

**What** are the key elements of this solution?

This PR updates the `textual-fastdatatable` dependency from 0.19.0 to 0.19.1, which includes a fix for crashes when rendering queries that return UUID columns or other Arrow extension types (e.g., Postgres `uuid`). The fix is implemented upstream in the textual-fastdatatable library.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The root cause of the crash was in the textual-fastdatatable library's handling of Arrow extension types: `_measure_cells()` cast an extension array to string and decoded its raw storage bytes as UTF-8, so a 16-byte UUID raised `UnicodeDecodeError` while measuring column widths. Rather than implementing a workaround in Harlequin, the appropriate solution was to bump the dependency to the patched version that properly handles these types.

Verified both directions: against 0.19.0, `create_backend()` on a table with a `pa.uuid()` column raises `UnicodeDecodeError` from `_measure_cells`; against 0.19.1 the same table measures as 36 cells and the value round-trips as a `UUID`.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] No, I believe tests aren't necessary.

The fix is in an upstream dependency and is covered by that library's test suite. The full suite passes here with no snapshot churn (1319 passed, 6 skipped, 148 snapshots passed).

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the upstream issue fixed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

https://claude.ai/code/session_01DG91vH9iBH5NckhdVzXDe7