### PR TITLE
SSH tunnels 5/5: changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Harlequin and hsql can now reach a database through an SSH tunnel, with any adapter: pass `--ssh-host` (and `--ssh-forward`, unless your ssh config already has a `LocalForward`), and point the connection details at the local end of the forward. Add `--ssh-batch-mode` in scripts and CI so ssh fails instead of prompting ([#545](https://github.com/tconbeer/harlequin/issues/545)).
 - Data Catalog items that are too wide for the catalog now show their full name and type in a tooltip on hover ([#1104](https://github.com/tconbeer/harlequin/issues/1104)).
 
 ### Bug Fixes


### PR DESCRIPTION
Part 5 of 5 of `docs/plans/ssh-tunnels-design.md`. **Based on #1115**; review the stack in order.

Stack: 1/5 tunnel → 2/5 options → 3/5 keepalive & reporting → 4/5 reconnect → **5/5 (this)**.

Closes #545

**What** are the key elements of this solution?

The `[Unreleased]` → Features entry, citing #545. One sentence on what to pass and where to point the connection details, and one on `--ssh-batch-mode` for scripts and CI.

**Why** did you design your solution this way?

The entry names the flags and the contract — point the details at the local end of the forward — and nothing about how it works inside, per `.claude/rules/changelog.md`. It lands at the end of the stack because that is where the feature becomes user-visible; each earlier PR is incomplete on its own.

Does this PR require a change to Harlequin's docs?
- [x] Yes; I haven't opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web), but the gist of the change is: a page for the tunnel options covering §2's contract (Harlequin runs `ssh` and touches nothing else; the connection details name the local end of the forward, so any adapter works), with the `Host` block of §3.1 as the recommended setup and the flags-only form of §3.2 for CI and agents; a note that a distinct local port — `15439`, not `5439` — turns "forgot the tunnel" into a connection refused rather than the wrong database; and `--ssh-batch-mode` in the headless docs beside the other flags a script should set.

Did you add or update tests for this change?
- [x] No, I believe tests aren't necessary. The four PRs under this one carry the tests.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD

---
_Generated by [Claude Code](https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD)_