### PR TITLE
Update all non-major dependencies, and keep hsql's generated documents right under click 8.5

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
 
       - name: Name this release, and the branch that carries it
         id: release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
 
       - name: Get harlequin Version
         id: harlequin_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
 
       - name: Create release branch
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -61,7 +61,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
           python-version: ${{ matrix.py }}
 
       - name: Ensure package can be built

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: "0.12.5"
+          version: "0.12.8"
           python-version: ${{ matrix.py }}
           enable-cache: true
 

--- a/docs/plans/hsql-warm-sessions-design.md
+++ b/docs/plans/hsql-warm-sessions-design.md
@@ -360,7 +360,7 @@ side.
 
 The response is three things: **stdout bytes, stderr bytes, exit code.** The server runs
 `harlequin.query` and `hsql.output` exactly as the cold path does, writing into a buffer
-instead of `click.get_binary_stream("stdout")`, and the client copies that buffer to its own
+instead of `click.open_file("-", mode="wb")`, and the client copies that buffer to its own
 stdout and exits with the code.
 
 This is the decision that makes the feature safe. It means:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "textual-textarea==0.18.1",
 
     # click
-    "click==8.4.2",
+    "click==8.5.0",
     # 1.9 is the first release compatible with click 8.2's Parameter.make_metavar()
     "rich-click==1.9.8",
 
