### PR TITLE
SSH tunnels 1/5: the ssh child that holds a local forward open

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,7 @@ source_modules = [
     "harlequin.options",
     "harlequin.plugins",
     "harlequin.redact",
+    "harlequin.ssh",
     "harlequin.transaction_mode",
     "harlequin_duckdb",
     "harlequin_sqlite",

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -43,6 +43,12 @@ class HarlequinQueryError(HarlequinError):
     pass
 
 
+class HarlequinSshError(HarlequinError):
+    """An `ssh` child that would not start, or would not open its forwards."""
+
+    pass
+
+
 class HarlequinThemeError(HarlequinError):
     pass
 

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -339,7 +339,12 @@ class SshTunnel:
 
     def _child_failed(self) -> HarlequinSshError:
         assert self._process is not None
-        detail = self._stderr.text() if self._stderr is not None else ""
+        detail = ""
+        if self._stderr is not None:
+            # the child has exited, but what it wrote on the way out may still
+            # be in the pipe; an error that quotes ssh has to wait for it
+            self._stderr.settle()
+            detail = self._stderr.text()
         return HarlequinSshError(
             f"ssh exited with code {self._process.returncode} without opening "
             f"the forward.\n\n{detail}".rstrip(),
@@ -369,6 +374,16 @@ class _Stderr:
 
     def text(self) -> str:
         return b"".join(self._chunks).decode("utf-8", errors="replace").strip()
+
+    def settle(self) -> None:
+        """Wait for the drain to reach the end of what the child wrote.
+
+        `Popen.wait()` returns when the child exits, which is before the pipe it
+        wrote to has been read to the end -- so a caller that quotes ssh calls
+        this first, or quotes nothing. Only useful once the child is gone;
+        while it runs there is no end to wait for.
+        """
+        self._thread.join(timeout=_TERMINATE_SECONDS)
 
     def close(self) -> None:
         self._thread.join(timeout=_TERMINATE_SECONDS)

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -252,7 +252,8 @@ class SshTunnel:
         "to authenticate, visit ..." has to appear to be worth anything.
         """
         self._process: subprocess.Popen[bytes] | None = None
-        self._stderr: _Stderr | None = None
+        self._stderr: _Output | None = None
+        self._stdout: _Output | None = None
 
     @property
     def endpoints(self) -> tuple[tuple[str, int], ...]:
@@ -291,7 +292,9 @@ class SshTunnel:
                 argv,
                 # ssh's prompts go to the terminal it inherits, not to this
                 # pipe, so capturing stderr does not swallow them
-                stdout=subprocess.DEVNULL,
+                # both, because ssh is not the only program writing here: a
+                # `ProxyCommand` helper inherits these and picks its own
+                stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
         except OSError as e:
@@ -299,7 +302,8 @@ class SshTunnel:
                 f"Harlequin could not run {argv[0]}: {e}", title=ERROR_TITLE
             ) from e
         self._process = process
-        self._stderr = _Stderr(process.stderr, echo=self.echo_stderr)
+        self._stderr = _Output(process.stderr, echo=self.echo_stderr)
+        self._stdout = _Output(process.stdout, echo=self.echo_stderr)
         atexit.register(self.stop)
         try:
             self._wait_until_ready(already_bound=already_bound)
@@ -321,8 +325,9 @@ class SshTunnel:
                 process.kill()
                 with contextlib.suppress(subprocess.TimeoutExpired):
                     process.wait(timeout=_TERMINATE_SECONDS)
-        if self._stderr is not None:
-            self._stderr.close()
+        for stream in (self._stderr, self._stdout):
+            if stream is not None:
+                stream.close()
 
     def __enter__(self) -> SshTunnel:
         self.start()
@@ -373,8 +378,9 @@ class SshTunnel:
         assert self._process is not None
         # the child has exited, but what it wrote on the way out may still be
         # in the pipe -- and it is the whole of why this failed
-        if self._stderr is not None:
-            self._stderr.settle()
+        for stream in (self._stderr, self._stdout):
+            if stream is not None:
+                stream.settle()
         return HarlequinSshError(
             f"ssh exited with code {self._process.returncode} without opening "
             f"the forward.\n\n{self._unseen()}".rstrip(),
@@ -384,9 +390,10 @@ class SshTunnel:
     def _timed_out(
         self, *, already_bound: Collection[tuple[str, int]] = ()
     ) -> HarlequinSshError:
-        if self._stderr is not None:
-            # a helper's last line may have no newline of its own
-            self._stderr.flush()
+        for stream in (self._stderr, self._stdout):
+            if stream is not None:
+                # a helper's last line may have no newline of its own
+                stream.flush()
         if already_bound:
             listed = ", ".join(f"{host}:{port}" for host, port in sorted(already_bound))
             reason = (
@@ -413,19 +420,28 @@ class SshTunnel:
         Nothing, where it was echoed as it arrived: an error that repeated it
         would print a helper's instructions twice.
         """
-        if self._stderr is None or self.echo_stderr:
+        if self.echo_stderr:
             return ""
-        return self._stderr.text()
+        said = [
+            stream.text()
+            for stream in (self._stderr, self._stdout)
+            if stream is not None and stream.text()
+        ]
+        return "\n".join(said)
 
 
-class _Stderr:
-    """What ssh wrote to stderr: passed through as it arrives, and kept.
+class _Output:
+    """One of ssh's streams: passed through to *our stderr* as it arrives, and kept.
 
     Passed through because the thing a user most needs to see arrives while the
     tunnel is still opening and nothing has failed yet -- Tailscale's "to
-    authenticate, visit ..." is written here, and a helper's instructions are
+    authenticate, visit ..." among them -- and a helper's instructions are
     worthless after the timeout they caused. `echo=False` is for a caller that
     no longer owns the screen; it keeps the text for an error to quote instead.
+
+    Always onto stderr, whichever of ssh's streams this is: `hsql`'s stdout
+    carries result sets and nothing else, and a helper that writes to ssh's
+    stdout must not be able to corrupt a caller's csv.
 
     A line at a time, so `redact_text()` sees whole lines: ssh is third-party
     output, and a driver's DSN can reach it.

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -2,23 +2,24 @@
 
 Harlequin runs `ssh` and touches nothing else. The connection details already
 name the local end of a forward -- `host = "localhost"`, `port = 15439` -- so no
-adapter is told a tunnel exists, and every adapter works, including the ones
-nobody in this org maintains. What lives here is the child's lifetime: build the
-argv, ask `ssh -G` what it is about to forward, wait for those ports to answer,
-and kill it on the way out.
+adapter is told a tunnel exists. What lives here is the child's lifetime: build
+the argv, ask `ssh -G` what it is about to forward, wait for those ports to
+answer, and kill it on the way out.
 
-Nothing a user typed is parsed. `ssh` owns the syntax of a destination and of a
-forward spec, and its error messages are better than any we would write, so both
-values reach it verbatim and its stderr is what an error quotes. The one thing
-this module reads is `ssh -G`'s own output (`parse_config()`), which says which
-local port to wait on -- the motivating case puts the forward in `~/.ssh/config`,
-where Harlequin never sees a port number at all.
+Nothing a user typed is parsed: `ssh` owns the syntax of a destination and of a
+forward spec, so both values reach it verbatim and its stderr is what an error
+quotes. They are checked for the characters ssh would read as an option or
+expand into a shell (`_refuse_unsafe_value()`), because a config file is
+discovered in the working directory. The one thing this module reads is `ssh
+-G`'s own output (`parse_config()`), which says which local port to wait on: a
+forward declared in `~/.ssh/config` never reaches Harlequin as a port number.
 """
 
 from __future__ import annotations
 
 import atexit
 import contextlib
+import os
 import re
 import socket
 import subprocess
@@ -26,12 +27,12 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Collection, Sequence
 
 from harlequin.exception import HarlequinSshError
 
 SSH = "ssh"
-"""The client, found on PATH: whichever one the user's `~/.ssh/config` is for."""
+"""The client, found on PATH."""
 
 DEFAULT_TIMEOUT = 10.0
 """Seconds to wait for the forwards, when nothing says otherwise."""
@@ -42,25 +43,36 @@ _POLL_INTERVAL = 0.05
 _CONNECT_TIMEOUT = 0.5
 """How long one probe of one local port may take."""
 
-_SETTLE_SECONDS = 1.0
-"""How long a port that was already bound gets to prove it was ssh's to take.
-
-Without this, a listener that answered before `ssh` even started would read as
-the forward being up -- the one case where a port answering proves nothing.
-"""
-
 _GRACE_SECONDS = 1.0
-"""What a tunnel with no port to poll waits instead, before trusting the child."""
+"""What a tunnel with no port to poll waits, before trusting the child."""
 
 _TERMINATE_SECONDS = 2.0
 """How long a terminated child has to exit before it is killed."""
 
+_STDERR_SETTLE_SECONDS = 0.5
+"""How long a caller quoting ssh waits for the drain to catch up.
+
+Bounded rather than open-ended: the pipe reaches EOF only when every write end
+is closed, and a `ProxyJump` helper or an askpass inherits ssh's stderr and
+holds one open after ssh itself is gone.
+"""
+
 _STDERR_LIMIT = 8192
 """Bytes of ssh's stderr kept for an error to quote."""
 
-_LOOPBACK = "127.0.0.1"
-_WILDCARD_HOSTS = {"", "*", "0.0.0.0", "localhost"}
+_ANY_INTERFACE = {"", "*", "0.0.0.0", "::"}
+"""Bind addresses that are not themselves an address to connect to."""
+
 _KEYWORD = re.compile(r"^([a-z][a-z0-9]*)(?:\s+(.*))?$")
+
+_UNSAFE_IN_VALUE = re.compile(r"""[\x00-\x20\x7f`$\\"'|&;<>(){}]""")
+"""Characters no destination or forward spec has, and that ssh may expand.
+
+A destination reaches the user's own `ssh_config` as `%h`, `%r` and `%p`, which
+a `ProxyCommand` there runs through a shell (CVE-2023-51385, CVE-2025-61984).
+Since a config file is discovered in the working directory, the value can come
+from a cloned repository's `pyproject.toml` rather than from its user.
+"""
 
 
 @dataclass(frozen=True)
@@ -68,8 +80,7 @@ class Forward:
     """One local forward, as `ssh -G` printed it: what listens, where it goes.
 
     Two whitespace-separated fields, each a port, a `[host]:port`, or a socket
-    path. Kept as text because that is all a notice needs; only the listening
-    side is ever read for a number.
+    path. Only the listening side is ever read for a number.
     """
 
     listen: str
@@ -90,7 +101,7 @@ class SshConfig:
 
     One list whether a forward came from `--ssh-forward`, a `Host` block, or
     both: `-G` echoes the command line's `-L` flags back along with the config
-    file's, so there are never two sources to keep in agreement.
+    file's.
     """
 
     forwards: tuple[Forward, ...]
@@ -106,14 +117,14 @@ def build_argv(
 
     `ExitOnForwardFailure` is the only option Harlequin imposes on its own: a
     forward that silently did not happen is the one failure a user cannot
-    diagnose. Notably not imposed is `ServerAliveInterval`, which a command-line
-    `-o` would take away from a `Host` block that already sets it.
+    diagnose.
 
-    Raises: HarlequinSshError if a value would reach `ssh` as a flag.
+    Raises: HarlequinSshError for a value ssh would read as an option or expand
+    into a shell.
     """
-    _refuse_a_flag("--ssh-host", host)
+    _refuse_unsafe_value("--ssh-host", host)
     for forward in forwards:
-        _refuse_a_flag("--ssh-forward", forward)
+        _refuse_unsafe_value("--ssh-forward", forward)
     argv = [SSH, "-N", "-o", "ExitOnForwardFailure=yes"]
     if batch_mode:
         argv += ["-o", "BatchMode=yes"]
@@ -158,10 +169,10 @@ def resolve_config(argv: Sequence[str], *, timeout: float) -> SshConfig | None:
     """What `ssh -G` says the argv about to run resolves to, or None.
 
     None is the degraded answer -- no client, no `-G`, or output this cannot
-    read -- and every caller reads it as "ask ssh nothing else": no poll, no
-    forwards-nothing error, and the adapter's own connection is the test.
+    read -- and every caller reads it as "ask ssh nothing else": no poll and no
+    forwards-nothing error.
     """
-    probe = [argv[0], "-G", *argv[1:]]
+    probe = [_client_path(argv[0]), "-G", *argv[1:]]
     try:
         completed = subprocess.run(
             probe,
@@ -206,10 +217,8 @@ def parse_config(text: str) -> SshConfig | None:
 class SshTunnel:
     """An `ssh` child process holding one or more local forwards open.
 
-    A child rather than `ssh -f`: the process that survives a fork is not ours
-    to kill, which is the orphaned tunnel this feature exists to remove. It also
-    keeps the terminal, so a passphrase or 2FA prompt still reaches a human --
-    which is why both commands start it before anything owns the screen.
+    It inherits the terminal, so a passphrase or 2FA prompt still reaches a
+    human, and it dies with the process that started it.
     """
 
     def __init__(
@@ -259,19 +268,21 @@ class SshTunnel:
         if self.running:
             return
         self.reused = False
-        already_bound = any(_accepts(endpoint) for endpoint in self.endpoints)
+        already_bound = frozenset(
+            endpoint for endpoint in self.endpoints if _accepts(endpoint)
+        )
+        argv = [_client_path(self.argv[0]), *self.argv[1:]]
         try:
             process = subprocess.Popen(
-                self.argv,
+                argv,
                 # ssh's prompts go to the terminal it inherits, not to this
-                # pipe, so capturing stderr costs no interactivity and buys an
-                # error message written by the program that failed.
+                # pipe, so capturing stderr does not swallow them
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
             )
         except OSError as e:
             raise HarlequinSshError(
-                f"Harlequin could not run {self.argv[0]}: {e}", title=ERROR_TITLE
+                f"Harlequin could not run {argv[0]}: {e}", title=ERROR_TITLE
             ) from e
         self._process = process
         self._stderr = _Stderr(process.stderr)
@@ -306,36 +317,43 @@ class SshTunnel:
     def __exit__(self, *exc: Any) -> None:
         self.stop()
 
-    def _wait_until_ready(self, *, already_bound: bool) -> None:
-        """Block until every forwarded port answers, or say why it never did."""
+    def _wait_until_ready(self, *, already_bound: Collection[tuple[str, int]]) -> None:
+        """Block until every forwarded port answers, or say why it never did.
+
+        A port that answered before the child started proves nothing by
+        answering now: ssh binds its local forwards only after authenticating,
+        so a listener already on the port satisfies the probe for the whole
+        handshake. Where one did, the only outcomes are the child exiting --
+        which `ExitOnForwardFailure=yes` guarantees it does when it cannot take
+        the port -- and the deadline.
+        """
         assert self._process is not None
-        started = time.monotonic()
-        deadline = started + self.timeout
-        settled = started + min(_SETTLE_SECONDS, self.timeout)
+        deadline = time.monotonic() + self.timeout
         if not self.endpoints:
-            # degraded, or forwarding to a socket path: there is no port to wait
-            # on, so the child gets a moment to fail outright and the adapter's
-            # connection is the real test.
-            time.sleep(min(_GRACE_SECONDS, self.timeout))
+            # no port to wait on: give the child a moment to fail outright
+            time.sleep(max(0.0, min(_GRACE_SECONDS, self.timeout)))
             if self._process.poll() is not None:
                 raise self._child_failed()
             return
         while True:
-            exited = self._process.poll() is not None
-            answering = all(_accepts(endpoint) for endpoint in self.endpoints)
-            if exited:
-                # `ExitOnForwardFailure=yes`, so ssh exits rather than connect
-                # without the forward. Ports that answer anyway are someone
-                # else's tunnel, which is a thing to use only when asked.
-                if answering and already_bound and self.allow_reuse:
+            if self._process.poll() is not None:
+                # ports that answer after ssh exited are someone else's tunnel
+                if already_bound and self.allow_reuse and self._answering():
                     self.reused = True
                     return
                 raise self._child_failed()
-            if answering and (not already_bound or time.monotonic() >= settled):
+            # a port that was bound before the child started is not polled
+            # again while it runs: its answer would say nothing, and a listener
+            # whose owner never accepts has a backlog to fill
+            if not already_bound and self._answering():
                 return
             if time.monotonic() >= deadline:
-                raise self._timed_out()
+                raise self._timed_out(already_bound=already_bound)
             time.sleep(_POLL_INTERVAL)
+
+    def _answering(self) -> bool:
+        """Whether every forwarded port accepts a connection right now."""
+        return all(_accepts(endpoint) for endpoint in self.endpoints)
 
     def _child_failed(self) -> HarlequinSshError:
         assert self._process is not None
@@ -351,15 +369,27 @@ class SshTunnel:
             title=ERROR_TITLE,
         )
 
-    def _timed_out(self) -> HarlequinSshError:
+    def _timed_out(
+        self, *, already_bound: Collection[tuple[str, int]] = ()
+    ) -> HarlequinSshError:
         detail = self._stderr.text() if self._stderr is not None else ""
-        return HarlequinSshError(
-            f"ssh did not open the forward within {self.timeout:g}s. It is most "
-            "likely waiting for a passphrase, a password, or confirmation of a "
-            "host key; answer it, or pass --ssh-batch-mode to fail immediately "
-            f"instead of waiting.\n\n{detail}".rstrip(),
-            title=ERROR_TITLE,
-        )
+        if already_bound:
+            listed = ", ".join(f"{host}:{port}" for host, port in sorted(already_bound))
+            reason = (
+                f"{listed} was already bound when the tunnel started, and ssh "
+                f"has not exited within {self.timeout:g}s to say whether it "
+                "could take the port. Free it, forward a different local port, "
+                "or pass --ssh-allow-reuse to connect through the listener "
+                "that already has it."
+            )
+        else:
+            reason = (
+                f"ssh did not open the forward within {self.timeout:g}s. It is "
+                "most likely waiting for a passphrase, a password, or "
+                "confirmation of a host key; answer it, or pass "
+                "--ssh-batch-mode to fail immediately instead of waiting."
+            )
+        return HarlequinSshError(f"{reason}\n\n{detail}".rstrip(), title=ERROR_TITLE)
 
 
 class _Stderr:
@@ -376,36 +406,39 @@ class _Stderr:
         return b"".join(self._chunks).decode("utf-8", errors="replace").strip()
 
     def settle(self) -> None:
-        """Wait for the drain to reach the end of what the child wrote.
+        """Wait for the drain to catch up with a child that has exited.
 
-        `Popen.wait()` returns when the child exits, which is before the pipe it
-        wrote to has been read to the end -- so a caller that quotes ssh calls
-        this first, or quotes nothing. Only useful once the child is gone;
-        while it runs there is no end to wait for.
+        `Popen.wait()` returns before the pipe the child wrote to has been read
+        to the end, so a caller that quotes ssh calls this first, or quotes
+        nothing.
         """
-        self._thread.join(timeout=_TERMINATE_SECONDS)
+        self._thread.join(timeout=_STDERR_SETTLE_SECONDS)
 
     def close(self) -> None:
-        self._thread.join(timeout=_TERMINATE_SECONDS)
+        self._thread.join(timeout=_STDERR_SETTLE_SECONDS)
         with contextlib.suppress(OSError):
             self._stream.close()
 
     def _drain(self) -> None:
+        # `read1()`, not `read()`: the latter blocks until it has the full 1024
+        # bytes or the pipe closes, and every ssh diagnostic is shorter -- so a
+        # tunnel still waiting on a passphrase would have nothing to quote.
         with contextlib.suppress(OSError, ValueError):
-            while chunk := self._stream.read(1024):
+            while chunk := self._stream.read1(1024):
                 self._chunks.append(chunk)
                 self._size += len(chunk)
                 while self._size > _STDERR_LIMIT and len(self._chunks) > 1:
                     self._size -= len(self._chunks.popleft())
 
 
-def _refuse_a_flag(option: str, value: str) -> None:
-    """Refuse a value `ssh` would read as an option rather than as a value.
+def _refuse_unsafe_value(option: str, value: str) -> None:
+    """Refuse a value ssh would read as an option, or expand into a shell.
 
-    `ssh` has no `--`, so a destination or a forward spec starting with `-`
-    reaches it as a flag -- and a config file is discovered in the working
-    directory, where a cloned repo must not be able to smuggle in an
-    `-oProxyCommand=`.
+    `ssh` has no `--`, so a value starting with `-` reaches it as a flag; and a
+    destination reaches the user's own config as `%h`, `%r` and `%p`, where a
+    `ProxyCommand` runs it through a shell. Both matter because a config file
+    is discovered in the working directory: neither value is necessarily one
+    its user typed.
     """
     if value.startswith("-"):
         raise HarlequinSshError(
@@ -413,10 +446,43 @@ def _refuse_a_flag(option: str, value: str) -> None:
             "option rather than a value. Options belong in your ssh config.",
             title=ERROR_TITLE,
         )
+    found = _UNSAFE_IN_VALUE.search(value)
+    if found is not None:
+        raise HarlequinSshError(
+            f"{option}={value!r} contains {found.group()!r}, which a "
+            "ProxyCommand in your ssh config would expand into a shell. "
+            "A destination and a forward spec have no use for it.",
+            title=ERROR_TITLE,
+        )
 
 
-def _endpoint(field: str) -> tuple[str, int] | None:
-    """A `ssh -G` listen field as an address to connect to, or None.
+def _client_path(program: str) -> str:
+    """`program` as a path, resolved against PATH and nothing else.
+
+    Windows' `CreateProcess` searches the working directory ahead of PATH, so a
+    repository that ships an `ssh.exe` would otherwise run in place of the
+    user's client. A program that already names a path is returned as it is,
+    and so is one PATH does not have -- letting the spawn raise as usual.
+    """
+    if os.path.dirname(program):
+        return program
+    suffixes = (
+        os.environ.get("PATHEXT", ".EXE").split(os.pathsep)
+        if os.name == "nt"
+        else ("",)
+    )
+    for directory in os.environ.get("PATH", os.defpath).split(os.pathsep):
+        if not directory:
+            continue
+        for suffix in suffixes:
+            candidate = os.path.join(directory, program + suffix)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+    return program
+
+
+def _split(field: str) -> tuple[str, str] | None:
+    """A `ssh -G` address field as the host and port it names, or None.
 
     None for a unix socket, which counts as a forward and cannot be polled, and
     for anything else without a port number in it.
@@ -429,23 +495,36 @@ def _endpoint(field: str) -> tuple[str, int] | None:
         host, _, port = field.rpartition(":")
     else:
         host, port = "", field
-    if not port.isdigit():
+    return (host, port) if port.isdigit() else None
+
+
+def _endpoint(field: str) -> tuple[str, int] | None:
+    """A `ssh -G` listen field as an address to connect to, or None.
+
+    A forward bound to every interface, or to no named one, is polled as
+    `localhost` rather than as a literal address: that is the name ssh binds it
+    under, and connecting by name tries every family it resolves to -- which
+    `127.0.0.1` would not, on a host where `localhost` is IPv6 only.
+    """
+    split = _split(field)
+    if split is None:
         return None
-    if host in _WILDCARD_HOSTS:
-        # a forward bound to every interface is reachable on the loopback, which
-        # is the interface the adapter is pointed at
-        host = _LOOPBACK
-    elif host == "::":
-        host = "::1"
-    return host, int(port)
+    host, port = split
+    return ("localhost" if host in _ANY_INTERFACE else host), int(port)
 
 
 def _pretty(field: str) -> str:
-    """One `ssh -G` field, as a person would write the address it names."""
-    endpoint = _endpoint(field)
-    if endpoint is None:
+    """One `ssh -G` field, as the address it names.
+
+    The bind address ssh reported, rather than the one `_endpoint()` polls: a
+    forward on `0.0.0.0` is reachable from the whole network, and a notice that
+    called it `localhost` would hide the thing worth noticing.
+    """
+    split = _split(field)
+    if split is None:
         return field
-    host, port = endpoint
+    host, port = split
+    host = host or "localhost"
     return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
 
 

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -23,6 +23,7 @@ import os
 import re
 import socket
 import subprocess
+import sys
 import threading
 import time
 from collections import deque
@@ -30,12 +31,19 @@ from dataclasses import dataclass
 from typing import Any, Collection, Sequence
 
 from harlequin.exception import HarlequinSshError
+from harlequin.redact import redact_text
 
 SSH = "ssh"
 """The client, found on PATH."""
 
-DEFAULT_TIMEOUT = 10.0
-"""Seconds to wait for the forwards, when nothing says otherwise."""
+DEFAULT_TIMEOUT = 60.0
+"""Seconds to wait for the forwards, when nothing says otherwise.
+
+Long because the wait is on a human as often as on a network: an ssh that opens
+a browser for an identity provider, or asks for a hardware key, is a minute of
+someone reading a screen. `--ssh-batch-mode` is what an unattended caller passes
+to fail at the first prompt instead of waiting this out.
+"""
 
 ERROR_TITLE = "Harlequin could not open the SSH tunnel."
 
@@ -237,6 +245,12 @@ class SshTunnel:
         self.timeout = timeout
         self.reused = False
         """Whether a listener that was already there is what answers now."""
+        self.echo_stderr = True
+        """Whether ssh's stderr goes to ours while the tunnel opens.
+
+        True while a caller still owns the screen, which is where a helper's
+        "to authenticate, visit ..." has to appear to be worth anything.
+        """
         self._process: subprocess.Popen[bytes] | None = None
         self._stderr: _Stderr | None = None
 
@@ -285,7 +299,7 @@ class SshTunnel:
                 f"Harlequin could not run {argv[0]}: {e}", title=ERROR_TITLE
             ) from e
         self._process = process
-        self._stderr = _Stderr(process.stderr)
+        self._stderr = _Stderr(process.stderr, echo=self.echo_stderr)
         atexit.register(self.stop)
         try:
             self._wait_until_ready(already_bound=already_bound)
@@ -357,22 +371,22 @@ class SshTunnel:
 
     def _child_failed(self) -> HarlequinSshError:
         assert self._process is not None
-        detail = ""
+        # the child has exited, but what it wrote on the way out may still be
+        # in the pipe -- and it is the whole of why this failed
         if self._stderr is not None:
-            # the child has exited, but what it wrote on the way out may still
-            # be in the pipe; an error that quotes ssh has to wait for it
             self._stderr.settle()
-            detail = self._stderr.text()
         return HarlequinSshError(
             f"ssh exited with code {self._process.returncode} without opening "
-            f"the forward.\n\n{detail}".rstrip(),
+            f"the forward.\n\n{self._unseen()}".rstrip(),
             title=ERROR_TITLE,
         )
 
     def _timed_out(
         self, *, already_bound: Collection[tuple[str, int]] = ()
     ) -> HarlequinSshError:
-        detail = self._stderr.text() if self._stderr is not None else ""
+        if self._stderr is not None:
+            # a helper's last line may have no newline of its own
+            self._stderr.flush()
         if already_bound:
             listed = ", ".join(f"{host}:{port}" for host, port in sorted(already_bound))
             reason = (
@@ -389,16 +403,40 @@ class SshTunnel:
                 "confirmation of a host key; answer it, or pass "
                 "--ssh-batch-mode to fail immediately instead of waiting."
             )
-        return HarlequinSshError(f"{reason}\n\n{detail}".rstrip(), title=ERROR_TITLE)
+        return HarlequinSshError(
+            f"{reason}\n\n{self._unseen()}".rstrip(), title=ERROR_TITLE
+        )
+
+    def _unseen(self) -> str:
+        """What ssh said that the user has not already read on stderr.
+
+        Nothing, where it was echoed as it arrived: an error that repeated it
+        would print a helper's instructions twice.
+        """
+        if self._stderr is None or self.echo_stderr:
+            return ""
+        return self._stderr.text()
 
 
 class _Stderr:
-    """The tail of what ssh wrote to stderr, drained so it cannot block on it."""
+    """What ssh wrote to stderr: passed through as it arrives, and kept.
 
-    def __init__(self, stream: Any) -> None:
+    Passed through because the thing a user most needs to see arrives while the
+    tunnel is still opening and nothing has failed yet -- Tailscale's "to
+    authenticate, visit ..." is written here, and a helper's instructions are
+    worthless after the timeout they caused. `echo=False` is for a caller that
+    no longer owns the screen; it keeps the text for an error to quote instead.
+
+    A line at a time, so `redact_text()` sees whole lines: ssh is third-party
+    output, and a driver's DSN can reach it.
+    """
+
+    def __init__(self, stream: Any, *, echo: bool = True) -> None:
         self._stream = stream
+        self._echo = echo
         self._chunks: deque[bytes] = deque()
         self._size = 0
+        self._pending = b""
         self._thread = threading.Thread(target=self._drain, daemon=True)
         self._thread.start()
 
@@ -414,6 +452,12 @@ class _Stderr:
         """
         self._thread.join(timeout=_STDERR_SETTLE_SECONDS)
 
+    def flush(self) -> None:
+        """Show a last line ssh left without a newline, before giving up on it."""
+        pending, self._pending = self._pending, b""
+        if pending and self._echo:
+            self._show(pending + b"\n")
+
     def close(self) -> None:
         self._thread.join(timeout=_STDERR_SETTLE_SECONDS)
         with contextlib.suppress(OSError):
@@ -422,13 +466,28 @@ class _Stderr:
     def _drain(self) -> None:
         # `read1()`, not `read()`: the latter blocks until it has the full 1024
         # bytes or the pipe closes, and every ssh diagnostic is shorter -- so a
-        # tunnel still waiting on a passphrase would have nothing to quote.
+        # helper's instructions would not appear until the tunnel gave up.
         with contextlib.suppress(OSError, ValueError):
             while chunk := self._stream.read1(1024):
-                self._chunks.append(chunk)
-                self._size += len(chunk)
-                while self._size > _STDERR_LIMIT and len(self._chunks) > 1:
-                    self._size -= len(self._chunks.popleft())
+                self._keep(chunk)
+                if self._echo:
+                    self._pending += chunk
+                    lines, _, self._pending = self._pending.rpartition(b"\n")
+                    if lines:
+                        self._show(lines + b"\n")
+        self.flush()
+
+    def _keep(self, chunk: bytes) -> None:
+        self._chunks.append(chunk)
+        self._size += len(chunk)
+        while self._size > _STDERR_LIMIT and len(self._chunks) > 1:
+            self._size -= len(self._chunks.popleft())
+
+    def _show(self, raw: bytes) -> None:
+        text = redact_text(raw.decode("utf-8", errors="replace"))
+        with contextlib.suppress(OSError, ValueError):
+            sys.stderr.write(text)
+            sys.stderr.flush()
 
 
 def _refuse_unsafe_value(option: str, value: str) -> None:

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -1,0 +1,443 @@
+"""An `ssh` child process holding local forwards open, for either command.
+
+Harlequin runs `ssh` and touches nothing else. The connection details already
+name the local end of a forward -- `host = "localhost"`, `port = 15439` -- so no
+adapter is told a tunnel exists, and every adapter works, including the ones
+nobody in this org maintains. What lives here is the child's lifetime: build the
+argv, ask `ssh -G` what it is about to forward, wait for those ports to answer,
+and kill it on the way out.
+
+Nothing a user typed is parsed. `ssh` owns the syntax of a destination and of a
+forward spec, and its error messages are better than any we would write, so both
+values reach it verbatim and its stderr is what an error quotes. The one thing
+this module reads is `ssh -G`'s own output (`parse_config()`), which says which
+local port to wait on -- the motivating case puts the forward in `~/.ssh/config`,
+where Harlequin never sees a port number at all.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import re
+import socket
+import subprocess
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from harlequin.exception import HarlequinSshError
+
+SSH = "ssh"
+"""The client, found on PATH: whichever one the user's `~/.ssh/config` is for."""
+
+DEFAULT_TIMEOUT = 10.0
+"""Seconds to wait for the forwards, when nothing says otherwise."""
+
+ERROR_TITLE = "Harlequin could not open the SSH tunnel."
+
+_POLL_INTERVAL = 0.05
+_CONNECT_TIMEOUT = 0.5
+"""How long one probe of one local port may take."""
+
+_SETTLE_SECONDS = 1.0
+"""How long a port that was already bound gets to prove it was ssh's to take.
+
+Without this, a listener that answered before `ssh` even started would read as
+the forward being up -- the one case where a port answering proves nothing.
+"""
+
+_GRACE_SECONDS = 1.0
+"""What a tunnel with no port to poll waits instead, before trusting the child."""
+
+_TERMINATE_SECONDS = 2.0
+"""How long a terminated child has to exit before it is killed."""
+
+_STDERR_LIMIT = 8192
+"""Bytes of ssh's stderr kept for an error to quote."""
+
+_LOOPBACK = "127.0.0.1"
+_WILDCARD_HOSTS = {"", "*", "0.0.0.0", "localhost"}
+_KEYWORD = re.compile(r"^([a-z][a-z0-9]*)(?:\s+(.*))?$")
+
+
+@dataclass(frozen=True)
+class Forward:
+    """One local forward, as `ssh -G` printed it: what listens, where it goes.
+
+    Two whitespace-separated fields, each a port, a `[host]:port`, or a socket
+    path. Kept as text because that is all a notice needs; only the listening
+    side is ever read for a number.
+    """
+
+    listen: str
+    destination: str
+
+    @property
+    def endpoint(self) -> tuple[str, int] | None:
+        """Where to connect to test this forward; None for a unix socket."""
+        return _endpoint(self.listen)
+
+    def __str__(self) -> str:
+        return f"{_pretty(self.listen)} -> {_pretty(self.destination)}"
+
+
+@dataclass(frozen=True)
+class SshConfig:
+    """What `ssh -G` resolved for the argv we are about to run.
+
+    One list whether a forward came from `--ssh-forward`, a `Host` block, or
+    both: `-G` echoes the command line's `-L` flags back along with the config
+    file's, so there are never two sources to keep in agreement.
+    """
+
+    forwards: tuple[Forward, ...]
+
+
+def build_argv(
+    host: str,
+    forwards: Sequence[str] = (),
+    *,
+    batch_mode: bool = False,
+) -> list[str]:
+    """The `ssh` command that holds `forwards` open, and runs nothing.
+
+    `ExitOnForwardFailure` is the only option Harlequin imposes on its own: a
+    forward that silently did not happen is the one failure a user cannot
+    diagnose. Notably not imposed is `ServerAliveInterval`, which a command-line
+    `-o` would take away from a `Host` block that already sets it.
+
+    Raises: HarlequinSshError if a value would reach `ssh` as a flag.
+    """
+    _refuse_a_flag("--ssh-host", host)
+    for forward in forwards:
+        _refuse_a_flag("--ssh-forward", forward)
+    argv = [SSH, "-N", "-o", "ExitOnForwardFailure=yes"]
+    if batch_mode:
+        argv += ["-o", "BatchMode=yes"]
+    for forward in forwards:
+        argv += ["-L", forward]
+    argv.append(host)
+    return argv
+
+
+def build_tunnel(
+    host: str,
+    forwards: Sequence[str] = (),
+    *,
+    batch_mode: bool = False,
+    allow_reuse: bool = False,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> SshTunnel:
+    """The tunnel this invocation runs, having asked ssh what it will forward.
+
+    Raises: HarlequinSshError if nothing anywhere configures a local forward,
+    which is a destination Harlequin would connect to and never use.
+    """
+    argv = build_argv(host, forwards, batch_mode=batch_mode)
+    config = resolve_config(argv, timeout=timeout)
+    if config is not None and not config.forwards:
+        raise HarlequinSshError(
+            f"{host} configures no local forward, so a tunnel to it would "
+            "carry nothing. Pass --ssh-forward LOCAL:HOST:REMOTE, or add a "
+            f"LocalForward line to the {host} block of your ssh config.",
+            title=ERROR_TITLE,
+        )
+    return SshTunnel(
+        argv,
+        forwards=config.forwards if config is not None else (),
+        host=host,
+        allow_reuse=allow_reuse,
+        timeout=timeout,
+    )
+
+
+def resolve_config(argv: Sequence[str], *, timeout: float) -> SshConfig | None:
+    """What `ssh -G` says the argv about to run resolves to, or None.
+
+    None is the degraded answer -- no client, no `-G`, or output this cannot
+    read -- and every caller reads it as "ask ssh nothing else": no poll, no
+    forwards-nothing error, and the adapter's own connection is the test.
+    """
+    probe = [argv[0], "-G", *argv[1:]]
+    try:
+        completed = subprocess.run(
+            probe,
+            capture_output=True,
+            timeout=timeout,
+            # a config that runs `Match exec` inherits our stdin otherwise
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return parse_config(completed.stdout.decode("utf-8", errors="replace"))
+
+
+def parse_config(text: str) -> SshConfig | None:
+    """`ssh -G`'s output, or None if this is not `ssh -G`'s output.
+
+    Each line is a lowercase keyword and its resolved value, and the only one
+    read is `localforward`. A `hostname` line is what tells the two apart: every
+    `-G` prints one, so text without it is something else, and the caller
+    degrades rather than concluding there is nothing to forward.
+    """
+    forwards: list[Forward] = []
+    is_ssh_output = False
+    for line in text.splitlines():
+        match = _KEYWORD.match(line.strip())
+        if match is None:
+            continue
+        keyword, value = match.group(1), (match.group(2) or "").strip()
+        if keyword == "hostname":
+            is_ssh_output = True
+        elif keyword == "localforward":
+            fields = value.split()
+            if len(fields) == 2:
+                forwards.append(Forward(listen=fields[0], destination=fields[1]))
+    if not is_ssh_output:
+        return None
+    return SshConfig(forwards=tuple(forwards))
+
+
+class SshTunnel:
+    """An `ssh` child process holding one or more local forwards open.
+
+    A child rather than `ssh -f`: the process that survives a fork is not ours
+    to kill, which is the orphaned tunnel this feature exists to remove. It also
+    keeps the terminal, so a passphrase or 2FA prompt still reaches a human --
+    which is why both commands start it before anything owns the screen.
+    """
+
+    def __init__(
+        self,
+        argv: Sequence[str],
+        *,
+        forwards: Sequence[Forward] = (),
+        host: str = "",
+        allow_reuse: bool = False,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self.argv = list(argv)
+        self.forwards = tuple(forwards)
+        self.host = host
+        self.allow_reuse = allow_reuse
+        self.timeout = timeout
+        self.reused = False
+        """Whether a listener that was already there is what answers now."""
+        self._process: subprocess.Popen[bytes] | None = None
+        self._stderr: _Stderr | None = None
+
+    @property
+    def endpoints(self) -> tuple[tuple[str, int], ...]:
+        """Every local address a caller can wait on. Socket paths are not polled."""
+        return tuple(
+            endpoint
+            for forward in self.forwards
+            if (endpoint := forward.endpoint) is not None
+        )
+
+    @property
+    def running(self) -> bool:
+        """Whether the child is still holding the forwards open."""
+        return self._process is not None and self._process.poll() is None
+
+    def describe(self) -> str:
+        """The one line that says which database is behind the local port."""
+        listed = ", ".join(str(forward) for forward in self.forwards)
+        via = f" via {self.host}" if self.host else ""
+        return f"{listed}{via}" if listed else f"tunnel to {self.host}"
+
+    def start(self) -> None:
+        """Start it and block until the forwarded ports accept connections.
+
+        Raises: HarlequinSshError, quoting ssh's stderr.
+        """
+        if self.running:
+            return
+        self.reused = False
+        already_bound = any(_accepts(endpoint) for endpoint in self.endpoints)
+        try:
+            process = subprocess.Popen(
+                self.argv,
+                # ssh's prompts go to the terminal it inherits, not to this
+                # pipe, so capturing stderr costs no interactivity and buys an
+                # error message written by the program that failed.
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as e:
+            raise HarlequinSshError(
+                f"Harlequin could not run {self.argv[0]}: {e}", title=ERROR_TITLE
+            ) from e
+        self._process = process
+        self._stderr = _Stderr(process.stderr)
+        atexit.register(self.stop)
+        try:
+            self._wait_until_ready(already_bound=already_bound)
+        except BaseException:
+            self.stop()
+            raise
+
+    def stop(self) -> None:
+        """Kill the child, if there is one. Safe to call more than once."""
+        atexit.unregister(self.stop)
+        process, self._process = self._process, None
+        if process is None:
+            return
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=_TERMINATE_SECONDS)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=_TERMINATE_SECONDS)
+        if self._stderr is not None:
+            self._stderr.close()
+
+    def __enter__(self) -> SshTunnel:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
+
+    def _wait_until_ready(self, *, already_bound: bool) -> None:
+        """Block until every forwarded port answers, or say why it never did."""
+        assert self._process is not None
+        started = time.monotonic()
+        deadline = started + self.timeout
+        settled = started + min(_SETTLE_SECONDS, self.timeout)
+        if not self.endpoints:
+            # degraded, or forwarding to a socket path: there is no port to wait
+            # on, so the child gets a moment to fail outright and the adapter's
+            # connection is the real test.
+            time.sleep(min(_GRACE_SECONDS, self.timeout))
+            if self._process.poll() is not None:
+                raise self._child_failed()
+            return
+        while True:
+            exited = self._process.poll() is not None
+            answering = all(_accepts(endpoint) for endpoint in self.endpoints)
+            if exited:
+                # `ExitOnForwardFailure=yes`, so ssh exits rather than connect
+                # without the forward. Ports that answer anyway are someone
+                # else's tunnel, which is a thing to use only when asked.
+                if answering and already_bound and self.allow_reuse:
+                    self.reused = True
+                    return
+                raise self._child_failed()
+            if answering and (not already_bound or time.monotonic() >= settled):
+                return
+            if time.monotonic() >= deadline:
+                raise self._timed_out()
+            time.sleep(_POLL_INTERVAL)
+
+    def _child_failed(self) -> HarlequinSshError:
+        assert self._process is not None
+        detail = self._stderr.text() if self._stderr is not None else ""
+        return HarlequinSshError(
+            f"ssh exited with code {self._process.returncode} without opening "
+            f"the forward.\n\n{detail}".rstrip(),
+            title=ERROR_TITLE,
+        )
+
+    def _timed_out(self) -> HarlequinSshError:
+        detail = self._stderr.text() if self._stderr is not None else ""
+        return HarlequinSshError(
+            f"ssh did not open the forward within {self.timeout:g}s. It is most "
+            "likely waiting for a passphrase, a password, or confirmation of a "
+            "host key; answer it, or pass --ssh-batch-mode to fail immediately "
+            f"instead of waiting.\n\n{detail}".rstrip(),
+            title=ERROR_TITLE,
+        )
+
+
+class _Stderr:
+    """The tail of what ssh wrote to stderr, drained so it cannot block on it."""
+
+    def __init__(self, stream: Any) -> None:
+        self._stream = stream
+        self._chunks: deque[bytes] = deque()
+        self._size = 0
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+        self._thread.start()
+
+    def text(self) -> str:
+        return b"".join(self._chunks).decode("utf-8", errors="replace").strip()
+
+    def close(self) -> None:
+        self._thread.join(timeout=_TERMINATE_SECONDS)
+        with contextlib.suppress(OSError):
+            self._stream.close()
+
+    def _drain(self) -> None:
+        with contextlib.suppress(OSError, ValueError):
+            while chunk := self._stream.read(1024):
+                self._chunks.append(chunk)
+                self._size += len(chunk)
+                while self._size > _STDERR_LIMIT and len(self._chunks) > 1:
+                    self._size -= len(self._chunks.popleft())
+
+
+def _refuse_a_flag(option: str, value: str) -> None:
+    """Refuse a value `ssh` would read as an option rather than as a value.
+
+    `ssh` has no `--`, so a destination or a forward spec starting with `-`
+    reaches it as a flag -- and a config file is discovered in the working
+    directory, where a cloned repo must not be able to smuggle in an
+    `-oProxyCommand=`.
+    """
+    if value.startswith("-"):
+        raise HarlequinSshError(
+            f"{option}={value!r} starts with a dash, which ssh would read as an "
+            "option rather than a value. Options belong in your ssh config.",
+            title=ERROR_TITLE,
+        )
+
+
+def _endpoint(field: str) -> tuple[str, int] | None:
+    """A `ssh -G` listen field as an address to connect to, or None.
+
+    None for a unix socket, which counts as a forward and cannot be polled, and
+    for anything else without a port number in it.
+    """
+    if "/" in field:
+        return None
+    if field.startswith("["):
+        host, _, port = field[1:].partition("]:")
+    elif ":" in field:
+        host, _, port = field.rpartition(":")
+    else:
+        host, port = "", field
+    if not port.isdigit():
+        return None
+    if host in _WILDCARD_HOSTS:
+        # a forward bound to every interface is reachable on the loopback, which
+        # is the interface the adapter is pointed at
+        host = _LOOPBACK
+    elif host == "::":
+        host = "::1"
+    return host, int(port)
+
+
+def _pretty(field: str) -> str:
+    """One `ssh -G` field, as a person would write the address it names."""
+    endpoint = _endpoint(field)
+    if endpoint is None:
+        return field
+    host, port = endpoint
+    return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+
+
+def _accepts(endpoint: tuple[str, int]) -> bool:
+    """Whether something is listening on a local port, right now."""
+    try:
+        with socket.create_connection(endpoint, timeout=_CONNECT_TIMEOUT):
+            return True
+    except OSError:
+        return False

--- a/tests/data/unit_tests/ssh/ssh
+++ b/tests/data/unit_tests/ssh/ssh
@@ -11,6 +11,7 @@ Environment variables shape what it does, so one script covers the cases:
     FAKE_SSH_ARGV       append each invocation's argv, as a JSON line, to this path
     FAKE_SSH_FORWARD    a `LocalForward` the destination's Host block supplies
     FAKE_SSH_STDERR     write this to stderr, as ssh writes its diagnostics
+    FAKE_SSH_STDERR_PARTIAL  write this to stderr with no trailing newline
     FAKE_SSH_EXIT       exit with this code instead of binding anything
     FAKE_SSH_HANG       bind nothing and sleep, as ssh does waiting on a passphrase
     FAKE_SSH_DELAY      seconds to wait before binding
@@ -100,6 +101,11 @@ def main() -> int:
     message = os.environ.get("FAKE_SSH_STDERR")
     if message:
         print(message, file=sys.stderr, flush=True)
+    partial = os.environ.get("FAKE_SSH_STDERR_PARTIAL")
+    if partial:
+        # no trailing newline, as a prompt has none
+        sys.stderr.write(partial)
+        sys.stderr.flush()
     code = os.environ.get("FAKE_SSH_EXIT")
     if code:
         return int(code)

--- a/tests/data/unit_tests/ssh/ssh
+++ b/tests/data/unit_tests/ssh/ssh
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""A stand-in for the `ssh` binary, for tests that must not need an SSH server.
+
+It understands the three things Harlequin passes it -- `-G`, `-L` and a
+destination -- and answers `-G` in the format OpenSSH's own config dumper uses.
+Without `-G` it binds the local end of each forward and sleeps, which is every
+observable thing a real forward does to the machine Harlequin is running on.
+
+Environment variables shape what it does, so one script covers the cases:
+
+    FAKE_SSH_ARGV       append each invocation's argv, as a JSON line, to this path
+    FAKE_SSH_FORWARD    a `LocalForward` the destination's Host block supplies
+    FAKE_SSH_STDERR     write this to stderr, as ssh writes its diagnostics
+    FAKE_SSH_EXIT       exit with this code instead of binding anything
+    FAKE_SSH_HANG       bind nothing and sleep, as ssh does waiting on a passphrase
+    FAKE_SSH_DELAY      seconds to wait before binding
+    FAKE_SSH_PROBE_EXIT exit `-G` with this code
+    FAKE_SSH_PROBE_TEXT print this from `-G` instead of a resolved config
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import time
+
+TAKES_A_VALUE = {"-L", "-R", "-D", "-o", "-i", "-p", "-l", "-F", "-b", "-c", "-W"}
+
+
+def parse_argv(argv: list[str]) -> tuple[list[str], str, bool]:
+    """The `-L` specs, the destination, and whether `-G` was asked for."""
+    forwards: list[str] = []
+    destination = ""
+    dump_config = False
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg in TAKES_A_VALUE:
+            value = argv[index + 1] if index + 1 < len(argv) else ""
+            if arg == "-L":
+                forwards.append(value)
+            index += 2
+        elif arg.startswith("-"):
+            dump_config = dump_config or "G" in arg
+            index += 1
+        else:
+            if not destination:
+                destination = arg
+            index += 1
+    return forwards, destination, dump_config
+
+
+def format_forward(spec: str) -> tuple[str, str]:
+    """One `-L` spec as the two fields `ssh -G` prints for it."""
+    parts = spec.split(":")
+    if len(parts) == 4:
+        bind, listen_port, host, port = parts
+        listen = f"[{bind}]:{listen_port}"
+    else:
+        listen_port, host, port = parts
+        listen = listen_port
+    return listen, f"[{host}]:{port}"
+
+
+def endpoint(listen: str) -> tuple[str, int]:
+    """Where the local end of a forward listens."""
+    if listen.startswith("["):
+        host, _, port = listen[1:].partition("]:")
+        return host, int(port)
+    return "127.0.0.1", int(listen)
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    record = os.environ.get("FAKE_SSH_ARGV")
+    if record:
+        with open(record, "a", encoding="utf-8") as f:
+            f.write(json.dumps(argv) + "\n")
+
+    forwards, destination, dump_config = parse_argv(argv)
+    from_config = os.environ.get("FAKE_SSH_FORWARD")
+    if from_config:
+        forwards.append(from_config)
+
+    if dump_config:
+        text = os.environ.get("FAKE_SSH_PROBE_TEXT")
+        if text is not None:
+            sys.stdout.write(text)
+            return int(os.environ.get("FAKE_SSH_PROBE_EXIT", "0"))
+        print(f"host {destination}")
+        print(f"hostname {destination}")
+        print("port 22")
+        for spec in forwards:
+            listen, connect = format_forward(spec)
+            print(f"localforward {listen} {connect}")
+        return int(os.environ.get("FAKE_SSH_PROBE_EXIT", "0"))
+
+    message = os.environ.get("FAKE_SSH_STDERR")
+    if message:
+        print(message, file=sys.stderr, flush=True)
+    code = os.environ.get("FAKE_SSH_EXIT")
+    if code:
+        return int(code)
+
+    time.sleep(float(os.environ.get("FAKE_SSH_DELAY", "0")))
+    listeners = []
+    if not os.environ.get("FAKE_SSH_HANG"):
+        for spec in forwards:
+            listen, _ = format_forward(spec)
+            host, port = endpoint(listen)
+            sock = socket.socket()
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+            except OSError as e:
+                print(f"bind [{host}]:{port}: {e.strerror}", file=sys.stderr)
+                return 255
+            sock.listen(8)
+            listeners.append(sock)
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/unit_tests/ssh/ssh
+++ b/tests/data/unit_tests/ssh/ssh
@@ -12,6 +12,7 @@ Environment variables shape what it does, so one script covers the cases:
     FAKE_SSH_FORWARD    a `LocalForward` the destination's Host block supplies
     FAKE_SSH_STDERR     write this to stderr, as ssh writes its diagnostics
     FAKE_SSH_STDERR_PARTIAL  write this to stderr with no trailing newline
+    FAKE_SSH_STDOUT     write this to stdout, as a ProxyCommand helper may
     FAKE_SSH_EXIT       exit with this code instead of binding anything
     FAKE_SSH_HANG       bind nothing and sleep, as ssh does waiting on a passphrase
     FAKE_SSH_DELAY      seconds to wait before binding
@@ -101,6 +102,9 @@ def main() -> int:
     message = os.environ.get("FAKE_SSH_STDERR")
     if message:
         print(message, file=sys.stderr, flush=True)
+    on_stdout = os.environ.get("FAKE_SSH_STDOUT")
+    if on_stdout:
+        print(on_stdout, flush=True)
     partial = os.environ.get("FAKE_SSH_STDERR_PARTIAL")
     if partial:
         # no trailing newline, as a prompt has none

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -33,6 +33,7 @@ HEADLESS_IMPORTS = [
     "import harlequin.plugins",
     "import harlequin.redact",
     "import harlequin.query",
+    "import harlequin.ssh",
     "import harlequin.statements",
     "import harlequin.transaction_mode",
     "import harlequin_duckdb",

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -19,6 +19,7 @@ import pytest
 
 from harlequin.exception import HarlequinSshError
 from harlequin.ssh import (
+    DEFAULT_TIMEOUT,
     Forward,
     SshTunnel,
     _client_path,
@@ -296,12 +297,14 @@ def test_a_child_that_never_opens_the_forward_names_batch_mode(
 
 
 def test_a_child_that_exits_is_reported_in_its_own_words(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("FAKE_SSH_STDERR", "Permission denied (publickey).")
     monkeypatch.setenv("FAKE_SSH_EXIT", "255")
-    with pytest.raises(HarlequinSshError, match="Permission denied"):
+    with pytest.raises(HarlequinSshError, match="exited with code 255"):
         child_tunnel(free_port()).start()
+    # on stderr as ssh wrote it, and so not repeated by the error
+    assert "Permission denied (publickey)." in capsys.readouterr().err
 
 
 def test_a_slow_client_does_not_make_a_bound_port_look_like_a_forward(
@@ -342,25 +345,72 @@ def test_a_bound_port_that_ssh_never_answers_for_names_the_flag(
     assert "already bound" in str(excinfo.value)
 
 
-def test_a_tunnel_waiting_on_a_passphrase_quotes_the_prompt(
-    monkeypatch: pytest.MonkeyPatch,
+def test_what_ssh_says_while_it_waits_is_shown_while_it_waits(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The one path where a user most needs ssh's own words, and it is alive."""
-    monkeypatch.setenv("FAKE_SSH_STDERR", "Enter passphrase for key '/k/id_ed25519':")
+    """A helper's instructions are worthless after the timeout they caused.
+
+    Tailscale writes "to authenticate, visit ..." here, and it is a URL someone
+    has to open before the tunnel can open -- so it goes to stderr as it
+    arrives rather than being kept for an error.
+    """
+    monkeypatch.setenv(
+        "FAKE_SSH_STDERR",
+        "# Tailscale SSH requires an additional check.\n"
+        "# To authenticate, visit: https://login.tailscale.com/a/l4fc5f072",
+    )
     monkeypatch.setenv("FAKE_SSH_HANG", "1")
-    with pytest.raises(HarlequinSshError, match="Enter passphrase for key"):
+    tunnel = child_tunnel(free_port(), timeout=0.5)
+    with pytest.raises(HarlequinSshError) as excinfo:
+        tunnel.start()
+    printed = capsys.readouterr().err
+    assert "https://login.tailscale.com/a/l4fc5f072" in printed
+    # and the error does not read it back at someone who has seen it
+    assert "tailscale" not in str(excinfo.value).lower()
+    assert "--ssh-batch-mode" in str(excinfo.value)
+
+
+def test_a_line_ssh_left_unfinished_is_still_shown(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A prompt has no newline of its own, and is the point of the line."""
+    monkeypatch.setenv("FAKE_SSH_STDERR_PARTIAL", "Enter passphrase for key '/k/id':")
+    monkeypatch.setenv("FAKE_SSH_HANG", "1")
+    with pytest.raises(HarlequinSshError):
         child_tunnel(free_port(), timeout=0.5).start()
+    assert "Enter passphrase for key" in capsys.readouterr().err
 
 
-def test_a_port_that_is_already_bound_fails(listener: int) -> None:
-    """Quoting the client, whose wording for a failed bind is its own.
+def test_a_caller_that_lost_the_screen_gets_the_words_in_the_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """After a restart there is no stderr a user reads, so the error carries it."""
+    monkeypatch.setenv("FAKE_SSH_STDERR", "Permission denied (publickey).")
+    monkeypatch.setenv("FAKE_SSH_EXIT", "255")
+    tunnel = child_tunnel(free_port())
+    tunnel.echo_stderr = False
+    with pytest.raises(HarlequinSshError, match="Permission denied"):
+        tunnel.start()
+    assert "Permission denied" not in capsys.readouterr().err
+
+
+def test_the_default_wait_is_long_enough_for_a_person() -> None:
+    """An ssh that opens a browser for an identity provider is a slow one."""
+    assert DEFAULT_TIMEOUT >= 30
+
+
+def test_a_port_that_is_already_bound_fails(
+    listener: int, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Passing the client's own words through, whatever they are.
 
     Windows says "an attempt was made to access a socket in a way forbidden by
     its access permissions" where Unix says "address already in use", so what
-    is asserted is that the client's own line reached the error.
+    is asserted is that the client's own line reached the user.
     """
-    with pytest.raises(HarlequinSshError, match=f"bind .*{listener}"):
+    with pytest.raises(HarlequinSshError):
         child_tunnel(listener).start()
+    assert "bind" in capsys.readouterr().err
 
 
 def test_allow_reuse_connects_through_the_existing_listener(listener: int) -> None:

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -252,7 +252,13 @@ def test_a_child_that_exits_is_reported_in_its_own_words(
 
 
 def test_a_port_that_is_already_bound_fails(listener: int) -> None:
-    with pytest.raises(HarlequinSshError, match="[Aa]ddress already in use"):
+    """Quoting the client, whose wording for a failed bind is its own.
+
+    Windows says "an attempt was made to access a socket in a way forbidden by
+    its access permissions" where Unix says "address already in use", so what
+    is asserted is that the client's own line reached the error.
+    """
+    with pytest.raises(HarlequinSshError, match=f"bind .*{listener}"):
         child_tunnel(listener).start()
 
 

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -1,0 +1,354 @@
+"""The `ssh` child's lifetime, and the one thing Harlequin parses: `ssh -G`.
+
+No SSH server, and no `ssh` binary except in the one test that asks a real
+client whether it accepts the argv. Everything else hands `SshTunnel` a Python
+child that binds the local end of a forward and sleeps, which is every
+observable thing a real forward does to the machine Harlequin runs on.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator, Sequence
+
+import pytest
+
+from harlequin.exception import HarlequinSshError
+from harlequin.ssh import (
+    Forward,
+    SshTunnel,
+    build_argv,
+    build_tunnel,
+    parse_config,
+    resolve_config,
+)
+
+FAKE_SSH = Path(__file__).parent.parent / "data" / "unit_tests" / "ssh" / "ssh"
+
+posix_only = pytest.mark.skipif(
+    os.name == "nt", reason="a Python script is not an executable on Windows"
+)
+
+
+def free_port() -> int:
+    """A port nothing is listening on, most likely still true a moment from now."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def accepts(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture
+def listener() -> Iterator[int]:
+    """A port already bound by something that is not Harlequin's tunnel."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(8)
+        yield int(sock.getsockname()[1])
+
+
+def child_tunnel(*ports: int, **kwargs: object) -> SshTunnel:
+    """A tunnel whose `ssh` is the fake one, run through this interpreter."""
+    specs = [f"{port}:remote:5439" for port in ports]
+    argv: list[str] = [sys.executable, str(FAKE_SSH), "-N"]
+    for spec in specs:
+        argv += ["-L", spec]
+    argv.append("redshift_prod")
+    forwards = tuple(Forward(str(port), "[remote]:5439") for port in ports)
+    return SshTunnel(argv, forwards=forwards, host="redshift_prod", **kwargs)  # type: ignore[arg-type]
+
+
+# the argv, which is the whole of what Harlequin says to ssh
+
+
+def test_the_argv_forwards_nothing_it_was_not_given() -> None:
+    assert build_argv("redshift_prod") == [
+        "ssh",
+        "-N",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "redshift_prod",
+    ]
+
+
+def test_forwards_reach_the_argv_unchanged_and_in_order() -> None:
+    specs = ["15439:one.internal:5439", "[::1]:15440:two.internal:5440"]
+    argv = build_argv("tco@web-1", specs)
+    assert argv[-1] == "tco@web-1"
+    assert [argv[i + 1] for i, arg in enumerate(argv) if arg == "-L"] == specs
+
+
+def test_batch_mode_is_ssh_s_own_option_and_the_only_one_added() -> None:
+    argv = build_argv("web-1", batch_mode=True)
+    assert "BatchMode=yes" in argv
+    assert [argv[i + 1] for i, arg in enumerate(argv) if arg == "-o"] == [
+        "ExitOnForwardFailure=yes",
+        "BatchMode=yes",
+    ]
+
+
+@pytest.mark.parametrize(
+    "host", ["user@web-1", "ssh://tco@web-1:2222", "redshift_prod", "10.0.0.4"]
+)
+def test_the_destination_is_not_parsed(host: str) -> None:
+    assert build_argv(host)[-1] == host
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"host": "-oProxyCommand=touch /tmp/pwned"},
+        {"host": "web-1", "forwards": ["-oProxyCommand=touch /tmp/pwned"]},
+    ],
+)
+def test_a_value_ssh_would_read_as_an_option_is_refused(kwargs: dict) -> None:
+    with pytest.raises(HarlequinSshError, match="dash"):
+        build_argv(**kwargs)
+
+
+# `ssh -G`, the one thing this feature parses
+
+
+def test_forwards_parse_with_a_bind_address_ipv6_and_a_socket_path() -> None:
+    config = parse_config(
+        "host redshift_prod\n"
+        "hostname web-1\n"
+        "user tco\n"
+        "localforward 15439 [data.example.com]:5439\n"
+        "localforward [127.0.0.1]:15440 [other.internal]:5440\n"
+        "localforward [::1]:15441 [::1]:5441\n"
+        "localforward /tmp/harlequin.sock [db.internal]:5432\n"
+        "remoteforward 9000 [localhost]:9000\n"
+    )
+    assert config is not None
+    assert [forward.endpoint for forward in config.forwards] == [
+        ("127.0.0.1", 15439),
+        ("127.0.0.1", 15440),
+        ("::1", 15441),
+        None,
+    ]
+    assert str(config.forwards[0]) == "127.0.0.1:15439 -> data.example.com:5439"
+
+
+def test_a_wildcard_bind_is_polled_on_the_loopback() -> None:
+    config = parse_config("hostname web-1\nlocalforward [0.0.0.0]:15439 [db]:5439\n")
+    assert config is not None
+    assert config.forwards[0].endpoint == ("127.0.0.1", 15439)
+
+
+def test_a_config_with_only_a_dynamic_forward_forwards_nothing() -> None:
+    config = parse_config("hostname web-1\ndynamicforward 1080\n")
+    assert config is not None
+    assert config.forwards == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "usage: ssh [-46AaCfGg...]\n", "Permission denied (publickey).\n", "{}\n"],
+)
+def test_output_that_is_not_a_resolved_config_degrades(text: str) -> None:
+    assert parse_config(text) is None
+
+
+@posix_only
+def test_a_probe_that_fails_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAKE_SSH_PROBE_EXIT", "255")
+    assert resolve_config([str(FAKE_SSH), "web-1"], timeout=10) is None
+
+
+@posix_only
+def test_a_missing_client_degrades() -> None:
+    assert resolve_config(["harlequin-no-such-ssh", "web-1"], timeout=10) is None
+
+
+# building a tunnel, which is the probe plus the argv
+
+
+@pytest.fixture
+def fake_ssh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("harlequin.ssh.SSH", str(FAKE_SSH))
+
+
+@posix_only
+def test_a_destination_that_forwards_nothing_names_both_places_to_put_one(
+    fake_ssh: None,
+) -> None:
+    with pytest.raises(HarlequinSshError, match="--ssh-forward") as excinfo:
+        build_tunnel("redshift_prod")
+    assert "LocalForward" in str(excinfo.value)
+
+
+@posix_only
+def test_a_forward_from_the_ssh_config_is_the_one_waited_on(
+    fake_ssh: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The motivating case: Harlequin was never told a port number."""
+    monkeypatch.setenv("FAKE_SSH_FORWARD", "15439:data.example.com:5439")
+    tunnel = build_tunnel("redshift_prod")
+    assert tunnel.endpoints == (("127.0.0.1", 15439),)
+    assert tunnel.describe() == (
+        "127.0.0.1:15439 -> data.example.com:5439 via redshift_prod"
+    )
+
+
+@posix_only
+def test_a_probe_that_says_nothing_readable_polls_nothing(
+    fake_ssh: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_PROBE_TEXT", "who knows\n")
+    assert build_tunnel("redshift_prod").endpoints == ()
+
+
+# the child's lifetime
+
+
+def test_a_tunnel_holds_its_port_open_and_gives_it_back() -> None:
+    port = free_port()
+    with child_tunnel(port) as tunnel:
+        assert accepts(port)
+        assert tunnel.running
+        assert not tunnel.reused
+    assert not accepts(port)
+
+
+def test_a_forward_that_takes_a_moment_is_waited_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_DELAY", "0.4")
+    port = free_port()
+    with child_tunnel(port):
+        assert accepts(port)
+
+
+def test_a_child_that_never_opens_the_forward_names_batch_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_HANG", "1")
+    tunnel = child_tunnel(free_port(), timeout=0.5)
+    with pytest.raises(HarlequinSshError, match="--ssh-batch-mode"):
+        tunnel.start()
+    assert not tunnel.running
+
+
+def test_a_child_that_exits_is_reported_in_its_own_words(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_STDERR", "Permission denied (publickey).")
+    monkeypatch.setenv("FAKE_SSH_EXIT", "255")
+    with pytest.raises(HarlequinSshError, match="Permission denied"):
+        child_tunnel(free_port()).start()
+
+
+def test_a_port_that_is_already_bound_fails(listener: int) -> None:
+    with pytest.raises(HarlequinSshError, match="[Aa]ddress already in use"):
+        child_tunnel(listener).start()
+
+
+def test_allow_reuse_connects_through_the_existing_listener(listener: int) -> None:
+    tunnel = child_tunnel(listener, allow_reuse=True)
+    tunnel.start()
+    try:
+        assert tunnel.reused
+        assert not tunnel.running
+    finally:
+        tunnel.stop()
+    # the listener was never ours to close
+    assert accepts(listener)
+
+
+def test_a_half_open_reuse_fails_like_any_other(listener: int) -> None:
+    """Some ports answering and some not is a state nobody meant."""
+    tunnel = child_tunnel(listener, free_port(), allow_reuse=True)
+    with pytest.raises(HarlequinSshError):
+        tunnel.start()
+    assert not tunnel.reused
+
+
+def test_a_client_that_is_not_installed_says_so() -> None:
+    tunnel = SshTunnel(["harlequin-no-such-ssh", "web-1"])
+    with pytest.raises(HarlequinSshError, match="could not run"):
+        tunnel.start()
+
+
+def test_a_tunnel_with_no_port_to_poll_trusts_a_child_that_lives() -> None:
+    """The degraded case: `-G` said nothing, so the adapter is the test."""
+    tunnel = child_tunnel(free_port())
+    tunnel.forwards = ()
+    with tunnel:
+        assert tunnel.running
+
+
+def test_a_tunnel_with_no_port_to_poll_still_notices_a_child_that_dies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_EXIT", "255")
+    tunnel = child_tunnel(free_port())
+    tunnel.forwards = ()
+    with pytest.raises(HarlequinSshError, match="exited"):
+        tunnel.start()
+
+
+def test_stopping_twice_is_not_an_error() -> None:
+    tunnel = child_tunnel(free_port())
+    tunnel.start()
+    tunnel.stop()
+    tunnel.stop()
+    assert not tunnel.running
+
+
+def test_a_stopped_tunnel_starts_again() -> None:
+    port = free_port()
+    tunnel = child_tunnel(port)
+    tunnel.start()
+    tunnel.stop()
+    assert not accepts(port)
+    tunnel.start()
+    try:
+        assert accepts(port)
+    finally:
+        tunnel.stop()
+
+
+# the one test that asks a real client
+
+
+def real_ssh() -> str | None:
+    path = shutil.which("ssh")
+    if path is None:
+        return None
+    try:
+        subprocess.run([path, "-V"], capture_output=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return path
+
+
+@pytest.mark.skipif(real_ssh() is None, reason="no ssh client installed")
+def test_a_real_client_accepts_the_argv_and_says_what_it_would_forward() -> None:
+    argv = build_argv(
+        "harlequin-test-destination", ["15439:data.example.com:5439"], batch_mode=True
+    )
+    config = resolve_config(argv, timeout=30)
+    assert config is not None
+    assert [forward.endpoint for forward in config.forwards] == [("127.0.0.1", 15439)]
+
+
+def test_the_lifecycle_helpers_agree_about_ports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fake client binds exactly the ports `-G` said it would."""
+    ports: Sequence[int] = (free_port(), free_port())
+    with child_tunnel(*ports):
+        assert all(accepts(port) for port in ports)

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -370,6 +370,23 @@ def test_what_ssh_says_while_it_waits_is_shown_while_it_waits(
     assert "--ssh-batch-mode" in str(excinfo.value)
 
 
+def test_what_a_helper_says_on_stdout_is_shown_on_stderr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A `ProxyCommand` helper inherits ssh's streams and picks its own.
+
+    Onto our stderr either way: hsql's stdout carries result sets, and a helper
+    must not be able to corrupt a caller's csv with an authentication notice.
+    """
+    monkeypatch.setenv("FAKE_SSH_STDOUT", "To authenticate, visit: https://example/a")
+    monkeypatch.setenv("FAKE_SSH_HANG", "1")
+    with pytest.raises(HarlequinSshError):
+        child_tunnel(free_port(), timeout=0.5).start()
+    captured = capsys.readouterr()
+    assert "To authenticate, visit: https://example/a" in captured.err
+    assert captured.out == ""
+
+
 def test_a_line_ssh_left_unfinished_is_still_shown(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -449,7 +449,7 @@ def test_a_real_client_accepts_the_argv_and_says_what_it_would_forward() -> None
     )
     config = resolve_config(argv, timeout=30)
     assert config is not None
-    assert [forward.endpoint for forward in config.forwards] == [("127.0.0.1", 15439)]
+    assert [forward.endpoint for forward in config.forwards] == [("localhost", 15439)]
 
 
 def test_the_lifecycle_helpers_agree_about_ports(

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -1,9 +1,8 @@
 """The `ssh` child's lifetime, and the one thing Harlequin parses: `ssh -G`.
 
 No SSH server, and no `ssh` binary except in the one test that asks a real
-client whether it accepts the argv. Everything else hands `SshTunnel` a Python
-child that binds the local end of a forward and sleeps, which is every
-observable thing a real forward does to the machine Harlequin runs on.
+client whether it accepts the argv. Everything else hands `SshTunnel` the fake
+client in `tests/data/unit_tests/ssh/ssh`.
 """
 
 from __future__ import annotations
@@ -22,6 +21,7 @@ from harlequin.exception import HarlequinSshError
 from harlequin.ssh import (
     Forward,
     SshTunnel,
+    _client_path,
     build_argv,
     build_tunnel,
     parse_config,
@@ -118,6 +118,56 @@ def test_a_value_ssh_would_read_as_an_option_is_refused(kwargs: dict) -> None:
         build_argv(**kwargs)
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "web-1`touch /tmp/pwned`",
+        "web-1$(touch /tmp/pwned)",
+        "tco\ntouch /tmp/pwned@web-1",
+        "web-1;touch /tmp/pwned",
+        "web-1 --lol",
+        "web\\-1",
+    ],
+)
+def test_a_value_a_proxycommand_would_expand_is_refused(host: str) -> None:
+    """A destination reaches the user's own ssh config as %h, %r and %p.
+
+    A `ProxyCommand` there runs them through a shell, and the destination can
+    come from a config file discovered in the working directory.
+    """
+    with pytest.raises(HarlequinSshError, match="ProxyCommand"):
+        build_argv(host)
+    with pytest.raises(HarlequinSshError, match="ProxyCommand"):
+        build_argv("web-1", [f"15439:{host}:5432"])
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["tco@web-1", "ssh://tco@web-1:2222", "10.0.0.4", "redshift_prod", "web-1.a.b"],
+)
+def test_an_ordinary_destination_is_not_refused(value: str) -> None:
+    assert build_argv(value)[-1] == value
+
+
+@posix_only
+def test_the_client_is_resolved_against_path_not_the_working_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Windows searches the working directory first; a repo could ship an ssh."""
+    on_path = tmp_path / "bin"
+    on_path.mkdir()
+    real = on_path / "ssh"
+    real.write_text("#!/bin/sh\nexit 0\n")
+    real.chmod(0o755)
+    decoy = tmp_path / "repo"
+    decoy.mkdir()
+    (decoy / "ssh").write_text("#!/bin/sh\ntouch pwned\n")
+    (decoy / "ssh").chmod(0o755)
+    monkeypatch.setenv("PATH", str(on_path))
+    monkeypatch.chdir(decoy)
+    assert _client_path("ssh") == str(real)
+
+
 # `ssh -G`, the one thing this feature parses
 
 
@@ -134,18 +184,21 @@ def test_forwards_parse_with_a_bind_address_ipv6_and_a_socket_path() -> None:
     )
     assert config is not None
     assert [forward.endpoint for forward in config.forwards] == [
-        ("127.0.0.1", 15439),
+        # a bare port is polled by name, so both families are tried
+        ("localhost", 15439),
         ("127.0.0.1", 15440),
         ("::1", 15441),
         None,
     ]
-    assert str(config.forwards[0]) == "127.0.0.1:15439 -> data.example.com:5439"
+    assert str(config.forwards[0]) == "localhost:15439 -> data.example.com:5439"
 
 
-def test_a_wildcard_bind_is_polled_on_the_loopback() -> None:
+def test_a_wildcard_bind_is_polled_by_name_and_reported_as_written() -> None:
+    """A forward on 0.0.0.0 reaches the whole network; the notice must say so."""
     config = parse_config("hostname web-1\nlocalforward [0.0.0.0]:15439 [db]:5439\n")
     assert config is not None
-    assert config.forwards[0].endpoint == ("127.0.0.1", 15439)
+    assert config.forwards[0].endpoint == ("localhost", 15439)
+    assert str(config.forwards[0]) == "0.0.0.0:15439 -> db:5439"
 
 
 def test_a_config_with_only_a_dynamic_forward_forwards_nothing() -> None:
@@ -197,9 +250,9 @@ def test_a_forward_from_the_ssh_config_is_the_one_waited_on(
     """The motivating case: Harlequin was never told a port number."""
     monkeypatch.setenv("FAKE_SSH_FORWARD", "15439:data.example.com:5439")
     tunnel = build_tunnel("redshift_prod")
-    assert tunnel.endpoints == (("127.0.0.1", 15439),)
+    assert tunnel.endpoints == (("localhost", 15439),)
     assert tunnel.describe() == (
-        "127.0.0.1:15439 -> data.example.com:5439 via redshift_prod"
+        "localhost:15439 -> data.example.com:5439 via redshift_prod"
     )
 
 
@@ -249,6 +302,54 @@ def test_a_child_that_exits_is_reported_in_its_own_words(
     monkeypatch.setenv("FAKE_SSH_EXIT", "255")
     with pytest.raises(HarlequinSshError, match="Permission denied"):
         child_tunnel(free_port()).start()
+
+
+def test_a_slow_client_does_not_make_a_bound_port_look_like_a_forward(
+    listener: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ssh binds its forwards only after authenticating.
+
+    A listener already on the port answers for the whole handshake, so nothing
+    but the child exiting or the deadline can say whether the forward is ours.
+    """
+    monkeypatch.setenv("FAKE_SSH_DELAY", "1.5")
+    tunnel = child_tunnel(listener)
+    with pytest.raises(HarlequinSshError):
+        tunnel.start()
+    assert not tunnel.reused
+
+
+def test_a_slow_client_still_reuses_the_listener_when_asked(
+    listener: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_DELAY", "1.5")
+    tunnel = child_tunnel(listener, allow_reuse=True)
+    tunnel.start()
+    try:
+        assert tunnel.reused
+    finally:
+        tunnel.stop()
+
+
+def test_a_bound_port_that_ssh_never_answers_for_names_the_flag(
+    listener: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """And a timeout under the old settle window no longer reads as success."""
+    monkeypatch.setenv("FAKE_SSH_HANG", "1")
+    tunnel = child_tunnel(listener, timeout=0.5)
+    with pytest.raises(HarlequinSshError, match="--ssh-allow-reuse") as excinfo:
+        tunnel.start()
+    assert "already bound" in str(excinfo.value)
+
+
+def test_a_tunnel_waiting_on_a_passphrase_quotes_the_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one path where a user most needs ssh's own words, and it is alive."""
+    monkeypatch.setenv("FAKE_SSH_STDERR", "Enter passphrase for key '/k/id_ed25519':")
+    monkeypatch.setenv("FAKE_SSH_HANG", "1")
+    with pytest.raises(HarlequinSshError, match="Enter passphrase for key"):
+        child_tunnel(free_port(), timeout=0.5).start()
 
 
 def test_a_port_that_is_already_bound_fails(listener: int) -> None:


### PR DESCRIPTION
Part 1 of 5 of `docs/plans/ssh-tunnels-design.md`, phased as §7 asks. Nothing here is reachable from either command yet; 2/5 adds the flags.

Stack: **1/5 (this)** → 2/5 options → 3/5 keepalive & reporting → 4/5 reconnect → 5/5 changelog.

Part of #545

**What** are the key elements of this solution?

- `harlequin/ssh.py`, one class. `SshTunnel` runs `ssh -N` as a child process and `start()` blocks until the local ends of its forwards accept connections; `stop()` terminates and then kills it, from a context manager and an `atexit` backstop.
- `build_argv()` — the whole of what Harlequin says to `ssh`: `-N`, `-o ExitOnForwardFailure=yes`, one `-L` per forward, and the destination. Nothing a user typed is parsed.
- `resolve_config()` / `parse_config()` — the `ssh -G` probe, run with the argv we are about to run, and its output. It is the only way to know which local port to wait on, since the motivating case puts the forward in a `Host` block where Harlequin never sees a port number. Two whitespace-separated fields per `localforward`, each a port, a `[host]:port` or a socket path.
- `HarlequinSshError`, and `harlequin.ssh` joins the "adapter API is reachable without the TUI" import-linter contract.

**Why** did you design your solution this way? Did you assess any alternatives?

The design doc has the alternatives (§8 — rewriting the adapter's host/port, `sshtunnel`, paramiko, SOCKS); the notable choices inside this module:

- **A child, not `ssh -f`.** A forked `ssh` signals readiness by exiting, but the surviving process is not ours to kill — which is the orphaned tunnel this feature removes. Staying in the foreground also keeps the terminal, so passphrase and 2FA prompts still work.
- **stderr is captured, drained by a thread, and quoted verbatim in errors.** `ssh` writes its prompts to `/dev/tty` rather than to stderr, so capturing costs no interactivity, and its diagnostics are better than any we would write.
- **A port answering is not proof our forward is up.** The readiness loop records which ports were already bound *before* the child started; when none was, it returns as soon as they all answer, and when some were, it waits out a one-second settle window for `ExitOnForwardFailure` to kill the child. That is what makes the reuse test behavioral (`allow_reuse` — the child failed, but the ports answer) rather than a match against ssh's wording. Half-open — some ports answering — fails either way.
- **One guard beyond the design.** A `--ssh-host` or `--ssh-forward` value starting with a dash is refused: `ssh` has no `--`, so such a value reaches it as a flag, and config files are discovered in the working directory. That is the same threat that got `--ssh-option` rejected in §8; a cloned repo's `pyproject.toml` must not be able to smuggle in `-oProxyCommand=`.
- **`ssh -G` output it cannot read degrades** to no poll, no forwards-nothing error and a short grace period, rather than to a refusal. A `hostname` line is what tells `-G`'s output from anything else.

Does this PR require a change to Harlequin's docs?
- [x] Yes, and it comes with 5/5 of this stack (the user-facing docs go to [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web); nothing in this PR is user-visible on its own).

Did you add or update tests for this change?
- [x] Yes.

`tests/unit_tests/test_ssh.py`, and a fake `ssh` at `tests/data/unit_tests/ssh/ssh` that understands `-G`, `-V` and `-L` and binds the local end of each forward. No SSH server and no `online` marker. Lifecycle tests run it through `sys.executable` so they cover all three OSes; the ones that need it on `PATH` are skipped on Windows. One test asks a real `ssh` whether it accepts the argv, and skips if none is installed.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md` — in 5/5 of this stack, where the feature becomes user-visible.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD

---
_Generated by [Claude Code](https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD)_