### PR TITLE
Load the catalog items the query editor names (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Data Catalog items that are too wide for the catalog now show their full name and type in a tooltip on hover ([#1104](https://github.com/tconbeer/harlequin/issues/1104)).
+- Autocompletion now offers the members of the schemas and tables you type: naming an object in the Query Editor loads its children from the database, without expanding it in the Data Catalog first ([#752](https://github.com/tconbeer/harlequin/issues/752)).
 
 ### Bug Fixes
 

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -657,6 +657,12 @@ class Harlequin(AppBase):
             callback = partial(self.post_message, message)
             self.set_timer(delay=0.5, callback=callback)
 
+    @on(CodeEditor.SymbolsFound)
+    def load_catalog_items_named_by_buffer(
+        self, message: CodeEditor.SymbolsFound
+    ) -> None:
+        self.data_catalog.database_tree.load_items_named(message.symbols.names)
+
     @on(QueriesExecuted)
     def fetch_data_or_reset_table(self, message: QueriesExecuted) -> None:
         if message.cursors:  # select query

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -331,9 +331,9 @@ class EditorCollection(Vertical):
         """Hand the loaded buffer's symbols to the completers.
 
         They are kept here as well, since the app swaps in whole new completers
-        every time it rebuilds them from the catalog.
+        every time it rebuilds them from the catalog. The message goes on to the
+        app, which asks the Data Catalog to load the items the buffer names.
         """
-        message.stop()
         self._buffer_symbols = message.symbols
         for completer in (self._word_completer, self._member_completer):
             if completer is not None:

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -93,11 +93,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         self._symbol_names: frozenset[str] = frozenset()
         """The casefolded identifiers in the loaded buffer, from the query editor."""
         self._node_ids: dict[int, NodeID] = {}
-        """The id of the node _populate_node() built for each item, keyed by id(item).
-
-        The alternative is a scan of the tree's nodes per load, which grows with
-        the part of the catalog the user has expanded.
-        """
+        """The id of the node built for each item, keyed by id(item)."""
         self._prefetch_timer: Timer | None = None
         super().__init__(
             label="Root",

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from asyncio import PriorityQueue
+from collections import deque
 from typing import TYPE_CHECKING, Generator, Iterable, TypeVar
 
 from rich.style import Style
@@ -27,8 +28,19 @@ if TYPE_CHECKING:
 DEMAND_PRIORITY = 0
 """Priority for a node the user expanded; jumps ahead of all speculative work."""
 
+SYMBOL_PRIORITY = 50
+"""Priority for a node the query editor names; behind demand, ahead of prefetch."""
+
 PREFETCH_PRIORITY = 100
 """Priority for a node we load speculatively, because it's on (or near) screen."""
+
+MAX_SYMBOL_LOADS = 25
+"""Nodes a single scan of the buffer's symbols will queue.
+
+A common word like `id` can name many objects, and each load is a round trip to
+the database; the ones this scan drops are queued by the next one, once these
+have loaded.
+"""
 
 PREFETCH_MARGIN = 20
 """Lines above and below the viewport to warm, so a short scroll finds data ready."""
@@ -60,20 +72,26 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         classes: str | None = None,
         disabled: bool = False,
     ) -> None:
-        self._load_queue: PriorityQueue[
-            tuple[int, int, TreeNode[InteractiveCatalogItem]]
-        ] = PriorityQueue()
+        self._load_queue: PriorityQueue[tuple[int, int, InteractiveCatalogItem]] = (
+            PriorityQueue()
+        )
         """
         _load_queue is a priority queue, ordered by a priority int, then by an
         ever-increasing sequence number, which makes the queue FIFO within a
-        priority and ensures the TreeNodes are never compared (they do not
+        priority and ensures the CatalogItems are never compared (they do not
         implement cmp operators).
+
+        It holds items rather than TreeNodes because the query editor asks for
+        items the tree has not built a node for; the node, if there is one, is
+        looked up when the fetch returns.
         """
         self._queue_seq = 0
         self._queued_priority: dict[int, int] = {}
-        """The priority each pending node was queued at, keyed by id(node)."""
+        """The priority each pending item was queued at, keyed by id(item)."""
         self._loading: set[int] = set()
-        """ids of nodes whose fetch_children() call is in flight."""
+        """ids of items whose fetch_children() call is in flight."""
+        self._symbol_names: frozenset[str] = frozenset()
+        """The casefolded identifiers in the loaded buffer, from the query editor."""
         self._prefetch_timer: Timer | None = None
         super().__init__(
             label="Root",
@@ -116,22 +134,22 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         self.loading = False
 
     def _add_to_load_queue(
-        self, node: TreeNode[InteractiveCatalogItem], priority: int = PREFETCH_PRIORITY
+        self, item: InteractiveCatalogItem | None, priority: int = PREFETCH_PRIORITY
     ) -> None:
-        """Add the given node to the load priority queue.
+        """Add the given catalog item to the load priority queue.
 
-        A node already queued at an equal or better priority is left alone; one
+        An item already queued at an equal or better priority is left alone; one
         queued at a worse priority is re-queued, and the stale entry is dropped
-        when it surfaces. This keeps a node the user expands from being fetched
+        when it surfaces. This keeps an item the user expands from being fetched
         (and re-rendered) twice.
 
         Args:
-            node: The node to add to the load queue.
-            priority: An order for this node to be loaded; lowest first.
+            item: The catalog item to add to the load queue.
+            priority: An order for this item to be loaded; lowest first.
         """
-        if node.data is None or node.data.loaded:
+        if item is None or item.loaded:
             return
-        key = id(node)
+        key = id(item)
         if key in self._loading:
             return
         queued_at = self._queued_priority.get(key)
@@ -139,7 +157,18 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
             return
         self._queued_priority[key] = priority
         self._queue_seq += 1
-        self._load_queue.put_nowait((priority, self._queue_seq, node))
+        self._load_queue.put_nowait((priority, self._queue_seq, item))
+
+    def _node_for_item(self, item: CatalogItem) -> TreeNode[CatalogItem] | None:
+        """The TreeNode showing the given item, if the tree has built one.
+
+        A collapsed node keeps its children on its data, so most of the catalog
+        is loaded without a node to show it.
+        """
+        for node in self._tree_nodes.values():
+            if node.data is item:
+                return node
+        return None
 
     def _prefetch_window(self) -> tuple[int, int]:
         """The inclusive range of tree lines worth loading speculatively."""
@@ -176,7 +205,42 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         for line_no in range(first, min(last + 1, len(lines))):
             node = lines[line_no].node
             if isinstance(node.data, InteractiveCatalogItem) and not node.data.loaded:
-                self._add_to_load_queue(node)  # type: ignore[arg-type]
+                self._add_to_load_queue(node.data)
+
+    def load_items_named(self, names: Iterable[str]) -> None:
+        """Fetch the children of the loaded catalog items a buffer names.
+
+        Lazy loading means an object only offers completions once its parent has
+        been loaded, and the query editor is the best evidence available of which
+        parents those are: an identifier the user has typed is usually a database,
+        schema or relation whose members they are about to want.
+        """
+        self._symbol_names = frozenset(name.casefold() for name in names)
+        self._queue_named_items()
+
+    def _queue_named_items(self) -> None:
+        """Queue the unloaded items the buffer names, shallowest first.
+
+        Each load reveals the next level down -- a schema's relations, then the
+        columns of the relation the buffer also names -- so this runs again
+        whenever the loader delivers more of the catalog.
+        """
+        if not self._symbol_names or self.root.data is None:
+            return
+        queued = 0
+        frontier: deque[CatalogItem] = deque(self.root.data.children)
+        while frontier and queued < MAX_SYMBOL_LOADS:
+            item = frontier.popleft()
+            if (
+                isinstance(item, InteractiveCatalogItem)
+                and not item.loaded
+                and not item.children
+            ):
+                if item.label.casefold() in self._symbol_names:
+                    self._add_to_load_queue(item, priority=SYMBOL_PRIORITY)
+                    queued += 1
+            else:
+                frontier.extend(item.children)
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         super().watch_scroll_y(old_value, new_value)
@@ -282,9 +346,10 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                     or reopening == node
                 ):
                     try:
-                        content = await self._load_children(reopening).wait()
+                        content = await self._load_children(reopening.data).wait()
                     except (WorkerCancelled, WorkerFailed):
                         continue
+                    reopening.allow_expand = bool(reopening.data.children)
                     await self._populate_node(reopening, content)
                     to_reopen.extend(reopening.children)
                     reopening.expand()
@@ -388,35 +453,33 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         return len(node.children) == 1 and node.children[0].data is LOADING_ITEM
 
     @work(thread=True, exit_on_error=False, description="_load_children")
-    def _load_children(self, node: TreeNode[CatalogItem]) -> list[CatalogItem]:
-        """Load the children for a given node.
+    def _load_children(self, item: CatalogItem) -> list[CatalogItem]:
+        """Load the children for a given catalog item.
 
         Args:
-            node: The node to load the children for.
+            item: The catalog item to load the children for.
 
         Returns:
-            The list of entries within the directory associated with the node.
+            The list of entries nested under that item.
         """
-        assert node.data is not None
         if (
-            not node.data.children
-            and isinstance(node.data, InteractiveCatalogItem)
-            and not node.data.loaded
+            not item.children
+            and isinstance(item, InteractiveCatalogItem)
+            and not item.loaded
         ):
             try:
-                children = list(node.data.fetch_children())
+                children = list(item.fetch_children())
             except BaseException as e:
                 self.post_message(self.CatalogError(catalog_type="database", error=e))
                 return []
             else:
-                node.data.children = children
-                self.post_message(NewCatalogItems(parent=node.data, items=children))
+                item.children = children
+                self.post_message(NewCatalogItems(parent=item, items=children))
             finally:
-                node.data.loaded = True
-                node.allow_expand = bool(node.data.children)
+                item.loaded = True
 
         return sorted(
-            node.data.children,
+            item.children,
             key=lambda catalog_item: catalog_item.label,
         )
 
@@ -434,30 +497,31 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         # retires this worker when reload() starts its successor.
         queue = self._load_queue
         while not worker.is_cancelled:
-            # Get the next node that needs loading off the queue. Note that
+            # Get the next item that needs loading off the queue. Note that
             # this blocks if the queue is empty.
-            priority, _, node = await queue.get()
-            key = id(node)
+            priority, _, item = await queue.get()
+            key = id(item)
             try:
                 if self._queued_priority.get(key) != priority:
-                    # a stale entry: this node was re-queued at a better priority
+                    # a stale entry: this item was re-queued at a better priority
                     # (or has since been loaded), so it is handled elsewhere.
                     continue
                 del self._queued_priority[key]
-                if priority > DEMAND_PRIORITY and not self._in_prefetch_window(
-                    node  # type: ignore[arg-type]
+                node = self._node_for_item(item)
+                if priority == PREFETCH_PRIORITY and (
+                    node is None or not self._in_prefetch_window(node)
                 ):
                     # scrolled or collapsed out of view before we got to it, so
                     # the speculation no longer pays for itself.
                     continue
                 self._loading.add(key)
                 try:
-                    # Spin up a short-lived thread that will load the children of
-                    # the catalog item associated with that node. The tree lock is
-                    # deliberately not held here: an adapter's fetch_children() can
-                    # take seconds against a remote database, and holding the lock
-                    # across it would block the tree's own rendering and input.
-                    content = await self._load_children(node).wait()
+                    # Spin up a short-lived thread that will load the item's
+                    # children. The tree lock is deliberately not held here: an
+                    # adapter's fetch_children() can take seconds against a remote
+                    # database, and holding the lock across it would block the
+                    # tree's own rendering and input.
+                    content = await self._load_children(item).wait()
                 except WorkerCancelled:
                     # The worker was cancelled, that would suggest we're all
                     # done here and we should get out of the loader in general.
@@ -468,15 +532,23 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                     continue
                 finally:
                     self._loading.discard(key)
-                # _load_children may have cleared allow_expand, and setting that
-                # only bumps the node's update counter -- nothing repaints. Without
-                # this, a node we found to be empty keeps a phantom expand arrow.
+                # the children we just loaded may include more of what the
+                # buffer names, a level deeper
+                self._queue_named_items()
+                # a node may have been built for this item while it was in flight
+                node = self._node_for_item(item)
+                if node is None:
+                    continue
+                # setting allow_expand only bumps the node's update counter --
+                # nothing repaints. Without the invalidate, a node we found to be
+                # empty keeps a phantom expand arrow.
+                node.allow_expand = bool(item.children)
                 self._invalidate()
                 # Only build TreeNodes the user can actually reach. A collapsed
                 # node keeps its children on `node.data`, and they are rendered
                 # if and when it is expanded. Empty content still has to be
                 # populated, to clear the placeholder off a node with no children.
-                if node.is_expanded or self._has_placeholder(node):  # type: ignore[arg-type]
+                if node.is_expanded or self._has_placeholder(node):
                     await self._populate_node(node, content)
                     self._schedule_prefetch_scan()
             finally:
@@ -493,7 +565,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         if isinstance(node.data, InteractiveCatalogItem) and not node.data.loaded:
             # if this node isn't loaded yet, add it to the front of the queue
             self._show_loading_placeholder(node)
-            self._add_to_load_queue(node, priority=DEMAND_PRIORITY)  # type: ignore[arg-type]
+            self._add_to_load_queue(node.data, priority=DEMAND_PRIORITY)
         elif node.data.children and (not node.children or self._has_placeholder(node)):
             await self._populate_node(node, content=node.data.children)
         self._schedule_prefetch_scan()

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -11,7 +11,7 @@ from textual import events, work
 from textual.await_complete import AwaitComplete
 from textual.reactive import var
 from textual.timer import Timer
-from textual.widgets._tree import Tree, TreeNode
+from textual.widgets._tree import NodeID, Tree, TreeNode
 from textual.worker import WorkerCancelled, WorkerFailed, get_current_worker
 
 from harlequin.catalog import (
@@ -92,6 +92,12 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         """ids of items whose fetch_children() call is in flight."""
         self._symbol_names: frozenset[str] = frozenset()
         """The casefolded identifiers in the loaded buffer, from the query editor."""
+        self._node_ids: dict[int, NodeID] = {}
+        """The id of the node _populate_node() built for each item, keyed by id(item).
+
+        The alternative is a scan of the tree's nodes per load, which grows with
+        the part of the catalog the user has expanded.
+        """
         self._prefetch_timer: Timer | None = None
         super().__init__(
             label="Root",
@@ -163,12 +169,15 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         """The TreeNode showing the given item, if the tree has built one.
 
         A collapsed node keeps its children on its data, so most of the catalog
-        is loaded without a node to show it.
+        is loaded without a node to show it. Removing a node drops it from the
+        tree's own index and node ids are never reused, so a stale id resolves
+        to nothing rather than to the wrong node.
         """
-        for node in self._tree_nodes.values():
-            if node.data is item:
-                return node
-        return None
+        node_id = self._node_ids.get(id(item))
+        if node_id is None:
+            return None
+        node = self._tree_nodes.get(node_id)
+        return node if node is not None and node.data is item else None
 
     def _prefetch_window(self) -> tuple[int, int]:
         """The inclusive range of tree lines worth loading speculatively."""
@@ -181,6 +190,11 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
             return False
         first, last = self._prefetch_window()
         return first <= line <= last
+
+    def _is_in_view(self, item: CatalogItem) -> bool:
+        """Whether the tree is showing the given item, near enough to prefetch it."""
+        node = self._node_for_item(item)
+        return node is not None and self._in_prefetch_window(node)
 
     def _schedule_prefetch_scan(self) -> None:
         """Queue a viewport scan, coalescing the bursts that scrolling produces."""
@@ -260,6 +274,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         self._load_queue = PriorityQueue()
         self._queued_priority.clear()
         self._loading.clear()
+        self._node_ids.clear()
         # ... reset the root node ...
         processed = self.reload_node(self.root)
         # ... and replace the old loader with a new one.
@@ -424,12 +439,13 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
         for offset in range(0, len(items), POPULATE_CHUNK_SIZE):
             async with self.lock:
                 for item in items[offset : offset + POPULATE_CHUNK_SIZE]:
-                    node.add(
+                    child = node.add(
                         self._build_item_label(item.label, item.type_label),
                         data=item,
                         allow_expand=bool(item.children)
                         or not getattr(item, "loaded", True),
                     )
+                    self._node_ids[id(item)] = child.id
             await asyncio.sleep(0)
 
     def _show_loading_placeholder(self, node: TreeNode[CatalogItem]) -> None:
@@ -507,10 +523,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
                     # (or has since been loaded), so it is handled elsewhere.
                     continue
                 del self._queued_priority[key]
-                node = self._node_for_item(item)
-                if priority == PREFETCH_PRIORITY and (
-                    node is None or not self._in_prefetch_window(node)
-                ):
+                if priority == PREFETCH_PRIORITY and not self._is_in_view(item):
                     # scrolled or collapsed out of view before we got to it, so
                     # the speculation no longer pays for itself.
                     continue

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -20,6 +20,7 @@ from textual.geometry import Offset
 from textual.widgets import Input, Tooltip
 
 from harlequin import Harlequin
+from harlequin.autocomplete.completers import BUFFER_TYPE_LABEL
 from harlequin.catalog import CatalogItem, InteractiveCatalogItem
 from harlequin.components import ExportScreen
 from harlequin_duckdb.adapter import DuckDbAdapter
@@ -459,16 +460,14 @@ async def test_reload_while_loader_is_fetching(
         while tree.loading:
             await pilot.pause()
 
-        node = tree.root.add(
-            "blocking",
-            data=BlockingCatalogItem(
-                qualified_identifier="blocking",
-                query_name="blocking",
-                label="blocking",
-                type_label="t",
-            ),
+        item = BlockingCatalogItem(
+            qualified_identifier="blocking",
+            query_name="blocking",
+            label="blocking",
+            type_label="t",
         )
-        tree._add_to_load_queue(node, priority=0)  # type: ignore[arg-type]
+        tree.root.add("blocking", data=item)
+        tree._add_to_load_queue(item, priority=0)
 
         # wait until the adapter call is actually in flight
         while not BlockingCatalogItem.started.is_set():
@@ -537,3 +536,65 @@ async def test_tooltip_shows_the_full_label_of_a_truncated_item(
         tooltip = app.screen.get_child_by_type(Tooltip)
         await pilot.pause(app.TOOLTIP_DELAY + 0.1)
         assert tooltip.display
+
+
+@pytest.mark.asyncio
+async def test_buffer_symbols_load_the_items_they_name(
+    duckdb_adapter: Type[DuckDbAdapter],
+    tmp_path: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """The catalog loads the children of the items the query editor names.
+
+    Lazy loading otherwise leaves a schema's relations (and their columns) out of
+    the completions until the user expands the schema in the Data Catalog
+    ([#752](https://github.com/tconbeer/harlequin/issues/752)).
+    """
+    db_path = tmp_path / "symbols.db"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("create schema my_schema")
+    conn.execute("create table my_schema.my_table (my_col int)")
+    conn.close()
+
+    app = Harlequin(
+        duckdb_adapter((str(db_path),), no_init=True),
+        connection_hash="symbols",
+    )
+    async with app.run_test(size=(120, 36)) as pilot:
+        await wait_for_workers(app)
+        tree = app.data_catalog.database_tree
+        while (
+            tree.loading
+            or app.editor is None
+            or app.editor_collection.member_completer is None
+        ):
+            await pilot.pause()
+        member_completer = app.editor_collection.member_completer
+
+        database_item = tree.root.data.children[0] if tree.root.data else None
+        assert database_item is not None
+        while not getattr(database_item, "loaded", False):
+            await pilot.pause()
+        schema_item = next(
+            item for item in database_item.children if item.label == "my_schema"
+        )
+        assert not schema_item.children
+        assert not member_completer("my_schema.my_t")
+
+        app.editor.text = "select * from my_schema.my_table"
+
+        # the editor re-reads the buffer on a timer, the tree loads the schema
+        # the buffer names, and then the relation it names under it
+        for _ in range(100):
+            if member_completer("my_table.my_c"):
+                break
+            await pilot.pause(0.1)
+
+        # the buffer names my_table, so its own completion for it is not proof;
+        # the column is one only the catalog could have offered.
+        (schema_label, schema_value), *_ = member_completer("my_schema.my_t")
+        assert schema_value == "my_schema.my_table"
+        assert schema_label[1] != BUFFER_TYPE_LABEL
+        (column_label, column_value), *_ = member_completer("my_table.my_c")
+        assert column_value == "my_table.my_col"
+        assert column_label[1] != BUFFER_TYPE_LABEL


### PR DESCRIPTION
Closes #752

**What** are the key elements of this solution?

- `CodeEditor.SymbolsFound` now bubbles past `EditorCollection` to the app, which hands the buffer's identifiers to `DatabaseTree.load_items_named()`.
- The tree walks the loaded catalog breadth-first and queues every unloaded item whose label a buffer names, at a new `SYMBOL_PRIORITY` — behind what the user expanded, ahead of the viewport prefetch. Capped at `MAX_SYMBOL_LOADS` (25) per scan; the rest are picked up by the next one.
- After each completed load it re-scans, so `select * from my_schema.my_table` loads the schema's relations and then that relation's columns.
- The load queue now holds `CatalogItem`s rather than `TreeNode`s, and the node — if there is one — is resolved when the fetch returns, through an `id(item) -> NodeID` index that `_populate_node()` maintains.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The issue proposes fetching children when a member completion is triggered, and notes the hard part: a deduplicated completion has no reference back to its nodes. Since #1077 that reverse mapping isn't needed — the editor already reads every identifier out of the buffer on a throttle for the completers, and those symbols name whole objects. An identifier a user has typed is usually a database, schema or relation whose members they are about to want, so it is a better trigger than the completion prefix, and it fires while they are still typing rather than after the dot.

The queue holding items rather than nodes is what makes this work at all: a collapsed node keeps its children on its data, so most of the catalog is loaded with no node to show it, and the editor asks for items the tree has never built a node for. Routing symbol-driven loads through the same background loader (rather than a second worker) keeps adapter calls serialized, and means an item the user expands mid-flight is populated when the fetch returns instead of keeping its "loading…" placeholder.

Resolving the node was first a scan of every node the tree had built, twice per load — 2.5ms at 50k nodes, on the event loop, in the path that loads a large catalog. It is now a dict hit validated against the tree's own `_tree_nodes`: removing a node drops it from there and node ids are never reused, so a stale entry resolves to nothing. Storing the node object instead would be one hop shorter but unsafe — `_populate_node()` removes a node's children before re-adding them a chunk at a time, so a directly-held node can be detached while the map still looks valid, and the loader would populate a ghost.

Tradeoffs: a common word (`id`) can name many objects, hence the per-scan cap; and if the completion list is already open when a load lands it doesn't refresh — the next keystroke re-queries.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

`test_buffer_symbols_load_the_items_they_name` asserts that a named schema's relation and that relation's columns become completions after typing, checking the type label so the buffer's own symbols can't pass the test for the wrong reason. Verified that it fails without the app handler. The existing expand/snapshot tests cover the node index: if the lookup missed, the loader would not populate an expanded node.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115ncV5X9kjKyZQQGDPYuh9

---
_Generated by [Claude Code](https://claude.ai/code/session_0115ncV5X9kjKyZQQGDPYuh9)_