@@ -76,7 +76,7 @@ dependencies = [
 
 [project.optional-dependencies]
 
-s3 = ["boto3==1.43.72"]
+s3 = ["boto3==1.43.85"]
 postgres = ["harlequin-postgres"]
 mysql = ["harlequin-mysql"]
 odbc = ["harlequin-odbc"]
@@ -111,7 +111,7 @@ test = [
     "pytest-asyncio==1.4.0",
     "pytest-xdist>=3.6",
     "pytest-textual-snapshot @ git+https://github.com/tconbeer/pytest-textual-snapshot.git@a2c6763b45283f76757a123342900accefcf04e8",
-    "boto3==1.43.72",
+    "boto3==1.43.85",
     # extension tests require consistent version of duckdb.
     "duckdb==1.5.5",
     "flaky>=3.8.1",

--- a/src/harlequin/config_schema.py
+++ b/src/harlequin/config_schema.py
@@ -284,7 +284,9 @@ def _from_parameter(param: click.Parameter) -> dict[str, Any]:
     description = getattr(param, "help", None) or DESCRIPTIONS.get(str(param.name))
     if description is not None:
         schema["description"] = description
-    default = param.default
+    # `to_info_dict()` rather than `default`, because click derives a flag's
+    # default rather than storing one, and that is the method that resolves it
+    default = param.to_info_dict()["default"]
     if isinstance(default, (str, int, float, bool)):
         # anything else is click's sentinel for a parameter declared without a
         # default, or a callable one that would read the environment

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -47,6 +47,7 @@ from typing import (
     Mapping,
     Sequence,
     TypeVar,
+    cast,
 )
 
 import click
@@ -1703,7 +1704,9 @@ def _read_statements(
             if kind == "command":
                 text = value
             elif value == "-":
-                text = click.get_text_stream("stdin").read()
+                # `-` is stdin, decoded the way click decodes it, so a stream
+                # the environment has misconfigured still reads as text
+                text = click.open_file("-", mode="r").read()
             else:
                 text = Path(value).expanduser().read_text(encoding="utf-8")
             for statement in split(text):
@@ -1859,7 +1862,8 @@ def _sink(
     """
     path = destination.file(filename)
     if path is None:
-        yield click.get_binary_stream("stdout")
+        # `-` is stdout, wrapped so that closing the stream is not on the table
+        yield cast(BinaryIO, click.open_file("-", mode="wb"))
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("wb") as f:

--- a/src/harlequin/hsql/modes/spec.py
+++ b/src/harlequin/hsql/modes/spec.py
@@ -130,7 +130,9 @@ def command_document(command: click.Command) -> dict[str, Any]:
     # `get_params` rather than `params`, because click keeps `--help` out of the
     # latter and adds it at parse time -- and a caller reading this to learn the
     # surface should be told about the flag that would have shown it to them
-    params = command.get_params(click.Context(command, info_name="hsql"))
+    ctx = click.Context(command, info_name="hsql")
+    params = command.get_params(ctx)
+    help_option = command.get_help_option(ctx)
     return {
         "arguments": [
             _from_argument(param)
@@ -139,13 +141,24 @@ def command_document(command: click.Command) -> dict[str, Any]:
         ],
         "options": sorted(
             (
-                _from_parameter(param)
+                _from_parameter(param, name=_name_of(param, help_option))
                 for param in params
                 if not isinstance(param, click.Argument)
             ),
             key=lambda entry: str(entry["name"]),
         ),
     }
+
+
+def _name_of(param: click.Parameter, help_option: click.Option | None) -> str:
+    """What a caller calls a parameter, which for `--help` is `help`.
+
+    click stores the help flag's value under a reserved name of its own, so that
+    a command may declare a parameter called `help`. hsql does not, and a
+    document that named the flag anything but `help` would be reporting click's
+    bookkeeping rather than the CLI.
+    """
+    return "help" if param is help_option else str(param.name)
 
 
 def _hsql_command() -> click.Command:
@@ -255,10 +268,10 @@ def _from_option(
     }
 
 
-def _from_parameter(param: click.Parameter) -> dict[str, Any]:
+def _from_parameter(param: click.Parameter, *, name: str) -> dict[str, Any]:
     """One of hsql's own options, as click holds it."""
     return {
-        "name": param.name,
+        "name": name,
         "decls": [*param.opts, *param.secondary_opts],
         "type": TYPES.get(param.type.name, param.type.name),
         "metavar": param.metavar,
@@ -300,8 +313,12 @@ def _default(param: click.Parameter) -> Any:
     declared without a default, a callable default (calling it here could read
     the environment, and a spec that varied with it is one nobody could cache),
     and anything else JSON has no room for.
+
+    Through `to_info_dict()` because click derives a flag's default rather than
+    storing one, and that is the method that resolves it -- to the `false` a
+    flag reads here.
     """
-    default = param.default
+    default = param.to_info_dict()["default"]
     if default is None or isinstance(default, (str, int, float, bool)):
         return default
     if isinstance(default, (list, tuple)):

--- a/uv.lock
+++ b/uv.lock
@@ -307,16 +307,16 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.72"
+version = "1.43.85"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/cc/f22093524c3b38e94ba2d0e6743d7e264f7190d149c8dceaf9603822c595/boto3-1.43.72.tar.gz", hash = "sha256:6280ce03cc85e9110fd9fb7e2fbf11eae0b1177cb041a0d69aa88edc9d178cf9", size = 112688, upload-time = "2026-08-14T19:24:53.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/db/adb561589806195a40e6f5015c884981595eed85ff43a887122165ffd3f4/boto3-1.43.85.tar.gz", hash = "sha256:113b6e1aa3f5722f90c01fc63968c269a9b1fd03ac2594fe16c56a66e6331c5f", size = 112656, upload-time = "2026-08-31T23:23:53.701Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/b7/fa7b827ce0fc9bd697381e40f59d69a74c6ab553e246271685ec0acc75b2/boto3-1.43.72-py3-none-any.whl", hash = "sha256:f1bbbad5ed8d8a8c64edb0cd092dc443c95a85623b2ac88b6f6d633717605f00", size = 140025, upload-time = "2026-08-14T19:24:52.013Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/57/a58073f8659d7673b0b629987ab4295b56f44759c1b1f79b3c87330e452a/boto3-1.43.85-py3-none-any.whl", hash = "sha256:f11bdaca18e59f53ec0529f4d6203dd1f0bb7ff165e51559d62fd863024abc9b", size = 140028, upload-time = "2026-08-31T23:23:52.275Z" },
 ]
 
 [[package]]
@@ -335,16 +335,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.43.72"
+version = "1.43.85"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/99/a8cfeaea98d5085a493af909d09d174466482235a7fda291be18c9a5a76e/botocore-1.43.72.tar.gz", hash = "sha256:1b878c69081e8e9d55aa4c0d85683e7b07f0e274a5554662f9507a46641be3d2", size = 15949280, upload-time = "2026-08-14T19:24:48.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/93/a8b3acb06fcbb440704f195dbf14d12bb83c9c9d67b2e699076017f3d5c6/botocore-1.43.85.tar.gz", hash = "sha256:8fc0a3c56078c629320b021edadf7a45d289eea21a4988ada6a02277e5bbbdc0", size = 16040188, upload-time = "2026-08-31T23:23:48.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/27/35814fd8701a6b8be0aa47a7fcbd1ea0706189410a47d71ff29ddcc3ad4d/botocore-1.43.72-py3-none-any.whl", hash = "sha256:de5a1bcf8d7602c6cefc15016f15dad82981e339192531f31fa9483e11feea47", size = 15641880, upload-time = "2026-08-14T19:24:45.882Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4b/bb053aec2a9902df4cdbf9301dd5a41dd197c1cef0c085a32f5d04eeb3e3/botocore-1.43.85-py3-none-any.whl", hash = "sha256:685510e5f4c0f321806c815a60f121a176c0969665f053c4a336209cbe62b1d5", size = 15732946, upload-time = "2026-08-31T23:23:45.927Z" },
 ]
 
 [[package]]
@@ -613,14 +613,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -1393,8 +1390,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", marker = "extra == 's3'", specifier = "==1.43.72" },
-    { name = "click", specifier = "==8.4.2" },
+    { name = "boto3", marker = "extra == 's3'", specifier = "==1.43.85" },
+    { name = "click", specifier = "==8.5.0" },
     { name = "duckdb", marker = "python_full_version < '3.14'", specifier = ">=1.1.1" },
     { name = "duckdb", marker = "python_full_version >= '3.14'", specifier = ">=1.4.2" },
     { name = "harlequin-adbc", marker = "extra == 'adbc'" },
@@ -1440,7 +1437,7 @@ static = [
     { name = "types-pyyaml", specifier = ">=6" },
 ]
 test = [
-    { name = "boto3", specifier = "==1.43.72" },
+    { name = "boto3", specifier = "==1.43.85" },
     { name = "duckdb", specifier = "==1.5.5" },
     { name = "flaky", specifier = ">=3.8.1" },
     { name = "jsonschema", specifier = ">=4.20" },


### PR DESCRIPTION
Supersedes #1098: Renovate's dependency bump, plus the compatibility fix that makes it pass CI.

**What** are the key elements of this solution?

The first commit is #1098 verbatim (uv 0.12.5 → 0.12.8, boto3 1.43.72 → 1.43.85, click 8.4.2 → 8.5.0). The second fixes the three things click 8.5.0 changes under hsql:

- **The help flag now has a reserved storage name.** click stores `--help` under `_click_default_help` so a command may declare its own `help` parameter. `hsql --spec` and `docs/generated/hsql-reference.md` report `param.name` verbatim, so the document grew an option called `_click_default_help` and the reference re-sorted around it. `spec.command_document()` now asks click which parameter is the help option and names that one `help`.
- **A flag's default is derived lazily.** `Option.default` holds an unset sentinel until it is resolved, so every flag's `default` came out `null` in `--spec` and `"default": false` vanished from the packaged `schemas/config-v1.json`. Both generators read the default through `param.to_info_dict()`, which is the method that resolves it.
- **`get_binary_stream` and `get_text_stream` are deprecated**, and reached through a module `__getattr__` typed `-> object`, which is what Static Analysis reported as `"object" not callable`. Both call sites use `click.open_file("-")` instead.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The two generated artifacts are byte-identical to what is committed, which is the point: this restores the documents rather than re-baselining them, and `--spec` keeps reporting the CLI a caller types rather than click's bookkeeping.

`to_info_dict()` over reading click's sentinel directly, because the sentinel is private and the method is the documented introspection API — it is what resolves a derived default, and it answers the same for a version that stores one. Likewise `get_help_option()` over matching the reserved name as a string: an identity check does not go stale when click renames it again.

`click.open_file("-", mode=...)` over `sys.stdin` / `sys.stdout.buffer`, because it delegates to the same compat machinery the deprecated helpers did. Reaching for the plain streams would have dropped click's handling of a Windows console and of a stream a `C` locale has misconfigured — a real difference for SQL read from stdin.

The fix commit is version-agnostic: the whole suite and mypy pass under click 8.4.2 as well as 8.5.0, so it can be cherry-picked onto `main` on its own and #1098 rebased into the green instead, if you would rather Renovate keep its PR.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] No, I believe tests aren't necessary. The four tests that caught this already exist and pin exactly what regressed: `test_spec_lists_the_flag_that_would_have_shown_the_help`, `test_spec_reports_every_spelling_of_an_option`, and the two that regenerate the committed reference and schema and compare.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. — no entry: hsql's output is byte-identical before and after, so there is nothing user-facing here.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

Verified on 3.10 with click 8.5.0: `ruff format`/`check`, `mypy`, `lint-imports`, `pytest -m 'not online'` (1319 passed), and the py12 run. The same suite and mypy pass with click pinned back to 8.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1eUM7tyL8tBcs5FfWMNsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1eUM7tyL8tBcs5FfWMNsg)_