### PR TITLE
fix: don't crash when opening a file that isn't text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).
-- Harlequin no longer crashes when you open a file that isn't text (a database file, say) with <kbd>ctrl+o</kbd>; it shows an error instead ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
-- `hsql -f` now reports an error when handed a file that isn't UTF-8 text (a database file, say), instead of crashing ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
-
-### Dependencies
-
-- Bumps textual-textarea to 0.18.2.
+- Harlequin and hsql no longer crash when trying to open a file that isn't text ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
 
 ## [2.12.2] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).
+- Harlequin no longer crashes when you open a file that isn't text (a database file, say) with <kbd>ctrl+o</kbd>; it shows an error instead ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
 - `hsql -f` now reports an error when handed a file that isn't UTF-8 text (a database file, say), instead of crashing ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
+
+### Dependencies
+
+- Bumps textual-textarea to 0.18.2.
 
 ## [2.12.2] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).
+- `hsql -f` now reports an error when handed a file that isn't UTF-8 text (a database file, say), instead of crashing ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
 
 ## [2.12.2] - 2026-08-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # textual and component libraries
     "textual==8.2.8",
     "textual-fastdatatable==0.19.1",
-    "textual-textarea==0.18.1",
+    "textual-textarea==0.18.2",
 
     # click
     "click==8.5.0",

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -37,6 +37,7 @@ import os
 import sys
 import time
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -703,6 +704,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             statements = _read_statements(sources)
         except OSError as e:
             diagnostics.error(f"could not read {e.filename}: {e.strerror}")
+            ctx.exit(ExitCode.USAGE)
+        except HarlequinConfigError as e:
+            diagnostics.report_error(e)
             ctx.exit(ExitCode.USAGE)
 
         # after the usage checks above, so that a run with nothing to run says
