### PR TITLE
SSH tunnels 2/5: --ssh-host and friends, in both commands

### DIFF
--- a/docs/generated/hsql-reference.md
+++ b/docs/generated/hsql-reference.md
@@ -57,6 +57,11 @@ Alphabetical by name. Flags are off by default.
 | `--result` | text | `all\|last\|N` | `all` |  | Which result set(s) to emit. |
 | `--skill` | boolean |  |  |  | Write the Agent Skill for driving hsql, as markdown. -o installs it: 'hsql --skill -o ~/.claude/skills/hsql/'. |
 | `--spec` | boolean |  |  |  | Every option here, plus every installed adapter's, as JSON. -a narrows it to one adapter. |
+| `--ssh-allow-reuse` | boolean |  |  |  | When the local port is already bound, warn and connect through the listener that has it instead of failing. |
+| `--ssh-batch-mode` | boolean |  |  |  | Fail rather than prompt for a passphrase, a password or a host key. ssh's own BatchMode; set it in scripts, CI and cron. |
+| `--ssh-forward` | text | `TEXT` |  |  | A local forward, spelled as ssh -L takes one: LOCAL:HOST:REMOTE. Repeatable. Omit it when your ssh config has the LocalForward. |
+| `--ssh-host` | text | `TEXT` |  |  | Open an SSH tunnel to this destination first, and connect through it. A Host alias, host, user@host or ssh://user@host:port, passed to ssh verbatim. |
+| `--ssh-timeout` | number | `SECONDS` |  |  | Seconds to wait for the tunnel's forwards. [default: 10] |
 | `--stats` | boolean |  |  |  | Write a one-line JSON summary to stderr. |
 | `--timeout` | number | `SECONDS` |  |  | Cancel the run after SECONDS and exit 4. Refused if the adapter cannot cancel a query; to check, use --info. |
 | `-t`, `--tuples-only` | boolean |  |  |  | Rows only: no header, no footer. As in psql. |

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -353,12 +353,15 @@ class Harlequin(AppBase):
         self.run_query_bar.apply_configured_limit()
 
         if self.ssh_tunnel is not None:
-            # which database this session is actually looking at, which the
-            # connection details alone no longer say
+            # which database this session is actually looking at
+            warnings = self.ssh_tunnel.warnings()
             self.notify(
-                self.ssh_tunnel.notice(),
+                "\n\n".join((self.ssh_tunnel.notice(), *warnings)),
                 title="SSH tunnel",
-                severity="warning" if self.ssh_tunnel.reused else "information",
+                severity=(
+                    "warning" if self.ssh_tunnel.reused or warnings else "information"
+                ),
+                markup=False,
             )
 
         self._connect()

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
     from textual.await_complete import AwaitComplete
 
     from harlequin.keymap import HarlequinKeyMap
+    from harlequin.ssh import SshTunnel
 
 
 class CatalogCacheLoaded(Message):
@@ -201,6 +202,7 @@ class Harlequin(AppBase):
         export_path: Path | str | None = None,
         viewer_max_rows: int | str | None = 100_000,
         query_limit: int | str | None = None,
+        ssh_tunnel: SshTunnel | None = None,
         driver_class: Union[Type[Driver], None] = None,
         css_path: Union[CSSPathType, None] = None,
         watch_css: bool = False,
@@ -217,6 +219,9 @@ class Harlequin(AppBase):
         self.history: History | None = None
         self.show_files = show_files
         self.show_s3 = show_s3 or None
+        # already started, by the command that built this app: `ssh` prompts for
+        # a passphrase on the terminal Textual is about to take.
+        self.ssh_tunnel = ssh_tunnel
         # kept as text: it is what the Data Exporter's path input starts with
         self.export_path = str(export_path) if export_path is not None else None
         # None is no cap: the viewer holds every row that was fetched. So are 0
@@ -346,6 +351,15 @@ class Harlequin(AppBase):
 
     async def on_mount(self) -> None:
         self.run_query_bar.apply_configured_limit()
+
+        if self.ssh_tunnel is not None:
+            # which database this session is actually looking at, which the
+            # connection details alone no longer say
+            self.notify(
+                self.ssh_tunnel.notice(),
+                title="SSH tunnel",
+                severity="warning" if self.ssh_tunnel.reused else "information",
+            )
 
         self._connect()
         self._load_catalog_cache()

