### PR TITLE
feat: tooltip for truncated data catalog items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Data Catalog items that are too wide for the catalog now show their full name and type in a tooltip on hover ([#1104](https://github.com/tconbeer/harlequin/issues/1104)).
+
 ### Bug Fixes
 
 - The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).

--- a/src/harlequin/components/data_catalog/tree.py
+++ b/src/harlequin/components/data_catalog/tree.py
@@ -70,6 +70,28 @@ class HarlequinTree(Tree[TTreeNode], inherit_bindings=False):
         if self.cursor_line < 0:
             self.cursor_line = 0
 
+    def watch_hover_line(self, previous_hover_line: int, hover_line: int) -> None:
+        super().watch_hover_line(previous_hover_line, hover_line)
+        self.tooltip = self._tooltip_for_line(hover_line)
+
+    def _tooltip_for_line(self, line_index: int) -> str | None:
+        """The full label of the node on that line, if it doesn't fit in the tree.
+
+        A label that fits gets no tooltip, since the tooltip would only cover
+        the item it repeats.
+        """
+        tree_lines = self._tree_lines
+        if not 0 <= line_index < len(tree_lines):
+            return None
+        line = tree_lines[line_index]
+        rendered_width = self.get_label_width(line.node) + line._get_guide_width(
+            self.guide_depth, self.show_root
+        )
+        if rendered_width <= self.size.width:
+            return None
+        label = line.node.label
+        return label if isinstance(label, str) else label.plain
+
     async def on_click(self, event: Click) -> None:
         meta = event.style.meta
         click_line: Union[int, None] = meta.get("line", None)

--- a/src/harlequin/components/data_catalog/tree.py
+++ b/src/harlequin/components/data_catalog/tree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Generic, TypeVar, Union
 
+from rich.text import Text
 from textual.events import Click
 from textual.message import Message
 from textual.widgets import (
@@ -74,7 +75,7 @@ class HarlequinTree(Tree[TTreeNode], inherit_bindings=False):
         super().watch_hover_line(previous_hover_line, hover_line)
         self.tooltip = self._tooltip_for_line(hover_line)
 
-    def _tooltip_for_line(self, line_index: int) -> str | None:
+    def _tooltip_for_line(self, line_index: int) -> Text | None:
         """The full label of the node on that line, if it doesn't fit in the tree.
 
         A label that fits gets no tooltip, since the tooltip would only cover
@@ -89,8 +90,11 @@ class HarlequinTree(Tree[TTreeNode], inherit_bindings=False):
         )
         if rendered_width <= self.size.width:
             return None
+        # the Text, not its plain string: the tooltip renders the type label in
+        # the same muted color the tree does, and a str would be parsed as
+        # console markup -- a list column's type label is literally "[s]".
         label = line.node.label
-        return label if isinstance(label, str) else label.plain
+        return label if isinstance(label, Text) else Text(label)
 
     async def on_click(self, event: Click) -> None:
         meta = event.style.meta

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -12,9 +12,10 @@ from typing import (
 )
 from unittest.mock import MagicMock
 
+import duckdb
 import pytest
 from textual.geometry import Offset
-from textual.widgets import Input
+from textual.widgets import Input, Tooltip
 
 from harlequin import Harlequin
 from harlequin.catalog import CatalogItem, InteractiveCatalogItem
@@ -481,3 +482,47 @@ async def test_reload_while_loader_is_fetching(
             w for w in app.workers if w.name == "_database_tree_background_loader"
         ]
         assert not [w.error for w in loaders if w.error is not None]
+
+
+@pytest.mark.asyncio
+async def test_tooltip_shows_the_full_label_of_a_truncated_item(
+    duckdb_adapter: Type[DuckDbAdapter],
+    tmp_path: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    expand_catalog_node: Callable[..., Awaitable[None]],
+) -> None:
+    """A catalog item too wide for the catalog gets a tooltip on hover.
+
+    ([#1104](https://github.com/tconbeer/harlequin/issues/1104))
+    """
+    db_path = tmp_path / "tooltip.db"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("create table a_table_with_a_name_too_long_to_fit (a int)")
+    conn.close()
+
+    app = Harlequin(duckdb_adapter([str(db_path)], no_init=True), connection_hash="tt")
+    async with app.run_test(size=(120, 36), tooltips=True) as pilot:
+        await wait_for_workers(app)
+        tree = app.data_catalog.database_tree
+        while tree.loading or not tree.root.children:
+            await pilot.pause()
+        db_node = tree.root.children[0]
+        await expand_catalog_node(pilot, db_node)
+        await expand_catalog_node(pilot, db_node.children[0])
+        await pilot.pause()
+
+        # the db's own label fits in the catalog, so it gets no tooltip
+        await pilot.hover(app.data_catalog.__class__, offset=Offset(x=6, y=1))
+        await pilot.pause()
+        assert tree.hover_line == 0
+        assert tree.tooltip is None
+
+        # the table's does not, so hovering it shows the label and type label
+        await pilot.hover(app.data_catalog.__class__, offset=Offset(x=6, y=3))
+        await pilot.pause()
+        assert tree.hover_line == 2
+        assert tree.tooltip == "a_table_with_a_name_too_long_to_fit t"
+
+        tooltip = app.screen.get_child_by_type(Tooltip)
+        await pilot.pause(app.TOOLTIP_DELAY + 0.1)
+        assert tooltip.display

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock
 
 import duckdb
 import pytest
+from rich.style import Style
+from rich.text import Text
 from textual.geometry import Offset
 from textual.widgets import Input, Tooltip
 
@@ -497,7 +499,9 @@ async def test_tooltip_shows_the_full_label_of_a_truncated_item(
     """
     db_path = tmp_path / "tooltip.db"
     conn = duckdb.connect(str(db_path))
-    conn.execute("create table a_table_with_a_name_too_long_to_fit (a int)")
+    # the brackets are a type label's shape ("[s]" is a list of strings), so this
+    # name also pins that a label never reaches the tooltip as console markup
+    conn.execute('create table "a_table_[s]_with_a_name_too_long_to_fit" (a int)')
     conn.close()
 
     app = Harlequin(duckdb_adapter([str(db_path)], no_init=True), connection_hash="tt")
@@ -521,7 +525,14 @@ async def test_tooltip_shows_the_full_label_of_a_truncated_item(
         await pilot.hover(app.data_catalog.__class__, offset=Offset(x=6, y=3))
         await pilot.pause()
         assert tree.hover_line == 2
-        assert tree.tooltip == "a_table_with_a_name_too_long_to_fit t"
+        assert isinstance(tree.tooltip, Text)
+        assert tree.tooltip.plain == "a_table_[s]_with_a_name_too_long_to_fit t"
+
+        # and the type label keeps the muted color it has in the tree
+        type_label_span = tree.tooltip.spans[-1]
+        assert tree.tooltip.plain[type_label_span.start : type_label_span.end] == "t"
+        assert isinstance(type_label_span.style, Style)
+        assert type_label_span.style.color is not None
 
         tooltip = app.screen.get_child_by_type(Tooltip)
         await pilot.pause(app.TOOLTIP_DELAY + 0.1)


### PR DESCRIPTION
Closes #1104

**What** are the key elements of this solution?

- `HarlequinTree` watches `hover_line` and sets its own `tooltip` to the hovered node's full label. For the Database tree that is the label plus the type label — exactly the text the row renders — so a clipped `a_table_with_a_name_too_long_to_fit t` is readable without inserting it into the editor.
- The tooltip only appears when the item is actually clipped: the line's rendered width (label, expand icon and guide indent) is compared to the tree's visible width, and a label that fits gets no tooltip.
- It lives on the shared base class, so the Files and S3 trees get the same affordance for long file names and keys.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Gating on truncation follows what the Results Viewer already does for cell values (`_set_tooltip_from_cell_at` in textual-fastdatatable): a tooltip over a label that fits would only cover the text it repeats, and the hover would flicker as Textual hid and re-armed it.

`watch_hover_line` is the hook rather than a `MouseMove` handler because `hover_line` already carries Textual's line-under-the-mouse resolution, including the reset to `-1` on leave; the tooltip content is then read when Textual's tooltip timer fires, and the setter refreshes a tooltip that is already showing.

Measuring the line width uses `Tree.get_label_width()` plus the tree line's guide width, which is how `Tree` itself computes `virtual_size`, so the estimate cannot drift from what is rendered. That reaches for one private helper on `_TreeLine`; the alternative was to re-derive the indent from the node's depth here, which would be a second copy of the same arithmetic.

Nothing here belongs upstream: this is Harlequin's own catalog affordance, and the widths come from public `Tree` API.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`test_tooltip_shows_the_full_label_of_a_truncated_item` builds a one-table database whose table name cannot fit in the catalog, hovers the database node (fits, so no tooltip) and the table node (label and type label), and waits out `TOOLTIP_DELAY` to assert the `Tooltip` widget actually displays. It fails on `main`.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbStkADWTio4u6xJ8vpKDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbStkADWTio4u6xJ8vpKDt)_