@@ -1688,6 +1692,33 @@ def _record_source(
     return value
 
 
+def _read_source_text(value: str) -> str:
+    """The text of one `-f` source: a path, or `-` for stdin.
+
+    A source that isn't text decodes as far as its first bad byte and then
+    raises, which is a crash rather than a diagnostic unless it is caught here.
+
+    Raises: HarlequinConfigError if the source is not UTF-8 text, OSError if
+    the file cannot be read at all.
+    """
+    source: str
+    read: Callable[[], str]
+    if value == "-":
+        # `-` is stdin, decoded the way click decodes it, so a stream
+        # the environment has misconfigured still reads as text
+        source, read = "standard input", click.open_file("-", mode="r").read
+    else:
+        path = Path(value).expanduser()
+        source, read = str(path), partial(path.read_text, encoding="utf-8")
+    try:
+        return read()
+    except UnicodeDecodeError as e:
+        raise HarlequinConfigError(
+            f"could not read {source}: not UTF-8 text ({e.reason} at byte {e.start}).",
+            title="Harlequin could not read a SQL file.",
+        ) from e
+
+
 def _read_statements(
     sources: Sequence[tuple[str, tuple[str, ...]]],
 ) -> list[Statement]:
@@ -1695,20 +1726,16 @@ def _read_statements(
 
     Each source is split on its own, so two `-c` values are two statements
     whether or not either ends in a semicolon.
+
+    Raises: HarlequinConfigError if a file is not text, OSError if it cannot
+    be read at all.
     """
     from harlequin.statements import Statement, split
 
     statements: list[Statement] = []
     for kind, values in sources:
         for value in values:
-            if kind == "command":
-                text = value
-            elif value == "-":
-                # `-` is stdin, decoded the way click decodes it, so a stream
-                # the environment has misconfigured still reads as text
-                text = click.open_file("-", mode="r").read()
-            else:
-                text = Path(value).expanduser().read_text(encoding="utf-8")
+            text = value if kind == "command" else _read_source_text(value)
             for statement in split(text):
                 statements.append(Statement(sql=statement.sql, index=len(statements)))
     return statements

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -536,6 +536,24 @@ def test_a_missing_file_is_a_usage_error(hsql: Hsql, duck: list[str]) -> None:
     assert "could not read" in res.stderr
 
 
+def test_a_binary_file_is_a_usage_error(
+    hsql: Hsql, duck: list[str], tmp_path: Path
+) -> None:
+    """A file that isn't text says so, instead of raising a decode error."""
+    script = tmp_path / "database.db"
+    script.write_bytes(b"\xcd\xe3k.4,9\x97DUCK")
+    res = hsql(*duck, "-f", str(script))
+    assert res.exit_code == ExitCode.USAGE
+    assert "could not read" in res.stderr
+    assert "not UTF-8 text" in res.stderr
+
+
+def test_binary_stdin_is_a_usage_error(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "-f", "-", input=b"\xcd\xe3k.4,9\x97DUCK")
+    assert res.exit_code == ExitCode.USAGE
+    assert "could not read standard input" in res.stderr
+
+
 # --- writing to a file -------------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1411,7 +1411,7 @@ requires-dist = [
     { name = "shandy-sqlfmt", specifier = ">=0.28.2" },
     { name = "textual", specifier = "==8.2.8" },
     { name = "textual-fastdatatable", specifier = "==0.19.1" },
-    { name = "textual-textarea", specifier = "==0.18.1" },
+    { name = "textual-textarea", specifier = "==0.18.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "tomlkit", specifier = ">=0.15.1,<0.16.0" },
     { name = "tree-sitter", specifier = ">=0.25,<0.27" },
@@ -3872,15 +3872,15 @@ wheels = [
 
 [[package]]
 name = "textual-textarea"
-version = "0.18.1"
+version = "0.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyperclip" },
     { name = "textual", extra = ["syntax"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/e4/aa225ac619c07149b18864a240fd8cc6a710e8ffc01028bafa0059ace893/textual_textarea-0.18.1.tar.gz", hash = "sha256:9db53da7659883cd905e66eabae11943c5b2e3a7530873ff85ee35d4bc3d928d", size = 28902, upload-time = "2026-08-05T17:35:48.676Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/e8/061ba3d6861984e5377b08bbf6f55d06fe43623d5bb4b26e27239a0f3959/textual_textarea-0.18.2.tar.gz", hash = "sha256:55890c62e270dd6f4a8988e0cfc54120a05022eead82c665095dd2be14bf17a9", size = 28994, upload-time = "2026-09-01T21:47:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/79/b117fd8f78fffffad74a411e9c48883a69bb4dbd8dff720263ec6c9949ed/textual_textarea-0.18.1-py3-none-any.whl", hash = "sha256:a99c072ab38fe667b9486f099d3dae2a99a59ca1f2207c0c143d0d5015cffe8d", size = 27343, upload-time = "2026-08-05T17:35:47.53Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ea/780c6e700c84f5532ed0bc9e24865f9e23b8bbaa358f6c6c6c9620589205/textual_textarea-0.18.2-py3-none-any.whl", hash = "sha256:d5e3952f8507972c73a8e830619174236a0bf725a5c6fe761812ba77f0bf2331", size = 27350, upload-time = "2026-09-01T21:47:48.367Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1108

**What** are the key elements of this solution?

The reported crash was one bug in two front ends. Opening a non-UTF-8 file decoded as far as its first bad byte and then raised `UnicodeDecodeError`, which neither front end caught.

- **The Query Editor (the issue as filed).** The crash was in `textual_textarea`'s `open_file`, which caught only `OSError`. Fixed upstream in tconbeer/textual-textarea#343 and picked up here by bumping the exact pin to 0.18.2. That change also widened `save_file`, which writes through the same locale codec and would fail symmetrically on a buffer the system encoding can't represent.
- **`hsql -f`.** The same file, read with `Path.read_text(encoding="utf-8")`, printed a raw traceback. `_read_source_text` now names the source that wouldn't decode, for a path and for `-`/stdin alike:

  ```
  hsql: error: could not read /path/database.db: not UTF-8 text (invalid continuation byte at byte 0).
  ```

  It exits `USAGE`, matching the existing `OSError` path, whose message shape is unchanged.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

Per `AGENTS.md`, the editor half belonged upstream rather than being worked around here — `CodeEditor` inherits `open_file` verbatim, so an override in this repo would have been a permanent tax on a problem one release away. The cost is the usual one: the fix needed a release and a pin bump before this repo saw it. No snapshot churn from the bump.

For `hsql`, the decode error is raised as a `HarlequinConfigError` carrying the source name, because `UnicodeDecodeError` has no `filename` to report and the existing handler formats `e.filename`/`e.strerror`. The alternative — attaching a `filename` attribute to the built-in exception — would have been opaque at the catch site.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

Two tests in `tests/unit_tests/test_hsql.py` cover a binary file and binary stdin; both reproduce the crash without the fix. The editor path is tested upstream, in the PR linked above — a copy here would be testing the dependency.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b4EBQtDX6nBWzXLJ8wxhr

---
_Generated by [Claude Code](https://claude.ai/code/session_011b4EBQtDX6nBWzXLJ8wxhr)_