### PR TITLE
fix: config wizard no longer prefills bad defaults (#1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).
+
 ## [2.12.2] - 2026-08-31
 
 ### Bug Fixes

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -98,15 +98,14 @@ def _wizard(config_path: Path | None) -> None:
 
     # two questions, because they are two limits: what leaves the database,
     # and what the Results Viewer holds of it.
-    limit = int(
-        questionary.text(
-            message="How many rows should each query fetch from the database?",
-            instruction="Enter -1 for no limit.",
-            validate=_validate_int,
-            default=str(selected_profile.get("limit", -1)),
-            style=HARLEQUIN_QUESTIONARY_STYLE,
-        ).unsafe_ask()
-    )
+    raw_limit = questionary.text(
+        message="How many rows should each query fetch from the database?",
+        instruction="Leave blank for app defaults; enter -1 for no limit.",
+        validate=_validate_int_or_blank,
+        default=str(selected_profile.get("limit", "")),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+    limit = None if raw_limit == "" else int(raw_limit)
 
     viewer_max_rows = int(
         questionary.text(
@@ -183,7 +182,7 @@ def _wizard(config_path: Path | None) -> None:
         "keymap_name": keymap_name,
     }
 
-    if limit >= 0:
+    if limit is not None and limit >= 0:
         # only when there is one: an unlimited fetch is the default, and a key
         # that says so is a line the reader has to work out the meaning of.
         new_profile["limit"] = limit
@@ -272,11 +271,14 @@ def _prompt_to_set_adapter_options(
             if option.name not in which:
                 continue
             value = option.to_questionary(
-                selected_profile.get(sluggify_option_name(option.name), None)
+                selected_profile.get(sluggify_option_name(option.name))
             ).unsafe_ask()
+            # A blank answer is not a value; False can be an explicit flag value.
+            if value == "":
+                continue
             if isinstance(option, ListOption):
                 value = value.split(" ")
-            adapter_options.update({sluggify_option_name(option.name): value})
+            adapter_options[sluggify_option_name(option.name)] = value
 
 
 def _prompt_to_set_default_profile(
@@ -350,6 +352,11 @@ def _validate_int(raw: str) -> bool:
         return False
     else:
         return True
+
+
+def _validate_int_or_blank(raw: str) -> bool:
+    """The limit prompt accepts blank, which means the app's default."""
+    return not raw or _validate_int(raw)
 
 
 def _validate_dir_or_blank(raw: str) -> bool:

--- a/src/harlequin/options.py
+++ b/src/harlequin/options.py
@@ -31,6 +31,16 @@ def concatenate(first: str, second: str) -> str:
     return f"{first}\n----or----\n{second}"
 
 
+def _stringify_or_none(existing_value: Any) -> str | None:
+    """Stringify an existing prompt value without turning `None` into text."""
+    if existing_value is None:
+        return None
+    try:
+        return str(existing_value)
+    except (ValueError, TypeError):
+        return None
+
+
 def _derived_type_name(cls: type) -> str:
     """A type name for an option class that never declared one.
 
@@ -278,10 +288,7 @@ class TextOption(AbstractOption):
             else:
                 return True
 
-        try:
-            safe_existing_value = str(existing_value)
-        except (ValueError, TypeError):
-            safe_existing_value = None
+        safe_existing_value = _stringify_or_none(existing_value)
 
         # do not echo secrets in questionary prompt
         ask = questionary.password if self.secret else questionary.text
@@ -517,10 +524,7 @@ class PathOption(AbstractOption):
 
             return True
 
-        try:
-            safe_existing_value = str(existing_value)
-        except (ValueError, TypeError):
-            safe_existing_value = None
+        safe_existing_value = _stringify_or_none(existing_value)
 
         if self.secret:
             # do not echo secrets in questionary prompt
@@ -643,10 +647,7 @@ class SelectOption(AbstractOption):
 
         from harlequin.colors import HARLEQUIN_QUESTIONARY_STYLE
 
-        try:
-            safe_existing_value = str(existing_value)
-        except (ValueError, TypeError):
-            safe_existing_value = None
+        safe_existing_value = _stringify_or_none(existing_value)
 
         if safe_existing_value not in self._flat_choices():
             safe_existing_value = None

--- a/tests/unit_tests/test_config_wizard.py
+++ b/tests/unit_tests/test_config_wizard.py
@@ -8,6 +8,7 @@ import pytest
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection
 from harlequin.config import load_config, load_profile
 from harlequin.config_wizard import _wizard
+from harlequin.options import FlagOption
 
 
 class FakePrompt:
@@ -30,13 +31,18 @@ def run_wizard(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
     Answers are keyed by a substring of the prompt's message; a prompt no test
     answers takes what the wizard offered it -- the value already in the
     profile, or the first choice -- so a test names only the prompts it is about.
+    An optional `record` list collects every prompt's (message, kwargs).
     """
     import questionary
 
     def fake(
-        answers: dict[str, Any], fallback: Callable[..., Any]
+        answers: dict[str, Any],
+        fallback: Callable[..., Any],
+        record: list[tuple[str, dict[str, Any]]] | None,
     ) -> Callable[..., Any]:
         def prompt(message: str = "", **kwargs: Any) -> FakePrompt:
+            if record is not None:
+                record.append((message, kwargs))
             for substring, answer in answers.items():
                 if substring in message:
                     return FakePrompt(answer)
@@ -58,7 +64,11 @@ def run_wizard(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
         # confirm that offers none means yes, as questionary's does
         return bool(default)
 
-    def run(config_path: Path, answers: dict[str, Any]) -> None:
+    def run(
+        config_path: Path,
+        answers: dict[str, Any],
+        record: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> None:
         fallbacks: tuple[tuple[str, Callable[..., Any]], ...] = (
             ("select", first_choice),
             ("text", the_default),
@@ -69,7 +79,7 @@ def run_wizard(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
             ("confirm", yes),
         )
         for name, fallback in fallbacks:
-            monkeypatch.setattr(questionary, name, fake(answers, fallback))
+            monkeypatch.setattr(questionary, name, fake(answers, fallback, record))
         _wizard(config_path=config_path)
 
     return run
@@ -329,3 +339,216 @@ class TestProfileWrite:
         }
         assert "two" in config.profiles
         assert config.default_profile == "one"
+
+
+class TestDefaults:
+    """Prompts that offered a value the user did not ask for (#1105).
+
+    The wizard's job is to write what a user typed, not to guess: a fresh
+    profile gets no `limit`, and an adapter option that stays blank (or gets
+    cleared) is not written at all.
+    """
+
+    def test_a_fresh_profile_is_not_given_a_limit(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(path, {"Which profile would you like to update?": "one"})
+
+        assert "limit" not in load_config(config_path=path).profiles["one"]
+
+    def test_an_existing_limit_is_offered_and_kept(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\nlimit = 500\n')
+
+        run_wizard(path, {"Which profile would you like to update?": "one"})
+
+        assert load_config(config_path=path).profiles["one"]["limit"] == 500
+
+    def test_blank_removes_an_existing_limit(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\nlimit = 500\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "How many rows should each query fetch": "",
+            },
+        )
+
+        assert "limit" not in load_config(config_path=path).profiles["one"]
+
+    def test_a_typed_limit_is_written(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "How many rows should each query fetch": "1000",
+            },
+        )
+
+        assert load_config(config_path=path).profiles["one"]["limit"] == 1000
+
+    def test_minus_one_is_accepted_and_omitted(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """`-1` still means no limit, which is the app default: no key."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "How many rows should each query fetch": "-1",
+            },
+        )
+
+        assert "limit" not in load_config(config_path=path).profiles["one"]
+
+    def test_the_limit_prompt_offers_blank_and_says_so(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+        record: list[tuple[str, dict[str, Any]]] = []
+
+        run_wizard(
+            path, {"Which profile would you like to update?": "one"}, record=record
+        )
+
+        limit_prompt = next(
+            kwargs
+            for message, kwargs in record
+            if "How many rows should each query fetch" in message
+        )
+        assert limit_prompt["default"] == ""
+        assert (
+            limit_prompt["instruction"]
+            == "Leave blank for app defaults; enter -1 for no limit."
+        )
+        validate = limit_prompt["validate"]
+        assert validate("") is True
+        assert validate("1000") is True
+        assert validate("abc") is False
+
+    def test_a_blank_secret_option_is_not_written(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """The `****` a secret's `None` used to be shown as never reaches the file."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "adapter options": ["md_token"],
+                "md_token": "",
+            },
+        )
+
+        assert "md_token" not in load_config(config_path=path).profiles["one"]
+
+    def test_a_blank_text_option_is_not_written(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "adapter options": ["custom-extension-repo"],
+                "custom-extension-repo": "",
+            },
+        )
+
+        assert (
+            "custom_extension_repo" not in load_config(config_path=path).profiles["one"]
+        )
+
+    def test_a_blank_list_option_is_not_written(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """Blank must not become a list that holds one empty item."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "adapter options": ["extension"],
+                "extension": "",
+            },
+        )
+
+        assert "extension" not in load_config(config_path=path).profiles["one"]
+
+    def test_blank_clears_an_existing_adapter_option(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "duckdb"\nmd_token = "hunter2"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "adapter options": ["md_token"],
+                "md_token": "",
+            },
+        )
+
+        assert "md_token" not in load_config(config_path=path).profiles["one"]
+
+    def test_an_explicit_false_on_a_flag_is_written(
+        self,
+        tmp_path: Path,
+        run_wizard: Callable[..., None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A flag whose declared default is true needs `false` stored to override it."""
+
+        class FakeAdapter(HarlequinAdapter):
+            ADAPTER_OPTIONS = [
+                FlagOption(name="legacy-mode", description="x", default=True)
+            ]
+
+            def __init__(self, conn_str: Sequence[str], **options: Any) -> None:
+                raise NotImplementedError
+
+            def connect(self) -> HarlequinConnection:
+                raise NotImplementedError
+
+        monkeypatch.setattr(
+            "harlequin.config_wizard.load_adapter_plugins",
+            lambda: {"fake": FakeAdapter},
+        )
+        path = tmp_path / ".harlequin.toml"
+        path.write_text('[profiles.one]\nadapter = "fake"\n')
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "adapter options": ["legacy-mode"],
+                "legacy-mode": False,
+            },
+        )
+
+        assert load_config(config_path=path).profiles["one"]["legacy_mode"] is False

--- a/tests/unit_tests/test_options.py
+++ b/tests/unit_tests/test_options.py
@@ -307,6 +307,28 @@ def _no_terminal() -> Iterator[None]:
             yield
 
 
+@contextmanager
+def _capture_prompt(
+    monkeypatch: pytest.MonkeyPatch, kind: str
+) -> Iterator[dict[str, Any]]:
+    """Capture the kwargs of one questionary prompt kind, without a terminal.
+
+    `to_questionary()` imports questionary when it is called, which resolves to
+    the same module object -- so patching the attribute on the real module is
+    enough, and no prompt session is ever built.
+    """
+    import questionary
+
+    captured: dict[str, Any] = {}
+
+    def fake_prompt(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(questionary, kind, fake_prompt)
+    yield captured
+
+
 def _masks_input(question: Any) -> bool:
     """Whether this prompt would show what is typed into it.
 
@@ -323,3 +345,72 @@ def _masks_input(question: Any) -> bool:
         and processor.filter()
         for processor in control.input_processors
     )
+
+
+# --- `to_questionary()`: what the wizard's prompts offer ---------------------
+
+
+@pytest.mark.parametrize(
+    ("option", "prompt_kind"),
+    [
+        (TextOption(name="host", description="The host."), "text"),
+        (PathOption(name="init-path", description="A file."), "path"),
+    ],
+    ids=["text", "path"],
+)
+def test_an_unset_option_prompts_blank(
+    monkeypatch: pytest.MonkeyPatch,
+    option: AbstractOption,
+    prompt_kind: str,
+) -> None:
+    """A profile that never set the option is not offered the string "None".
+
+    The wizard passes `None` for an option the profile does not set, and
+    `str(None)` would pre-fill "None" -- a value the user would save as text.
+    """
+    with _capture_prompt(monkeypatch, prompt_kind) as captured:
+        option.to_questionary(None)
+    assert captured["default"] == ""
+
+
+def test_an_unset_secret_option_prompts_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The secret's default must be blank too: "None" renders as `****`."""
+    with _capture_prompt(monkeypatch, "password") as captured:
+        TextOption(name="token", description="A token.", secret=True).to_questionary(
+            None
+        )
+    assert captured["default"] == ""
+
+
+def test_an_unset_option_with_a_declared_default_offers_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset is not the same as blank for an option that declares a default."""
+    with _capture_prompt(monkeypatch, "text") as captured:
+        TextOption(
+            name="host", description="The host.", default="localhost"
+        ).to_questionary(None)
+    assert captured["default"] == "localhost"
+
+
+def test_an_unset_select_option_offers_its_declared_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _capture_prompt(monkeypatch, "select") as captured:
+        SelectOption(
+            name="mode", description="How.", choices=["ro", "rw"], default="ro"
+        ).to_questionary(None)
+    assert captured["default"] == "ro"
+
+
+def test_an_existing_value_is_still_offered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the profile already says is what the prompt offers."""
+    with _capture_prompt(monkeypatch, "text") as captured:
+        TextOption(name="host", description="The host.").to_questionary(
+            "db.example.com"
+        )
+    assert captured["default"] == "db.example.com"


### PR DESCRIPTION
The config wizard prefilled `-1` for an unset query limit and the literal string `"None"` for unset adapter options. For secrets, `"None"` appeared as `****` and could be written into the profile if accepted.

This change keeps unset values unset, while preserving declared defaults and existing profile values. The limit prompt now starts blank and explains how to use the app default or explicitly request no limit.

Closes #1105

**What** are the key elements of this solution?

* Treat `None` as an absent prompt value in `TextOption`, `PathOption`, and `SelectOption`, rather than converting it to the string `"None"`.
* Allow the query limit prompt to be left blank and omit the `limit` key in that case.
* Skip blank adapter-option answers when writing the profile, including clearing existing values.
* Compare blank answers with `value == ""` so an explicit `False` from a `FlagOption` is still written.
* Preserve declared option defaults and existing profile values.
* Add regression coverage for limit handling, text/path/select defaults, secrets, lists, cleared values, and explicit false flags.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The `"None"` value originated in Harlequin before questionary received it, so the conversion is fixed in the option classes rather than worked around in questionary or only in the wizard. A shared helper keeps the three affected option types consistent.

Blank answers are omitted at the wizard's write boundary so empty strings and `[""]` do not become configuration values. The check is intentionally limited to `""` a general truthiness check would incorrectly discard an explicit `False` from a flag option.

Existing values, declared defaults, `viewer_max_rows`, and non-wizard config paths are unchanged.

Does this PR require a change to Harlequin's docs?

* [x] No.
* [ ] Yes, and I have opened a PR at https://github.com/tconbeer/harlequin-web.
* [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?

* [x] Yes.
* [ ] No, I believe tests aren't necessary.
* [ ] No, I need help with testing this change.

Testing performed:

* 57 config-wizard and option unit tests passed.
* `mypy` passed.
* Ruff formatting and lint checks passed.
* Import-linter contracts passed.

Please complete the following checklist:

* [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
* [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