--- a/src/harlequin/catalog_cache.py
+++ b/src/harlequin/catalog_cache.py
@@ -64,7 +64,7 @@ def get_connection_hash(
     `through` is how it was reached, where that is not part of the details
     themselves: two SSH tunnels front two databases that both look like
     `localhost:15439`. Absent from the hashed material when there is none, so
-    an untunneled connection keys the same as it always has.
+    an untunneled connection keys on its details alone.
     """
     material: dict[str, Any] = {"conn_str": tuple(conn_str), **config}
     if through:

--- a/src/harlequin/catalog_cache.py
+++ b/src/harlequin/catalog_cache.py
@@ -56,14 +56,21 @@ class CatalogCache:
         return self.s3.get(cache_key, None)
 
 
-def get_connection_hash(conn_str: Sequence[str], config: Mapping[str, Any]) -> str:
+def get_connection_hash(
+    conn_str: Sequence[str], config: Mapping[str, Any], *, through: Sequence[str] = ()
+) -> str:
+    """What a connection's cached catalog and query history are keyed by.
+
+    `through` is how it was reached, where that is not part of the details
+    themselves: two SSH tunnels front two databases that both look like
+    `localhost:15439`. Absent from the hashed material when there is none, so
+    an untunneled connection keys the same as it always has.
+    """
+    material: dict[str, Any] = {"conn_str": tuple(conn_str), **config}
+    if through:
+        material["through"] = tuple(through)
     return (
-        hashlib.md5(
-            json.dumps(
-                {"conn_str": tuple(conn_str), **config},
-                cls=PermissiveEncoder,
-            ).encode("utf-8")
-        )
+        hashlib.md5(json.dumps(material, cls=PermissiveEncoder).encode("utf-8"))
         .digest()
         .hex()
     )

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -38,6 +38,7 @@ from harlequin.keys_app import HarlequinKeys
 from harlequin.locale_manager import set_locale
 from harlequin.options import AbstractOption
 from harlequin.plugins import adapter_names, load_adapter, load_adapter_plugins
+from harlequin.redact import hide_secrets_in
 from harlequin.windows_timezone import check_and_install_tzdata
 
 if TYPE_CHECKING:
@@ -284,8 +285,8 @@ def _adapter_option_group(
 def _open_tunnel(ctx: click.Context, ssh_config: dict[str, Any]) -> "SshTunnel | None":
     """The tunnel the IDE runs through, or exit having said why there is none.
 
-    Here rather than in the app: once Textual owns the terminal, `ssh` cannot
-    ask for a passphrase and a 2FA push has nowhere to print "check your phone".
+    Once Textual owns the terminal, `ssh` cannot ask for a passphrase and a 2FA
+    push has nowhere to print "check your phone".
     """
     if not ssh_config.get("ssh_host"):
         # nothing to open, and so nothing to import
@@ -589,6 +590,11 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             profile=profile_config, cli_values=kwargs, explicitly_set=explicitly_set
         )
 
+        # what this process must not print, before anything can print it: an
+        # error panel quotes a driver, and ssh's stderr quotes whatever a
+        # config file pointed it at
+        hide_secrets_in(config, adapter_cls.ADAPTER_OPTIONS)
+
         # detect and install (if necessary) a tzdatabase on Windows
         if sys.platform == "win32" and not config.pop("no_download_tzdata", None):
             try:
@@ -643,9 +649,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             )
             ctx.exit(2)
 
-        # off the config before the adapter is handed the rest of it: the
-        # connection details already name the local end of the forward, so an
-        # adapter is never told a tunnel exists
+        # off the config before the adapter is handed the rest of it
         try:
             ssh_config = take_ssh_keys(config, typed=explicitly_set)
         except HarlequinConfigError as e:
@@ -663,40 +667,42 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             pretty_print_error(e)
             ctx.exit(2)
 
-        # before Textual owns the terminal, which is the only place a
-        # passphrase prompt or a 2FA push has anywhere to go
-        tunnel = _open_tunnel(ctx, ssh_config)
-
-        connection_id = (
-            adapter_instance.connection_id
-            if adapter_instance.connection_id is not None
-            else get_connection_hash(conn_str, config)
-        )
-        if tunnel is not None:
-            connection_id = get_connection_hash(
-                (connection_id,), {}, through=tunnel.cache_material()
-            )
-
-        tui = Harlequin(
-            adapter=adapter_instance,
-            profile_name=profile,
-            keymap_names=keymap_names,
-            user_defined_keymaps=user_defined_keymaps,
-            connection_hash=connection_id,
-            viewer_max_rows=viewer_max_rows,
-            query_limit=query_limit,
-            theme=theme,
-            show_files=show_files,
-            show_s3=show_s3,
-            export_path=export_path,
-            ssh_tunnel=tunnel,
-        )
         with contextlib.ExitStack() as stack:
-            if tunnel is not None:
+            if ssh_config.get("ssh_host"):
                 from harlequin.ssh import stopping_on_signal
 
-                stack.callback(tunnel.stop)
+                # entered before the child exists: `start()` blocks for the
+                # whole handshake, and a signal caught in that window would
+                # otherwise leave `ssh` running
                 stack.enter_context(stopping_on_signal())
+            tunnel = _open_tunnel(ctx, ssh_config)
+            if tunnel is not None:
+                stack.callback(tunnel.stop)
+
+            connection_id = (
+                adapter_instance.connection_id
+                if adapter_instance.connection_id is not None
+                else get_connection_hash(conn_str, config)
+            )
+            if tunnel is not None:
+                connection_id = get_connection_hash(
+                    (connection_id,), {}, through=tunnel.cache_material()
+                )
+
+            tui = Harlequin(
+                adapter=adapter_instance,
+                profile_name=profile,
+                keymap_names=keymap_names,
+                user_defined_keymaps=user_defined_keymaps,
+                connection_hash=connection_id,
+                viewer_max_rows=viewer_max_rows,
+                query_limit=query_limit,
+                theme=theme,
+                show_files=show_files,
+                show_s3=show_s3,
+                export_path=export_path,
+                ssh_tunnel=tunnel,
+            )
             tui.run()
 
     # this command's own options, before any adapter's are added to it

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 import sys
 import warnings
 from functools import lru_cache
 from importlib.metadata import entry_points, version
 from pathlib import Path
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 import rich_click as click
 from rich_click.utils import OptionGroupDict
@@ -16,16 +17,19 @@ from harlequin.catalog_cache import get_connection_hash
 from harlequin.colors import GREEN, PINK, PURPLE, VALID_THEMES, YELLOW
 from harlequin.config import (
     DEFAULT_ADAPTER,
+    DEFAULT_SSH_TIMEOUT,
     Profile,
     load_profile_and_keymaps,
     merge_profile_with_cli,
     parse_profile_options,
     parse_row_count,
+    take_ssh_keys,
 )
 from harlequin.config_wizard import wizard
 from harlequin.exception import (
     HarlequinConfigError,
     HarlequinLocaleError,
+    HarlequinSshError,
     HarlequinTzDataError,
     pretty_print_error,
 )
@@ -35,6 +39,9 @@ from harlequin.locale_manager import set_locale
 from harlequin.options import AbstractOption
 from harlequin.plugins import adapter_names, load_adapter, load_adapter_plugins
 from harlequin.windows_timezone import check_and_install_tzdata
+
+if TYPE_CHECKING:
+    from harlequin.ssh import SshTunnel
 
 # configure defaults
 DEFAULT_VIEWER_MAX_ROWS = 100_000
@@ -139,6 +146,16 @@ HARLEQUIN_OPTION_GROUPS: list[OptionGroupDict] = [
             "--config-path",
             "--locale",
             "--no-download-tzdata",
+        ],
+    },
+    {
+        "name": "SSH Tunnel Options",
+        "options": [
+            "--ssh-host",
+            "--ssh-forward",
+            "--ssh-batch-mode",
+            "--ssh-allow-reuse",
+            "--ssh-timeout",
         ],
     },
     {
@@ -262,6 +279,27 @@ def _adapter_option_group(
         "name": f"{name} Adapter Options",
         "options": [f"--{option.name}" for option in adapter_cls.ADAPTER_OPTIONS or []],
     }
+
+
+def _open_tunnel(ctx: click.Context, ssh_config: dict[str, Any]) -> "SshTunnel | None":
+    """The tunnel the IDE runs through, or exit having said why there is none.
+
+    Here rather than in the app: once Textual owns the terminal, `ssh` cannot
+    ask for a passphrase and a 2FA push has nowhere to print "check your phone".
+    """
+    if not ssh_config.get("ssh_host"):
+        # nothing to open, and so nothing to import
+        return None
+    from harlequin.ssh import open_tunnel
+
+    try:
+        return open_tunnel(ssh_config)
+    except HarlequinConfigError as e:
+        pretty_print_error(e)
+        ctx.exit(2)
+    except HarlequinSshError as e:
+        pretty_print_error(e)
+        ctx.exit(3)
 
 
 def build_cli(argv: Sequence[str]) -> click.Command:
@@ -427,6 +465,47 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         default=DEFAULT_KEYMAP_NAMES,
     )
     @click.option(
+        "--ssh-host",
+        help=(
+            "Open an SSH tunnel to this destination first, and connect through "
+            "it. A Host alias, host, user@host or ssh://user@host:port, passed "
+            "to ssh verbatim."
+        ),
+    )
+    @click.option(
+        "--ssh-forward",
+        multiple=True,
+        help=(
+            "A local forward, spelled as ssh -L takes one: LOCAL:HOST:REMOTE. "
+            "Repeat this option for more than one. Omit it when your ssh config "
+            "already has the LocalForward."
+        ),
+    )
+    @click.option(
+        "--ssh-batch-mode",
+        is_flag=True,
+        help=(
+            "Fail rather than prompt for a passphrase, a password or a host "
+            "key. ssh's own BatchMode."
+        ),
+    )
+    @click.option(
+        "--ssh-allow-reuse",
+        is_flag=True,
+        help=(
+            "When the local port is already bound, warn and connect through "
+            "the listener that has it instead of failing."
+        ),
+    )
+    @click.option(
+        "--ssh-timeout",
+        type=click.FloatRange(min=0, min_open=True),
+        help=(
+            "Seconds to wait for the tunnel's forwards. Default is "
+            f"{DEFAULT_SSH_TIMEOUT:g}"
+        ),
+    )
+    @click.option(
         "--config",
         help=(
             "Run the configuration wizard to create or update a Harlequin config file."
@@ -564,6 +643,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             )
             ctx.exit(2)
 
+        # off the config before the adapter is handed the rest of it: the
+        # connection details already name the local end of the forward, so an
+        # adapter is never told a tunnel exists
+        try:
+            ssh_config = take_ssh_keys(config)
+        except HarlequinConfigError as e:
+            pretty_print_error(e)
+            ctx.exit(2)
+
         # instantiate the adapter, which was named and imported above -- the
         # key comes off either way, because what is left is its options
         config.pop("adapter", None)
@@ -575,11 +663,19 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             pretty_print_error(e)
             ctx.exit(2)
 
+        # before Textual owns the terminal, which is the only place a
+        # passphrase prompt or a 2FA push has anywhere to go
+        tunnel = _open_tunnel(ctx, ssh_config)
+
         connection_id = (
             adapter_instance.connection_id
             if adapter_instance.connection_id is not None
             else get_connection_hash(conn_str, config)
         )
+        if tunnel is not None:
+            connection_id = get_connection_hash(
+                (connection_id,), {}, through=tunnel.cache_material()
+            )
 
         tui = Harlequin(
             adapter=adapter_instance,
@@ -593,8 +689,12 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             show_files=show_files,
             show_s3=show_s3,
             export_path=export_path,
+            ssh_tunnel=tunnel,
         )
-        tui.run()
+        with contextlib.ExitStack() as stack:
+            if tunnel is not None:
+                stack.callback(tunnel.stop)
+            tui.run()
 
     # this command's own options, before any adapter's are added to it
     harlequin_options = {param.name for param in inner_cli.params}

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -95,6 +95,22 @@ caller asks a database what a query's columns are, and an option that spent
 that spelling on "unlimited" would take the idiom away.
 """
 
+DEFAULT_SSH_TIMEOUT = 10.0
+"""Seconds both commands wait for an SSH tunnel's forwards, by default."""
+
+SSH_KEYS = (
+    "ssh_host",
+    "ssh_forward",
+    "ssh_batch_mode",
+    "ssh_allow_reuse",
+    "ssh_timeout",
+)
+"""The profile keys that describe an SSH tunnel, which both commands read.
+
+Named here rather than in `harlequin.ssh` so that an invocation with no tunnel
+can take them off a config without importing the module that opens one.
+"""
+
 TUI_ONLY_KEYS = (
     "theme",
     "keymap_name",
@@ -636,6 +652,26 @@ def parse_seconds(value: Any, *, key: str) -> float | None:
     if not seconds > 0 or not math.isfinite(seconds):
         raise refuse()
     return seconds
+
+
+def take_ssh_keys(config: MutableMapping[str, Any]) -> dict[str, Any]:
+    """Remove the tunnel's keys from a merged config and return them.
+
+    They come off whether or not any is set: what is left of the config is the
+    adapter's, and an adapter is never told a tunnel exists.
+
+    Raises: HarlequinConfigError if a tunnel is described with no destination to
+    open it through, which would otherwise connect straight past the forward.
+    """
+    taken = {key: config.pop(key) for key in SSH_KEYS if key in config}
+    if not taken.get("ssh_host") and any(taken.values()):
+        named = ", ".join(key for key in SSH_KEYS if taken.get(key))
+        raise HarlequinConfigError(
+            f"{named} describes an SSH tunnel, but ssh_host says nothing to "
+            "open one to.",
+            title=CONFIG_ERROR_TITLE,
+        )
+    return taken
 
 
 def discover_config_files(config_path: Path | None) -> list[Path]:

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -681,7 +681,8 @@ def take_ssh_keys(
 
     Raises: HarlequinConfigError if a tunnel is described with no destination to
     open it through, which would otherwise connect straight past the forward,
-    or if a config file answered a key only a caller may.
+    if a config file answered a key only a caller may, or if `ssh_timeout` is
+    not a number of seconds.
     """
     taken = {key: config.pop(key) for key in SSH_KEYS if key in config}
     for key in CLI_ONLY_SSH_KEYS:
@@ -693,8 +694,15 @@ def take_ssh_keys(
                 f"and not from a config file. Pass --{spelled}.",
                 title=CONFIG_ERROR_TITLE,
             )
-    if not taken.get("ssh_host") and any(taken.values()):
-        named = ", ".join(key for key in SSH_KEYS if taken.get(key))
+    if "ssh_timeout" in taken:
+        # typed before the destination check below, so that a value that is not
+        # a number is named as one rather than as a tunnel with nowhere to go
+        parse_seconds(taken["ssh_timeout"], key="ssh_timeout")
+    describe_the_tunnel = [
+        key for key in SSH_KEYS if key in taken and key != "ssh_host"
+    ]
+    if not taken.get("ssh_host") and describe_the_tunnel:
+        named = ", ".join(describe_the_tunnel)
         raise HarlequinConfigError(
             f"{named} describes an SSH tunnel, but ssh_host says nothing to "
             "open one to.",

--- a/src/harlequin/config_schema.py
+++ b/src/harlequin/config_schema.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Container, Mapping, Sequence
 import msgspec
 
 from harlequin.config import (
+    CLI_ONLY_SSH_KEYS,
     DEFAULT_ADAPTER,
     TUI_ONLY_KEYS,
     Config,
@@ -199,6 +200,10 @@ def _profile(
     }
     for key in TUI_ONLY_KEYS:
         properties.setdefault(key, {"description": IDE_ONLY})
+    for key in CLI_ONLY_SSH_KEYS:
+        # refused from a profile at run time, so a file that sets one is wrong
+        # however the editor validating it was told to read this document
+        properties.pop(key, None)
 
     schema: dict[str, Any] = {
         "type": "object",

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -54,6 +54,7 @@ from typing import (
 import click
 
 from harlequin.config import (
+    CLI_ONLY_SSH_KEYS,
     DEFAULT_ADAPTER,
     DEFAULT_SSH_TIMEOUT,
     TUI_ONLY_KEYS,
@@ -510,8 +511,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
         read_only: bool = bool(values.pop("read_only", False))
         try:
-            # off the config either way: an adapter is never told a tunnel
-            # exists, so these keys are never part of what it is handed
+            # off the config either way: what is left of it is the adapter's
             ssh_config = take_ssh_keys(values, typed=explicitly_set)
         except HarlequinConfigError as e:
             diagnostics.report_error(e)
@@ -669,15 +669,19 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         )
         deadline = _deadline(timeout_seconds)
 
+        if ssh_config.get("ssh_host"):
+            # entered before the child exists: `start()` blocks for the whole
+            # handshake, and a signal caught in that window would otherwise
+            # leave `ssh` running
+            from harlequin.ssh import stopping_on_signal
+
+            ctx.with_resource(stopping_on_signal())
         tunnel = _open_tunnel(ctx, ssh_config)
         if tunnel is not None:
             # the run's, not the process's: click closes the context however
             # this ends, and `harlequin.ssh` keeps an atexit backstop under that
-            from harlequin.ssh import stopping_on_signal
-
-            ctx.with_resource(stopping_on_signal())
             ctx.call_on_close(tunnel.stop)
-            diagnostics.report_tunnel(tunnel.notice())
+            diagnostics.report_tunnel(tunnel.notice(), tunnel.warnings())
 
         if catalog:
             catalog_path = _catalog_path(ctx, path)
@@ -1437,6 +1441,10 @@ def _typed_profile_keys(
     # written from the mode's own argument instead, so that it is there whether
     # or not the caller named one
     typed.pop("adapter", None)
+    for key in CLI_ONLY_SSH_KEYS:
+        # a profile that set one is refused on the next run, so writing it here
+        # would be writing a file this command will not read back
+        typed.pop(key, None)
     if format_chosen:
         typed["format"] = format_name
     # first among what a profile sets, as it is on the command line, because it

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -55,18 +55,21 @@ import click
 
 from harlequin.config import (
     DEFAULT_ADAPTER,
+    DEFAULT_SSH_TIMEOUT,
     TUI_ONLY_KEYS,
     UNLIMITED,
     merge_profile_with_cli,
     parse_profile_options,
     parse_row_count,
     parse_seconds,
+    take_ssh_keys,
 )
 from harlequin.exception import (
     HarlequinCatalogPathError,
     HarlequinConfigError,
     HarlequinConnectionError,
     HarlequinError,
+    HarlequinSshError,
 )
 from harlequin.export import names_a_directory
 from harlequin.first_pass import (
@@ -86,6 +89,7 @@ if TYPE_CHECKING:
     from harlequin.layout import LayoutOptions
     from harlequin.navigate import CatalogPath
     from harlequin.query import ExecutedStatement, OnError, ResultSet, RowLimit
+    from harlequin.ssh import SshTunnel
     from harlequin.statements import Statement
 
 T = TypeVar("T")
@@ -284,6 +288,49 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             "cannot cancel a query; to check, use --info."
         ),
     )
+    @click.option(
+        "--ssh-host",
+        metavar="TEXT",
+        help=(
+            "Open an SSH tunnel to this destination first, and connect through "
+            "it. A Host alias, host, user@host or ssh://user@host:port, passed "
+            "to ssh verbatim."
+        ),
+    )
+    @click.option(
+        "--ssh-forward",
+        metavar="TEXT",
+        multiple=True,
+        help=(
+            "A local forward, spelled as ssh -L takes one: LOCAL:HOST:REMOTE. "
+            "Repeatable. Omit it when your ssh config has the LocalForward."
+        ),
+    )
+    @click.option(
+        "--ssh-batch-mode",
+        is_flag=True,
+        help=(
+            "Fail rather than prompt for a passphrase, a password or a host "
+            "key. ssh's own BatchMode; set it in scripts, CI and cron."
+        ),
+    )
+    @click.option(
+        "--ssh-allow-reuse",
+        is_flag=True,
+        help=(
+            "When the local port is already bound, warn and connect through "
+            "the listener that has it instead of failing."
+        ),
+    )
+    @click.option(
+        "--ssh-timeout",
+        metavar="SECONDS",
+        type=click.FloatRange(min=0, min_open=True),
+        help=(
+            "Seconds to wait for the tunnel's forwards. "
+            f"[default: {DEFAULT_SSH_TIMEOUT:g}]"
+        ),
+    )
     # existence is not click's to check: every mode that reads this path
     # already refuses a file that is not there, naming it, and `--config init`
     # is the one invocation whose whole job is to write a file that is not there
@@ -462,6 +509,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.exit(ExitCode.USAGE)
         on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
         read_only: bool = bool(values.pop("read_only", False))
+        try:
+            # off the config either way: an adapter is never told a tunnel
+            # exists, so these keys are never part of what it is handed
+            ssh_config = take_ssh_keys(values)
+        except HarlequinConfigError as e:
+            diagnostics.report_error(e)
+            ctx.exit(ExitCode.USAGE)
         raw_timeout = values.pop("timeout", None)
         stats: bool = bool(values.pop("stats", False))
         tuples_only: bool = bool(values.pop("tuples_only", False))
@@ -614,6 +668,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             typed="timeout" in explicitly_set,
         )
         deadline = _deadline(timeout_seconds)
+
+        tunnel = _open_tunnel(ctx, ssh_config)
+        if tunnel is not None:
+            # the run's, not the process's: click closes the context however
+            # this ends, and `harlequin.ssh` keeps an atexit backstop under that
+            ctx.call_on_close(tunnel.stop)
+            diagnostics.report_tunnel(tunnel.notice())
 
         if catalog:
             catalog_path = _catalog_path(ctx, path)
@@ -887,6 +948,30 @@ def _one_mode(
         )
         ctx.exit(ExitCode.USAGE)
     return chosen[0] if chosen else None
+
+
+def _open_tunnel(
+    ctx: click.Context, ssh_config: Mapping[str, Any]
+) -> "SshTunnel | None":
+    """The tunnel this run connects through, or exit having said why there is none.
+
+    Ahead of the connection and of anything that writes to stdout, because this
+    is where `ssh` may still ask a human for a passphrase. An unattended caller
+    passes `--ssh-batch-mode` and gets the refusal immediately instead.
+    """
+    if not ssh_config.get("ssh_host"):
+        # nothing to open, and so nothing to import
+        return None
+    from harlequin.ssh import open_tunnel
+
+    try:
+        return open_tunnel(ssh_config)
+    except HarlequinConfigError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.USAGE)
+    except HarlequinSshError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.CONNECTION)
 
 
 def _connect(

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -140,7 +140,7 @@ def report_theme_confusion(conn_str: Sequence[str]) -> None:
     )
 
 
-def report_tunnel(notice: str) -> None:
+def report_tunnel(notice: str, warnings: Sequence[str] = ()) -> None:
     """Say which local port the run is about to use, and where it goes.
 
     On stderr, like every other diagnostic, because it is the one thing about
@@ -148,6 +148,8 @@ def report_tunnel(notice: str) -> None:
     carrying them.
     """
     note(f"ssh: {notice}")
+    for warning in warnings:
+        note(f"ssh: {warning}")
 
 
 def timeout_message(seconds: float) -> str:

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -30,6 +30,7 @@ from harlequin.exception import (
     HarlequinConfigError,
     HarlequinConnectionError,
     HarlequinError,
+    HarlequinSshError,
 )
 from harlequin.redact import redact_text
 
@@ -90,7 +91,9 @@ def exit_code_for(error: BaseException) -> ExitCode:
         # a path that names nothing is a bad argument, not a failed query: the
         # catalog answered, and what it answered is that there is no such item.
         return ExitCode.USAGE
-    if isinstance(error, HarlequinConnectionError):
+    if isinstance(error, (HarlequinConnectionError, HarlequinSshError)):
+        # a tunnel that would not open is a database that cannot be reached,
+        # which is the one thing a caller does about either of them
         return ExitCode.CONNECTION
     return ExitCode.QUERY
 
@@ -135,6 +138,16 @@ def report_theme_confusion(conn_str: Sequence[str]) -> None:
         f"hsql has no themes; -t is --tuples-only, as in psql, "
         f"so {themed!r} was read as a connection string."
     )
+
+
+def report_tunnel(notice: str) -> None:
+    """Say which local port the run is about to use, and where it goes.
+
+    On stderr, like every other diagnostic, because it is the one thing about
+    the run that says which database the results came from -- and stdout is
+    carrying them.
+    """
+    note(f"ssh: {notice}")
 
 
 def timeout_message(seconds: float) -> str:

--- a/src/harlequin/hsql/timeout.py
+++ b/src/harlequin/hsql/timeout.py
@@ -118,6 +118,12 @@ class Deadline:
 
 def _halt(code: ExitCode) -> NoReturn:
     """End the process now, around a worker thread that would abort it."""
+    with contextlib.suppress(Exception):
+        # `os._exit()` runs no atexit handler, and an ssh child that outlives
+        # the run is the thing the tunnel feature exists to remove
+        from harlequin.ssh import stop_all
+
+        stop_all()
     for stream in (sys.stdout, sys.stderr):
         with contextlib.suppress(Exception):
             stream.flush()

--- a/src/harlequin/hsql/timeout.py
+++ b/src/harlequin/hsql/timeout.py
@@ -118,13 +118,13 @@ class Deadline:
 
 def _halt(code: ExitCode) -> NoReturn:
     """End the process now, around a worker thread that would abort it."""
-    with contextlib.suppress(Exception):
-        # `os._exit()` runs no atexit handler, and an ssh child that outlives
-        # the run is the thing the tunnel feature exists to remove
-        from harlequin.ssh import stop_all
-
-        stop_all()
     for stream in (sys.stdout, sys.stderr):
         with contextlib.suppress(Exception):
             stream.flush()
+    # ahead of `os._exit()`, which runs no atexit handler, and after the flush,
+    # because stopping a tunnel can spend seconds on a child that will not go
+    with contextlib.suppress(BaseException):
+        from harlequin.ssh import stop_all
+
+        stop_all()
     os._exit(code)

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -207,11 +207,6 @@
           "description": "Fail rather than prompt for a passphrase, a password or a host key. ssh's own BatchMode; set it in scripts, CI and cron.",
           "default": false
         },
-        "ssh_allow_reuse": {
-          "type": "boolean",
-          "description": "When the local port is already bound, warn and connect through the listener that has it instead of failing.",
-          "default": false
-        },
         "ssh_timeout": {
           "type": "number",
           "description": "Seconds to wait for the tunnel's forwards. [default: 60]"

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -184,6 +184,38 @@
           "type": "number",
           "description": "Cancel the run after SECONDS and exit 4. Refused if the adapter cannot cancel a query; to check, use --info."
         },
+        "ssh_host": {
+          "type": "string",
+          "description": "Open an SSH tunnel to this destination first, and connect through it. A Host alias, host, user@host or ssh://user@host:port, passed to ssh verbatim."
+        },
+        "ssh_forward": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "A local forward, spelled as ssh -L takes one: LOCAL:HOST:REMOTE. Repeatable. Omit it when your ssh config has the LocalForward."
+        },
+        "ssh_batch_mode": {
+          "type": "boolean",
+          "description": "Fail rather than prompt for a passphrase, a password or a host key. ssh's own BatchMode; set it in scripts, CI and cron.",
+          "default": false
+        },
+        "ssh_allow_reuse": {
+          "type": "boolean",
+          "description": "When the local port is already bound, warn and connect through the listener that has it instead of failing.",
+          "default": false
+        },
+        "ssh_timeout": {
+          "type": "number",
+          "description": "Seconds to wait for the tunnel's forwards. [default: 10]"
+        },
         "config_path": {
           "type": "string",
           "description": "Use this config file instead of the ones hsql discovers."

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -26,14 +26,15 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
-from harlequin.exception import HarlequinSshError
+from harlequin.config import CONFIG_ERROR_TITLE, DEFAULT_SSH_TIMEOUT, parse_seconds
+from harlequin.exception import HarlequinConfigError, HarlequinSshError
 
 SSH = "ssh"
 """The client, found on PATH: whichever one the user's `~/.ssh/config` is for."""
 
-DEFAULT_TIMEOUT = 10.0
+DEFAULT_TIMEOUT = DEFAULT_SSH_TIMEOUT
 """Seconds to wait for the forwards, when nothing says otherwise."""
 
 ERROR_TITLE = "Harlequin could not open the SSH tunnel."
@@ -61,6 +62,9 @@ _STDERR_LIMIT = 8192
 _LOOPBACK = "127.0.0.1"
 _WILDCARD_HOSTS = {"", "*", "0.0.0.0", "localhost"}
 _KEYWORD = re.compile(r"^([a-z][a-z0-9]*)(?:\s+(.*))?$")
+
+_LIVE: set[SshTunnel] = set()
+"""Every tunnel with a child running, for `stop_all()`."""
 
 
 @dataclass(frozen=True)
@@ -94,6 +98,73 @@ class SshConfig:
     """
 
     forwards: tuple[Forward, ...]
+
+
+@dataclass(frozen=True)
+class SshOptions:
+    """The five `--ssh-*` values, as either command's merged config supplies them."""
+
+    host: str | None = None
+    forwards: tuple[str, ...] = ()
+    batch_mode: bool = False
+    allow_reuse: bool = False
+    timeout: float = DEFAULT_TIMEOUT
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> SshOptions:
+        """What `config.take_ssh_keys()` took, as values `ssh` can be run with.
+
+        Raises: HarlequinConfigError for a value its key does not take. A
+        profile can put anything under one, and click has already vetted
+        whatever was typed on the command line.
+        """
+        forwards = config.get("ssh_forward") or ()
+        if isinstance(forwards, str):
+            forwards = (forwards,)
+        return cls(
+            host=_text(config.get("ssh_host"), key="ssh_host"),
+            forwards=tuple(
+                _text(forward, key="ssh_forward") or "" for forward in forwards
+            ),
+            batch_mode=bool(config.get("ssh_batch_mode")),
+            allow_reuse=bool(config.get("ssh_allow_reuse")),
+            timeout=parse_seconds(config.get("ssh_timeout"), key="ssh_timeout")
+            or DEFAULT_TIMEOUT,
+        )
+
+
+def open_tunnel(config: Mapping[str, Any]) -> SshTunnel | None:
+    """The tunnel this invocation runs under, started, or None for no tunnel.
+
+    Both commands' one line of this feature: everything from the five keys to a
+    child process holding a forward open, with prompts still reaching a human
+    because neither has taken the terminal yet.
+
+    Raises: HarlequinConfigError for a value a key does not take, and
+    HarlequinSshError for a tunnel that would not open.
+    """
+    options = SshOptions.from_config(config)
+    if options.host is None:
+        return None
+    tunnel = build_tunnel(
+        options.host,
+        options.forwards,
+        batch_mode=options.batch_mode,
+        allow_reuse=options.allow_reuse,
+        timeout=options.timeout,
+    )
+    tunnel.start()
+    return tunnel
+
+
+def stop_all() -> None:
+    """Kill every tunnel this process started.
+
+    The `atexit` backstop cannot reach a process that ends in `os._exit()`, and
+    an ssh child that outlives the session is the thing this feature removes.
+    """
+    for tunnel in list(_LIVE):
+        tunnel.stop()
 
 
 def build_argv(
@@ -133,13 +204,16 @@ def build_tunnel(
 ) -> SshTunnel:
     """The tunnel this invocation runs, having asked ssh what it will forward.
 
-    Raises: HarlequinSshError if nothing anywhere configures a local forward,
-    which is a destination Harlequin would connect to and never use.
+    Raises: HarlequinConfigError if nothing anywhere configures a local
+    forward, which is a destination Harlequin would connect to and never use,
+    and HarlequinSshError for an argv `ssh` must not be handed.
     """
     argv = build_argv(host, forwards, batch_mode=batch_mode)
     config = resolve_config(argv, timeout=timeout)
     if config is not None and not config.forwards:
-        raise HarlequinSshError(
+        # a usage error rather than a failure to connect: nothing has been run
+        # yet, and what is wrong is what was asked for
+        raise HarlequinConfigError(
             f"{host} configures no local forward, so a tunnel to it would "
             "carry nothing. Pass --ssh-forward LOCAL:HOST:REMOTE, or add a "
             f"LocalForward line to the {host} block of your ssh config.",
@@ -251,6 +325,30 @@ class SshTunnel:
         via = f" via {self.host}" if self.host else ""
         return f"{listed}{via}" if listed else f"tunnel to {self.host}"
 
+    def notice(self) -> str:
+        """What a started tunnel says for itself, on stderr or as a notification.
+
+        It is what tells a user which database they are actually looking at --
+        or, having reused a listener, that the one answering is not one
+        Harlequin opened.
+        """
+        if self.reused:
+            listed = ", ".join(f"{host}:{port}" for host, port in self.endpoints)
+            return (
+                f"{listed} is already bound; connecting through the existing "
+                "listener (--ssh-allow-reuse)"
+            )
+        return self.describe()
+
+    def cache_material(self) -> tuple[str, ...]:
+        """What a connection reached through this tunnel is keyed by, beside itself.
+
+        Two bastions fronting two databases both look like `localhost:15439`,
+        and a catalog cache or a query history shared between them would be one
+        database's answers under the other's name.
+        """
+        return (self.host, *(f"{f.listen} {f.destination}" for f in self.forwards))
+
     def start(self) -> None:
         """Start it and block until the forwarded ports accept connections.
 
@@ -275,6 +373,7 @@ class SshTunnel:
             ) from e
         self._process = process
         self._stderr = _Stderr(process.stderr)
+        _LIVE.add(self)
         atexit.register(self.stop)
         try:
             self._wait_until_ready(already_bound=already_bound)
@@ -285,6 +384,7 @@ class SshTunnel:
     def stop(self) -> None:
         """Kill the child, if there is one. Safe to call more than once."""
         atexit.unregister(self.stop)
+        _LIVE.discard(self)
         process, self._process = self._process, None
         if process is None:
             return
@@ -382,6 +482,18 @@ class _Stderr:
                 self._size += len(chunk)
                 while self._size > _STDERR_LIMIT and len(self._chunks) > 1:
                     self._size -= len(self._chunks.popleft())
+
+
+def _text(value: Any, *, key: str) -> str | None:
+    """One config value as the string `ssh` takes, or None where nothing was set."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise HarlequinConfigError(
+            f"{key}={value!r} is not text that ssh could read.",
+            title=CONFIG_ERROR_TITLE,
+        )
+    return value
 
 
 def _refuse_a_flag(option: str, value: str) -> None:

--- a/src/harlequin/ssh.py
+++ b/src/harlequin/ssh.py
@@ -50,6 +50,15 @@ _CONNECT_TIMEOUT = 0.5
 _GRACE_SECONDS = 1.0
 """What a tunnel with no port to poll waits, before trusting the child."""
 
+_PROBE_SECONDS = 10.0
+"""How long `ssh -G` has to print the resolved config.
+
+Its own bound rather than the caller's: `-G` connects to nothing, so the wait a
+user configures -- for a network, or for a person answering a prompt -- says
+nothing about it, and a small one would otherwise skip the readiness poll by
+leaving Harlequin with no forwards to wait on.
+"""
+
 _TERMINATE_SECONDS = 2.0
 """How long a terminated child has to exit before it is killed."""
 
@@ -68,6 +77,9 @@ _ANY_INTERFACE = {"", "*", "0.0.0.0", "::"}
 """Bind addresses that are not themselves an address to connect to."""
 
 _KEYWORD = re.compile(r"^([a-z][a-z0-9]*)(?:\s+(.*))?$")
+
+_CONTROL = re.compile(r"[^\n\t\x20-\x7e\xa0-\U0010ffff]")
+"""Every character a terminal reads as a command rather than as text."""
 
 _LIVE: set[SshTunnel] = set()
 """Every tunnel with a child running, for `stop_all()`."""
@@ -132,16 +144,11 @@ class SshOptions:
         profile can put anything under one, and click has already vetted
         whatever was typed on the command line.
         """
-        forwards = config.get("ssh_forward") or ()
-        if isinstance(forwards, str):
-            forwards = (forwards,)
         return cls(
             host=_text(config.get("ssh_host"), key="ssh_host"),
-            forwards=tuple(
-                _text(forward, key="ssh_forward") or "" for forward in forwards
-            ),
-            batch_mode=bool(config.get("ssh_batch_mode")),
-            allow_reuse=bool(config.get("ssh_allow_reuse")),
+            forwards=_forwards(config.get("ssh_forward")),
+            batch_mode=_flag(config.get("ssh_batch_mode"), key="ssh_batch_mode"),
+            allow_reuse=_flag(config.get("ssh_allow_reuse"), key="ssh_allow_reuse"),
             timeout=parse_seconds(config.get("ssh_timeout"), key="ssh_timeout")
             or DEFAULT_TIMEOUT,
         )
@@ -187,8 +194,11 @@ def stopping_on_signal() -> Iterator[None]:
 
     Neither signal runs an `atexit` handler, so a session that is killed, or
     whose terminal goes away, would otherwise leave `ssh` holding a forward
-    open. The tunnels are stopped from the handler rather than by the exception
-    it raises, which something further up may catch.
+    open.
+
+    Having stopped them, the handler dies of the signal it caught rather than
+    raising: a `SystemExit` here unwinds the main thread while a worker is
+    still inside a database driver, which aborts the interpreter and exits 134.
 
     A no-op off the main thread, and on a platform without the signal.
     """
@@ -196,7 +206,11 @@ def stopping_on_signal() -> Iterator[None]:
 
     def handle(number: int, frame: Any) -> None:
         stop_all()
-        raise SystemExit(128 + number)
+        for stream in (sys.stdout, sys.stderr):
+            with contextlib.suppress(Exception):
+                stream.flush()
+        signal.signal(number, signal.SIG_DFL)
+        os.kill(os.getpid(), number)
 
     for name in ("SIGTERM", "SIGHUP"):
         number = getattr(signal, name, None)
@@ -208,7 +222,10 @@ def stopping_on_signal() -> Iterator[None]:
         yield
     finally:
         for number, previous in replaced:
-            with contextlib.suppress(ValueError, OSError):
+            if previous is None:
+                # not installed from Python, and `signal()` takes no None back
+                continue
+            with contextlib.suppress(ValueError, OSError, TypeError):
                 signal.signal(number, previous)
 
 
@@ -251,13 +268,12 @@ def build_tunnel(
 
     Raises: HarlequinConfigError if nothing anywhere configures a local
     forward, which is a destination Harlequin would connect to and never use,
-    and HarlequinSshError for an argv `ssh` must not be handed.
+    and HarlequinSshError for an argv `ssh` must not be handed, or would not
+    take.
     """
     argv = build_argv(host, forwards, batch_mode=batch_mode)
-    config = resolve_config(argv, timeout=timeout)
+    config = resolve_config(argv)
     if config is not None and not config.forwards:
-        # a usage error rather than a failure to connect: nothing has been run
-        # yet, and what is wrong is what was asked for
         raise HarlequinConfigError(
             f"{host} configures no local forward, so a tunnel to it would "
             "carry nothing. Pass --ssh-forward LOCAL:HOST:REMOTE, or add a "
@@ -267,18 +283,26 @@ def build_tunnel(
     return SshTunnel(
         argv,
         forwards=config.forwards if config is not None else (),
+        requested=tuple(forwards),
+        resolved=config is not None,
         host=host,
         allow_reuse=allow_reuse,
         timeout=timeout,
     )
 
 
-def resolve_config(argv: Sequence[str], *, timeout: float) -> SshConfig | None:
+def resolve_config(
+    argv: Sequence[str], *, timeout: float = _PROBE_SECONDS
+) -> SshConfig | None:
     """What `ssh -G` says the argv about to run resolves to, or None.
 
     None is the degraded answer -- no client, no `-G`, or output this cannot
     read -- and every caller reads it as "ask ssh nothing else": no poll and no
     forwards-nothing error.
+
+    Raises: HarlequinSshError where the probe ran and rejected the argv. That
+    is the same argv `start()` is about to run, so the run ends either way, and
+    ssh names the value that is wrong while nothing has been spawned.
     """
     probe = [_client_path(argv[0]), "-G", *argv[1:]]
     try:
@@ -292,7 +316,11 @@ def resolve_config(argv: Sequence[str], *, timeout: float) -> SshConfig | None:
     except (OSError, subprocess.SubprocessError):
         return None
     if completed.returncode != 0:
-        return None
+        said = _readable(completed.stderr.decode("utf-8", errors="replace")).strip()
+        raise HarlequinSshError(
+            f"ssh would not accept the tunnel's options.\n\n{said}".rstrip(),
+            title=ERROR_TITLE,
+        )
     return parse_config(completed.stdout.decode("utf-8", errors="replace"))
 
 
@@ -334,12 +362,23 @@ class SshTunnel:
         argv: Sequence[str],
         *,
         forwards: Sequence[Forward] = (),
+        requested: Sequence[str] = (),
+        resolved: bool = True,
         host: str = "",
         allow_reuse: bool = False,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         self.argv = list(argv)
         self.forwards = tuple(forwards)
+        self.requested = tuple(requested)
+        """The forward specs a caller asked for, as `ssh -L` spells them."""
+        self.resolved = resolved
+        """Whether `ssh -G` said what this tunnel forwards.
+
+        False leaves `forwards` empty however many were asked for, so there is
+        nothing to poll and nothing to name: what the tunnel opened is taken on
+        the child's word.
+        """
         self.host = host
         self.allow_reuse = allow_reuse
         self.timeout = timeout
@@ -375,6 +414,20 @@ class SshTunnel:
         via = f" via {self.host}" if self.host else ""
         return f"{listed}{via}" if listed else f"tunnel to {self.host}"
 
+    @property
+    def exposed(self) -> tuple[str, ...]:
+        """Every forward of this tunnel that is not bound to loopback alone.
+
+        A forward on `0.0.0.0` or `*` reaches the whole network the machine is
+        on, which is worth saying out loud: the spec may come from a config
+        file discovered in the working directory rather than from its user.
+        """
+        return tuple(
+            _pretty(forward.listen)
+            for forward in self.forwards
+            if _is_exposed(forward.listen)
+        )
+
     def notice(self) -> str:
         """What a started tunnel says for itself, on stderr or as a notification.
 
@@ -390,14 +443,42 @@ class SshTunnel:
             )
         return self.describe()
 
+    def warnings(self) -> tuple[str, ...]:
+        """What is worth saying about this tunnel beyond where it goes.
+
+        A forward spec can come from a config file discovered in the working
+        directory, so what it opened is not necessarily what its user asked
+        for.
+        """
+        said = []
+        if self.exposed:
+            said.append(
+                f"{', '.join(self.exposed)} is bound to every interface, so "
+                "anything that can reach this machine can reach the database "
+                "through it."
+            )
+        if not self.resolved:
+            said.append(
+                "ssh did not say what it forwards, so Harlequin did not wait "
+                "for a local port to answer before connecting."
+            )
+        return tuple(said)
+
     def cache_material(self) -> tuple[str, ...]:
         """What a connection reached through this tunnel is keyed by, beside itself.
 
         Two bastions fronting two databases both look like `localhost:15439`,
         and a catalog cache or a query history shared between them would be one
-        database's answers under the other's name.
+        database's answers under the other's name. The specs a caller asked for
+        stand in where `ssh -G` did not say what was resolved, so two tunnels
+        that forward different ports never key alike.
         """
-        return (self.host, *(f"{f.listen} {f.destination}" for f in self.forwards))
+        forwarded = (
+            [f"{f.listen} {f.destination}" for f in self.forwards]
+            if self.forwards
+            else list(self.requested)
+        )
+        return (self.host, *forwarded)
 
     def start(self) -> None:
         """Start it and block until the forwarded ports accept connections.
@@ -570,7 +651,8 @@ class _Output:
     stdout must not be able to corrupt a caller's csv.
 
     A line at a time, so `redact_text()` sees whole lines: ssh is third-party
-    output, and a driver's DSN can reach it.
+    output, and a driver's DSN can reach it. `_readable()` takes the control
+    characters out for the same reason.
     """
 
     def __init__(self, stream: Any, *, echo: bool = True) -> None:
@@ -583,7 +665,9 @@ class _Output:
         self._thread.start()
 
     def text(self) -> str:
-        return b"".join(self._chunks).decode("utf-8", errors="replace").strip()
+        """What ssh said, as an error may quote it: redacted, and printable."""
+        raw = b"".join(self._chunks).decode("utf-8", errors="replace")
+        return redact_text(_readable(raw)).strip()
 
     def settle(self) -> None:
         """Wait for the drain to catch up with a child that has exited.
@@ -626,7 +710,7 @@ class _Output:
             self._size -= len(self._chunks.popleft())
 
     def _show(self, raw: bytes) -> None:
-        text = redact_text(raw.decode("utf-8", errors="replace"))
+        text = redact_text(_readable(raw.decode("utf-8", errors="replace")))
         with contextlib.suppress(OSError, ValueError):
             sys.stderr.write(text)
             sys.stderr.flush()
@@ -640,6 +724,54 @@ def _text(value: Any, *, key: str) -> str | None:
         raise HarlequinConfigError(
             f"{key}={value!r} is not text that ssh could read.",
             title=CONFIG_ERROR_TITLE,
+        )
+    return value
+
+
+def _forwards(value: Any) -> tuple[str, ...]:
+    """One config value as the forward specs `ssh -L` takes.
+
+    A profile can put anything under the key: one spec, a list of them, or
+    something that is neither. An entry with nothing in it is refused rather
+    than passed on, since `ssh` answers `-L ""` by refusing the whole run.
+
+    Raises: HarlequinConfigError for a value that is not a spec or a list of them.
+    """
+    if value is None or value == "":
+        return ()
+    if isinstance(value, str):
+        value = (value,)
+    if not isinstance(value, (list, tuple)):
+        raise HarlequinConfigError(
+            f"ssh_forward={value!r} is not a forward spec, or a list of them.",
+            title=CONFIG_ERROR_TITLE,
+        )
+    forwards = []
+    for forward in value:
+        spec = _text(forward, key="ssh_forward")
+        if spec is None:
+            raise HarlequinConfigError(
+                "ssh_forward has an entry with nothing in it. Spell each one "
+                "LOCAL:HOST:REMOTE, or leave the key out.",
+                title=CONFIG_ERROR_TITLE,
+            )
+        forwards.append(spec)
+    return tuple(forwards)
+
+
+def _flag(value: Any, *, key: str) -> bool:
+    """One config value as the boolean its key takes.
+
+    Only a boolean: TOML has one, and reading `"false"` as true is the kind of
+    wrong a user cannot see in their own file.
+
+    Raises: HarlequinConfigError for anything else.
+    """
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise HarlequinConfigError(
+            f"{key}={value!r} is not true or false.", title=CONFIG_ERROR_TITLE
         )
     return value
 
@@ -739,6 +871,30 @@ def _pretty(field: str) -> str:
     host, port = split
     host = host or "localhost"
     return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+
+
+def _is_exposed(field: str) -> bool:
+    """Whether an `ssh -G` listen field binds somewhere other than loopback.
+
+    A field with no host is loopback: that is what ssh binds a bare port to. A
+    socket path is not an interface, so it is not one either.
+    """
+    split = _split(field)
+    if split is None:
+        return False
+    host = split[0]
+    return host not in ("", "localhost", "::1", "[::1]") and not host.startswith("127.")
+
+
+def _readable(text: str) -> str:
+    """`text` with the control characters a terminal would act on removed.
+
+    ssh's stderr carries a server's pre-auth banner and a helper's output
+    verbatim, and both are chosen by whatever the config file pointed at: an
+    escape sequence in either would drive the terminal it is printed to, or
+    become markup in the widget it is shown in.
+    """
+    return _CONTROL.sub("", text)
 
 
 def _accepts(endpoint: tuple[str, int]) -> bool:

--- a/tests/data/unit_tests/ssh/ssh
+++ b/tests/data/unit_tests/ssh/ssh
@@ -87,17 +87,24 @@ def main() -> int:
         forwards.append(from_config)
 
     if dump_config:
+        probe_exit = int(os.environ.get("FAKE_SSH_PROBE_EXIT", "0"))
+        if probe_exit:
+            # a real client says why it would not take the argv
+            message = os.environ.get("FAKE_SSH_STDERR")
+            if message:
+                print(message, file=sys.stderr, flush=True)
+            return probe_exit
         text = os.environ.get("FAKE_SSH_PROBE_TEXT")
         if text is not None:
             sys.stdout.write(text)
-            return int(os.environ.get("FAKE_SSH_PROBE_EXIT", "0"))
+            return 0
         print(f"host {destination}")
         print(f"hostname {destination}")
         print("port 22")
         for spec in forwards:
             listen, connect = format_forward(spec)
             print(f"localforward {listen} {connect}")
-        return int(os.environ.get("FAKE_SSH_PROBE_EXIT", "0"))
+        return 0
 
     message = os.environ.get("FAKE_SSH_STDERR")
     if message:

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -140,6 +140,7 @@ def test_default(
         show_files=None,
         show_s3=None,
         export_path=None,
+        ssh_tunnel=None,
     )
 
 

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -8,6 +8,7 @@ observable thing a real forward does to the machine Harlequin runs on.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import socket
@@ -15,12 +16,20 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Iterator, Sequence
+from unittest.mock import MagicMock
 
+import click
 import pytest
+from click.testing import CliRunner, Result
 
-from harlequin.exception import HarlequinSshError
+from harlequin.cli import build_cli as harlequin_cli
+from harlequin.config import DEFAULT_SSH_TIMEOUT, SSH_KEYS, take_ssh_keys
+from harlequin.exception import HarlequinConfigError, HarlequinSshError
+from harlequin.hsql.cli import build_cli as hsql_cli
+from harlequin.hsql.diagnostics import ExitCode
 from harlequin.ssh import (
     Forward,
+    SshOptions,
     SshTunnel,
     build_argv,
     build_tunnel,
@@ -185,7 +194,7 @@ def fake_ssh(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_a_destination_that_forwards_nothing_names_both_places_to_put_one(
     fake_ssh: None,
 ) -> None:
-    with pytest.raises(HarlequinSshError, match="--ssh-forward") as excinfo:
+    with pytest.raises(HarlequinConfigError, match="--ssh-forward") as excinfo:
         build_tunnel("redshift_prod")
     assert "LocalForward" in str(excinfo.value)
 
@@ -352,3 +361,260 @@ def test_the_lifecycle_helpers_agree_about_ports(
     ports: Sequence[int] = (free_port(), free_port())
     with child_tunnel(*ports):
         assert all(accepts(port) for port in ports)
+
+
+# both commands, end to end, against a fake client on PATH
+
+
+@pytest.fixture
+def ssh_on_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """A fake `ssh` the real CLI path will find, and a log of how it was called."""
+    monkeypatch.setenv("PATH", f"{FAKE_SSH.parent}{os.pathsep}{os.environ['PATH']}")
+    record = tmp_path / "argv.jsonl"
+    monkeypatch.setenv("FAKE_SSH_ARGV", str(record))
+    return record
+
+
+def calls(record: Path) -> list[list[str]]:
+    """Every argv the fake client was run with, probe included."""
+    if not record.exists():
+        return []
+    return [json.loads(line) for line in record.read_text().splitlines()]
+
+
+def run_hsql(*args: str) -> Result:
+    argv = [str(arg) for arg in args]
+    return CliRunner().invoke(hsql_cli(argv), argv, catch_exceptions=False)
+
+
+def run_harlequin(*args: str) -> Result:
+    argv = [str(arg) for arg in args]
+    return CliRunner().invoke(harlequin_cli(argv), argv, catch_exceptions=False)
+
+
+TUNNELED = ["--ssh-host", "redshift_prod", "--ssh-forward"]
+DUCK = ["-a", "duckdb", "--no-init", ":memory:"]
+
+
+@posix_only
+def test_hsql_runs_sql_through_a_tunnel(
+    ssh_on_path: Path, no_discovered_config: None
+) -> None:
+    port = free_port()
+    result = run_hsql(
+        *DUCK, *TUNNELED, f"{port}:data.example.com:5439", "-c", "select 1 as one"
+    )
+    assert result.exit_code == 0
+    assert "one" in result.output
+    assert f"ssh: 127.0.0.1:{port} -> data.example.com:5439 via redshift_prod" in (
+        result.stderr
+    )
+    # the child is gone with the run, rather than left for the user to kill
+    assert not accepts(port)
+
+
+@posix_only
+def test_the_forward_reaches_ssh_unchanged_and_repeats_in_order(
+    ssh_on_path: Path, no_discovered_config: None
+) -> None:
+    specs = [f"{free_port()}:one.internal:5439", f"{free_port()}:two.internal:5440"]
+    result = run_hsql(
+        *DUCK,
+        "--ssh-host",
+        "tco@web-1",
+        *[arg for spec in specs for arg in ("--ssh-forward", spec)],
+        "--ssh-batch-mode",
+        "-c",
+        "select 1",
+    )
+    assert result.exit_code == 0
+    argv = calls(ssh_on_path)[-1]
+    assert argv[-1] == "tco@web-1"
+    assert [argv[i + 1] for i, arg in enumerate(argv) if arg == "-L"] == specs
+    assert "BatchMode=yes" in argv
+
+
+@posix_only
+def test_a_destination_that_forwards_nothing_is_a_usage_error(
+    ssh_on_path: Path, no_discovered_config: None
+) -> None:
+    result = run_hsql(*DUCK, "--ssh-host", "redshift_prod", "-c", "select 1")
+    assert result.exit_code == ExitCode.USAGE
+    assert "--ssh-forward" in result.stderr
+    assert "LocalForward" in result.stderr
+
+
+@posix_only
+def test_a_tunnel_that_will_not_open_exits_3_quoting_ssh(
+    ssh_on_path: Path, no_discovered_config: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAKE_SSH_STDERR", "Permission denied (publickey).")
+    monkeypatch.setenv("FAKE_SSH_EXIT", "255")
+    result = run_hsql(
+        *DUCK, *TUNNELED, f"{free_port()}:db.internal:5432", "-c", "select 1"
+    )
+    assert result.exit_code == ExitCode.CONNECTION
+    assert "Permission denied (publickey)." in result.stderr
+    assert result.stdout == ""
+
+
+@posix_only
+def test_the_tunnel_is_not_opened_for_a_mode_that_never_connects(
+    ssh_on_path: Path, no_discovered_config: None
+) -> None:
+    result = run_hsql("-a", "duckdb", *TUNNELED, "15439:db.internal:5432", "--info")
+    assert result.exit_code == 0
+    assert calls(ssh_on_path) == []
+
+
+@posix_only
+def test_a_profile_carries_the_tunnel_and_the_details_that_need_it(
+    ssh_on_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """§3.1: one key beside the connection details that already work."""
+    port = free_port()
+    config = tmp_path / ".harlequin.toml"
+    config.write_text(
+        "[profiles.redshift]\n"
+        'adapter = "duckdb"\n'
+        "no_init = true\n"
+        'ssh_host = "redshift_prod"\n'
+        f'ssh_forward = ["{port}:data.example.com:5439"]\n'
+    )
+    monkeypatch.setattr(
+        "harlequin.config._search_directories",
+        lambda: [(tmp_path, (".harlequin.toml",))],
+    )
+    result = run_hsql("-P", "redshift", ":memory:", "-c", "select 1 as one")
+    assert result.exit_code == 0, result.stderr
+    assert "redshift_prod" in result.stderr
+    assert calls(ssh_on_path)[-1][-1] == "redshift_prod"
+
+
+@posix_only
+def test_the_adapter_is_never_told_a_tunnel_exists(
+    ssh_on_path: Path, no_discovered_config: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The contract: the connection details reach the adapter exactly as typed."""
+    from harlequin.plugins import load_adapter
+
+    handed: dict[str, object] = {}
+
+    def spy(name: str) -> type:
+        adapter_cls = load_adapter(name)
+
+        class Recording(adapter_cls):  # type: ignore[valid-type,misc]
+            def __init__(self, **kwargs: object) -> None:
+                handed.update(kwargs)
+                super().__init__(**kwargs)
+
+        return Recording
+
+    monkeypatch.setattr("harlequin.hsql.cli.load_adapter", spy)
+    result = run_hsql(
+        *DUCK, *TUNNELED, f"{free_port()}:data.example.com:5439", "-c", "select 1"
+    )
+    assert result.exit_code == 0, result.stderr
+    assert handed["conn_str"] == (":memory:",)
+    assert not [key for key in handed if key.startswith("ssh")]
+
+
+@posix_only
+def test_the_ide_opens_the_tunnel_before_it_starts(
+    ssh_on_path: Path, no_discovered_config: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = MagicMock()
+    monkeypatch.setattr("harlequin.cli.Harlequin", app)
+    port = free_port()
+    result = run_harlequin(
+        "-a",
+        "duckdb",
+        "--no-init",
+        ":memory:",
+        *TUNNELED,
+        f"{port}:data.example.com:5439",
+    )
+    assert result.exit_code == 0
+    tunnel = app.call_args.kwargs["ssh_tunnel"]
+    assert tunnel is not None
+    assert tunnel.host == "redshift_prod"
+    # started before the app was built, and stopped when it returned
+    assert app.return_value.run.called
+    assert not accepts(port)
+
+
+@posix_only
+def test_two_bastions_do_not_share_a_catalog_cache(
+    ssh_on_path: Path, no_discovered_config: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both look like `localhost:15439`, and the details cannot tell them apart."""
+    app = MagicMock()
+    monkeypatch.setattr("harlequin.cli.Harlequin", app)
+    forward = f"{free_port()}:data.example.com:5439"
+    hashes = []
+    for host in ("bastion_one", "bastion_two"):
+        run_harlequin(
+            "-a",
+            "duckdb",
+            "--no-init",
+            ":memory:",
+            "--ssh-host",
+            host,
+            "--ssh-forward",
+            forward,
+        )
+        hashes.append(app.call_args.kwargs["connection_hash"])
+    assert hashes[0] != hashes[1]
+
+
+def test_both_commands_take_the_same_ssh_options() -> None:
+    """One profile serves both, so a spelling that drifted would only work in one."""
+
+    def spellings(command: click.Command) -> dict[str, tuple[str, ...]]:
+        return {
+            param.name: tuple(param.opts)
+            for param in command.params
+            if param.name is not None and param.name.startswith("ssh_")
+        }
+
+    ide = spellings(harlequin_cli([]))
+    headless = spellings(hsql_cli([]))
+    assert set(ide) == set(SSH_KEYS)
+    assert ide == headless
+
+
+def test_the_ssh_timeout_is_the_one_default_both_commands_carry() -> None:
+    assert SshOptions.from_config({}).timeout == DEFAULT_SSH_TIMEOUT
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"ssh_forward": ["15439:db:5432"]},
+        {"ssh_batch_mode": True},
+        {"ssh_timeout": 30},
+    ],
+)
+def test_a_tunnel_with_no_destination_is_refused(config: dict) -> None:
+    with pytest.raises(HarlequinConfigError, match="ssh_host"):
+        take_ssh_keys(dict(config))
+
+
+def test_the_ssh_keys_come_off_whatever_else_a_profile_holds() -> None:
+    profile = {"host": "localhost", "port": 15439, "ssh_host": "web-1"}
+    taken = take_ssh_keys(profile)
+    assert profile == {"host": "localhost", "port": 15439}
+    assert taken == {"ssh_host": "web-1"}
+
+
+@pytest.mark.parametrize("value", [42, ["a", "b"], {"x": 1}])
+def test_a_destination_that_is_not_text_is_refused(value: object) -> None:
+    with pytest.raises(HarlequinConfigError, match="ssh_host"):
+        SshOptions.from_config({"ssh_host": value})
+
+
+def test_a_profile_may_write_one_forward_as_a_string() -> None:
+    options = SshOptions.from_config(
+        {"ssh_host": "web-1", "ssh_forward": "15439:db:5432"}
+    )
+    assert options.forwards == ("15439:db:5432",)

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -226,14 +226,35 @@ def test_output_that_is_not_a_resolved_config_degrades(text: str) -> None:
 
 
 @posix_only
-def test_a_probe_that_fails_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_probe_that_ssh_rejects_is_reported_in_its_own_words(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same argv `start()` would run, so the run ends here either way."""
     monkeypatch.setenv("FAKE_SSH_PROBE_EXIT", "255")
-    assert resolve_config([str(FAKE_SSH), "web-1"], timeout=10) is None
+    monkeypatch.setenv("FAKE_SSH_STDERR", "Bad local forwarding specification ''")
+    with pytest.raises(HarlequinSshError) as excinfo:
+        resolve_config([str(FAKE_SSH), "web-1"])
+    assert "Bad local forwarding specification" in str(excinfo.value)
 
 
 @posix_only
 def test_a_missing_client_degrades() -> None:
-    assert resolve_config(["harlequin-no-such-ssh", "web-1"], timeout=10) is None
+    assert resolve_config(["harlequin-no-such-ssh", "web-1"]) is None
+
+
+@posix_only
+def test_the_probe_does_not_spend_the_wait_configured_for_the_tunnel(
+    fake_ssh: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`ssh -G` connects to nothing, so a short --ssh-timeout must not skip it.
+
+    A probe that timed out would leave the tunnel with no forwards to poll, and
+    so nothing to check the local port against.
+    """
+    monkeypatch.setenv("FAKE_SSH_FORWARD", "15439:db.internal:5439")
+    tunnel = build_tunnel("redshift_prod", timeout=0.001)
+    assert tunnel.resolved
+    assert tunnel.endpoints == (("localhost", 15439),)
 
 
 # building a tunnel, which is the probe plus the argv
@@ -804,3 +825,64 @@ def test_a_profile_may_write_one_forward_as_a_string() -> None:
         {"ssh_host": "web-1", "ssh_forward": "15439:db:5432"}
     )
     assert options.forwards == ("15439:db:5432",)
+
+
+@pytest.mark.parametrize("value", [5432, True, 1.5, {"15439:db:5432": 1}, [42]])
+def test_a_forward_that_is_not_a_spec_or_a_list_of_them_is_refused(
+    value: object,
+) -> None:
+    with pytest.raises(HarlequinConfigError, match="ssh_forward"):
+        SshOptions.from_config({"ssh_host": "web-1", "ssh_forward": value})
+
+
+def test_a_forward_with_nothing_in_it_is_refused() -> None:
+    """`ssh` answers `-L ""` by refusing the whole run, naming nothing useful."""
+    with pytest.raises(HarlequinConfigError, match="ssh_forward"):
+        SshOptions.from_config(
+            {"ssh_host": "web-1", "ssh_forward": ["", "15439:db:5432"]}
+        )
+
+
+@pytest.mark.parametrize("key", ["ssh_batch_mode", "ssh_allow_reuse"])
+@pytest.mark.parametrize("value", ["false", "no", 0, 1])
+def test_a_flag_a_profile_did_not_write_as_a_boolean_is_refused(
+    key: str, value: object
+) -> None:
+    """`ssh_batch_mode = "false"` read as true is a wrong a user cannot see."""
+    with pytest.raises(HarlequinConfigError, match=key):
+        SshOptions.from_config({"ssh_host": "web-1", key: value})
+
+
+def test_a_timeout_that_is_not_seconds_is_named_as_one() -> None:
+    """Ahead of the destination check, which would otherwise answer first."""
+    with pytest.raises(HarlequinConfigError, match="positive number of seconds"):
+        take_ssh_keys({"ssh_timeout": -5})
+
+
+def test_two_tunnels_that_forward_different_ports_never_key_alike() -> None:
+    """`ssh -G` says nothing here, so the specs asked for are what is left."""
+    one = SshTunnel(["ssh", "web-1"], requested=("15439:a:5439",), host="web-1")
+    two = SshTunnel(["ssh", "web-1"], requested=("15440:b:5440",), host="web-1")
+    assert one.cache_material() != two.cache_material()
+
+
+def test_a_forward_on_every_interface_is_said_out_loud() -> None:
+    tunnel = SshTunnel(
+        ["ssh", "web-1"],
+        forwards=(Forward("[0.0.0.0]:15439", "[db]:5439"),),
+        host="web-1",
+    )
+    assert tunnel.exposed == ("0.0.0.0:15439",)
+    assert "every interface" in " ".join(tunnel.warnings())
+
+
+def test_a_loopback_forward_says_nothing_beyond_where_it_goes() -> None:
+    tunnel = SshTunnel(
+        ["ssh", "web-1"], forwards=(Forward("15439", "[db]:5439"),), host="web-1"
+    )
+    assert tunnel.warnings() == ()
+
+
+def test_a_tunnel_ssh_would_not_describe_says_it_waited_for_nothing() -> None:
+    tunnel = SshTunnel(["ssh", "web-1"], resolved=False, host="web-1")
+    assert "did not wait" in " ".join(tunnel.warnings())


### PR DESCRIPTION
Part 2 of 5 of `docs/plans/ssh-tunnels-design.md`. **Based on #1112**, which is where `harlequin/ssh.py` lands; review that one first, and this diff on top of it.

Stack: 1/5 tunnel → **2/5 (this)** → 3/5 keepalive & reporting → 4/5 reconnect → 5/5 changelog.

Part of #545

**What** are the key elements of this solution?

Five options, in `harlequin` and in `hsql`, and one profile key each: `--ssh-host`, `--ssh-forward` (repeatable), `--ssh-batch-mode`, `--ssh-allow-reuse`, `--ssh-timeout`.

```toml
[profiles.redshift]
adapter = "postgres"
host = "localhost"
port = 15439
dbname = "prod"
ssh_host = "redshift_prod"
```

- `harlequin.config` names the five keys (`SSH_KEYS`) and `take_ssh_keys()` takes them off a merged config; `harlequin.ssh.open_tunnel()` turns what it took into a started child.
- The tunnel opens in the click callback, before Textual and before anything connects. `hsql` registers `tunnel.stop` with `ctx.call_on_close`; the IDE wraps `tui.run()` in an `ExitStack`.
- `hsql` writes the tunnel's line to stderr (`note: ssh: 127.0.0.1:15439 -> data.example.com:5439 via redshift_prod`) and exits 3 for a tunnel that would not open, quoting ssh. The IDE notifies instead, and gets the tunnel object as `Harlequin(ssh_tunnel=...)`.
- The ssh destination and its resolved forwards join the connection hash, via a new `through=` argument to `get_connection_hash()`.
- The generated `schemas/config-v1.json` and `docs/generated/hsql-reference.md` are regenerated, which is what makes the profile keys valid ones.

**Why** did you design your solution this way? Did you assess any alternatives?

- **The adapter is never told a tunnel exists.** `conn_str` and every adapter option reach it exactly as typed — which is why any adapter works, including out-of-tree ones. That is §2 of the design, and there is a test for it.
- **Two exit codes, not one.** A destination that forwards nothing is a *usage* error (exit 2), because nothing has run yet and what is wrong is what was asked for; `build_tunnel()` raises `HarlequinConfigError` there. A tunnel that would not open is a database that cannot be reached (exit 3), which `exit_code_for()` now maps `HarlequinSshError` to.
- **The five options are declared in each command rather than shared.** Importing a shared module at CLI import time would put `harlequin.ssh` on the path of every invocation, and §6 promises it is imported only when `ssh_host` is set. A test pins the two declarations to the same spellings, in the spirit of the copies the two commands already keep of each other.
- **`--ssh-timeout` carries no click default**, so that "any ssh key set with no destination" is detectable and refused rather than silently connecting past a forward the user meant to use.
- **Two bastions fronting two databases both look like `localhost:15439`.** Without the cache-key change they would share a catalog cache and a query history. `through=` is omitted from the hashed material when there is no tunnel, so an untunneled connection keys exactly as it always has.
- **`hsql --timeout`'s hard exit now stops the tunnel** (`harlequin.ssh.stop_all()`): `os._exit()` runs no `atexit` handler, and an ssh child that outlives the run is the thing this feature removes.

Does this PR require a change to Harlequin's docs?
- [x] Yes, and it comes with 5/5 of this stack ([tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web)).

Did you add or update tests for this change?
- [x] Yes.

End-to-end tests drive the real CLI path for both commands against the fake `ssh` on `PATH` (Unix only, as the design says): a query runs through a tunnel and the child is gone with the run; the forwards reach the argv unchanged and in order; a mode that never connects opens nothing; a profile carries the tunnel; two bastions hash differently; the adapter is handed no `ssh_*` key. Plus unit tests for `take_ssh_keys()` and `SshOptions`.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md` — in 5/5 of this stack.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD

---
_Generated by [Claude Code](https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD)_