### PR TITLE
fix: surface errors from unrecognized background workers (#1117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - The config wizard no longer pre-fills the unset query limit with `-1` or unset adapter options with `None` (`****` for secrets). Leave the limit blank for app defaults, or enter `-1` for no limit ([#1105](https://github.com/tconbeer/harlequin/issues/1105)).
 - Harlequin and hsql no longer crash when trying to open a file that isn't text ([#1108](https://github.com/tconbeer/harlequin/issues/1108)).
+- Background task failures no longer disappear silently or crash Harlequin; they now show an error dialog or warning as appropriate ([#1117](https://github.com/tconbeer/harlequin/issues/1117)).
 
 ## [2.12.2] - 2026-08-31
 

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -177,6 +177,18 @@ class CompletersReady(Message):
         self.member_completer = member_completer
 
 
+_PARTIAL_FAILURE_WORKER_NOTIFICATIONS: dict[str, str] = {
+    "_load_catalog_cache": (
+        "Harlequin could not load its cache; your query history may be missing."
+    ),
+    "_extend_and_merge_completers": "Harlequin could not update completions.",
+    "_build_completers": "Harlequin could not build completions.",
+}
+"""Toast text for the workers whose failure is partial: the app stays usable,
+so their errors surface as a notification rather than an error modal.
+"""
+
+
 class Harlequin(AppBase):
     """
     The SQL IDE for your Terminal.
@@ -574,30 +586,60 @@ class Harlequin(AppBase):
             await self._handle_worker_error(message)
 
     async def _handle_worker_error(self, message: Worker.StateChanged) -> None:
-        if (
-            message.worker.name == "update_schema_data"
-            and message.worker.error is not None
-        ):
+        worker_name = message.worker.name
+        worker_error = message.worker.error
+        if self._exit or worker_error is None:
+            # an error that lands while the app is exiting is noise, not news.
+            return
+        if worker_name == "update_schema_data":
             self._push_error_modal(
                 title="Catalog Error",
                 header="Could not update data catalog",
-                error=message.worker.error,
+                error=worker_error,
             )
             self.data_catalog.database_tree.loading = False
-        elif message.worker.name == "_connect" and message.worker.error is not None:
+        elif worker_name == "_connect":
             title = getattr(
-                message.worker.error,
+                worker_error,
                 "title",
                 "Harlequin could not connect to your database.",
             )
             error = (
-                message.worker.error
-                if isinstance(message.worker.error, HarlequinError)
-                else HarlequinConnectionError(
-                    msg=str(message.worker.error), title=title
-                )
+                worker_error
+                if isinstance(worker_error, HarlequinError)
+                else HarlequinConnectionError(msg=str(worker_error), title=title)
             )
             self.exit(return_code=2, message=pretty_error_message(error))
+        elif worker_name in ("_execute_query", "_fetch_data"):
+            # the worker died before posting QueriesExecuted or ResultsFetched,
+            # which is what would have restored these.
+            self.run_query_bar.set_responsive()
+            self.results_viewer.show_table()
+            header = getattr(worker_error, "title", worker_error.__class__.__name__)
+            self._push_error_modal(
+                title="Query Error",
+                header=header,
+                error=worker_error,
+            )
+        elif worker_name == "toggle_transaction_mode":
+            self._push_error_modal(
+                title="Transaction Error",
+                header="Harlequin could not change the transaction mode.",
+                error=worker_error,
+            )
+        elif worker_name in _PARTIAL_FAILURE_WORKER_NOTIFICATIONS:
+            self.notify(
+                _PARTIAL_FAILURE_WORKER_NOTIFICATIONS[worker_name],
+                severity="warning",
+            )
+        else:
+            # loud by default: a worker added later is an error modal until
+            # someone decides its failures are benign.
+            self._push_error_modal(
+                title="Unexpected Error",
+                header="A background task failed. Harlequin is still running.",
+                error=worker_error,
+            )
 
     @on(HarlequinTree.CatalogError)
     def handle_catalog_error(self, message: HarlequinTree.CatalogError) -> None:

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -14,6 +14,7 @@ from textual.reactive import reactive
 from textual.timer import Timer
 from textual.widgets import Tab, Tabs, TextArea
 from textual.widgets.text_area import EditHistory, Location, Selection
+from textual.worker import Worker, WorkerState
 from textual_textarea import TextAreaSaved, TextEditor
 
 from harlequin.autocomplete import (
@@ -72,6 +73,8 @@ class CodeEditor(TextEditor, inherit_bindings=False):
             self.symbols = symbols
 
     _symbol_scan_timer: Union[Timer, None] = None
+    _symbol_scan_failed: bool = False
+    """Whether the last symbol scan failed; one toast per failure streak."""
 
     @on(TextArea.Changed)
     def schedule_symbol_scan(self, message: TextArea.Changed) -> None:
@@ -85,9 +88,35 @@ class CodeEditor(TextEditor, inherit_bindings=False):
         self._symbol_scan_timer = None
         self.read_symbols(self.text)
 
-    @work(thread=True, exclusive=True, group="symbol_scanners")
+    @work(
+        thread=True,
+        exclusive=True,
+        exit_on_error=False,
+        group="symbol_scanners",
+    )
     def read_symbols(self, text: str) -> None:
         self.post_message(self.SymbolsFound(symbols=find_symbols(text)))
+
+    @on(Worker.StateChanged)
+    def handle_symbol_scan_error(self, message: Worker.StateChanged) -> None:
+        if (
+            message.state == WorkerState.ERROR
+            and message.worker.name == "read_symbols"
+            and message.worker.error is not None
+            and not self._symbol_scan_failed
+        ):
+            # a scan failure is a degraded buffer, not a reason to die; typing
+            # in the same broken buffer would toast on every debounced scan.
+            self._symbol_scan_failed = True
+            self.app.notify(
+                "Harlequin could not read this buffer's identifiers.",
+                severity="warning",
+            )
+
+    @on(SymbolsFound)
+    def reset_symbol_scan_failure(self, message: SymbolsFound) -> None:
+        # not stopped: SymbolsFound must keep bubbling to the app.
+        self._symbol_scan_failed = False
 
     def selected_queries(self) -> list[str]:
         """

--- a/src/harlequin/components/data_catalog/database_tree.py
+++ b/src/harlequin/components/data_catalog/database_tree.py
@@ -7,12 +7,18 @@ from typing import TYPE_CHECKING, Generator, Iterable, TypeVar
 
 from rich.style import Style
 from rich.text import Text, TextType
-from textual import events, work
+from textual import events, on, work
 from textual.await_complete import AwaitComplete
 from textual.reactive import var
 from textual.timer import Timer
 from textual.widgets._tree import NodeID, Tree, TreeNode
-from textual.worker import WorkerCancelled, WorkerFailed, get_current_worker
+from textual.worker import (
+    Worker,
+    WorkerCancelled,
+    WorkerFailed,
+    WorkerState,
+    get_current_worker,
+)
 
 from harlequin.catalog import (
     Catalog,
@@ -498,6 +504,7 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
     @work(
         name="_database_tree_background_loader",
         exclusive=True,
+        exit_on_error=False,
         group="database_tree_loaders",
     )
     async def _loader(self) -> None:
@@ -563,6 +570,16 @@ class DatabaseTree(HarlequinTree[CatalogItem], inherit_bindings=False):
             finally:
                 # Mark this iteration as done, on the queue this item came from.
                 queue.task_done()
+
+    @on(Worker.StateChanged)
+    def handle_worker_error(self, message: Worker.StateChanged) -> None:
+        # _load_children already reports its own failures, so an ERROR from
+        # either of this tree's workers is unexpected. Surfaced here rather
+        # than through exit_on_error=True, which would crash the whole app.
+        if message.state == WorkerState.ERROR and message.worker.error is not None:
+            self.post_message(
+                self.CatalogError(catalog_type="database", error=message.worker.error)
+            )
 
     async def _on_tree_node_expanded(
         self, event: Tree.NodeExpanded[CatalogItem]

--- a/tests/functional_tests/test_app.py
+++ b/tests/functional_tests/test_app.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from types import SimpleNamespace
+from typing import Awaitable, Callable, cast
 
 import pytest
 from textual.message import Message
+from textual.worker import Worker, WorkerState
 
 from harlequin import Harlequin
 from harlequin.app import QueriesExecuted, QuerySubmitted, ResultsFetched
@@ -376,3 +378,253 @@ async def test_adapter_raises_unexpected_error(
         assert len(app.screen_stack) == 1
         assert "non-responsive" not in app.run_query_bar.classes
         assert "non-responsive" not in app.results_viewer.classes
+
+
+def worker_error_message(
+    worker_name: str, error: BaseException | None
+) -> Worker.StateChanged:
+    """A StateChanged ERROR the handler sees from a real failed worker.
+
+    The message only carries the worker object; the handler reads its name and
+    error, so a namespace stands in for the Worker.
+    """
+    return Worker.StateChanged(
+        cast(
+            "Worker",
+            SimpleNamespace(name=worker_name, error=error),
+        ),
+        WorkerState.ERROR,
+    )
+
+
+def _modal_errors_on_screen(app: Harlequin) -> list[ErrorModal]:
+    return [screen for screen in app.screen_stack if isinstance(screen, ErrorModal)]
+
+
+@pytest.mark.asyncio
+async def test_update_schema_data_worker_error_shows_catalog_modal(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        app.data_catalog.database_tree.loading = True
+        await app.handle_worker_error(
+            worker_error_message("update_schema_data", RuntimeError("boom"))
+        )
+        await pilot.pause()
+        assert isinstance(app.screen, ErrorModal)
+        assert app.screen.header == "Could not update data catalog"
+        assert "boom" in str(app.screen.error)
+        assert app.data_catalog.database_tree.loading is False
+
+
+@pytest.mark.asyncio
+async def test_connect_worker_error_exits_with_code_two(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await app.handle_worker_error(
+            worker_error_message("_connect", RuntimeError("connection refused"))
+        )
+        await pilot.pause()
+    assert app.return_code == 2
+
+
+@pytest.mark.asyncio
+async def test_worker_error_from_unrecognized_worker_shows_modal(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """A worker the handler doesn't name is loud by default, not silent.
+
+    Regression test for #1117: errors from every unrecognized worker used to
+    vanish without a trace.
+    """
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await app.handle_worker_error(
+            worker_error_message("some_future_worker", RuntimeError("boom"))
+        )
+        await pilot.pause()
+        assert app.is_running
+        assert isinstance(app.screen, ErrorModal)
+        assert "boom" in str(app.screen.error)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_name", ["_execute_query", "_fetch_data"])
+async def test_query_worker_error_shows_modal_and_restores_ui(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    worker_name: str,
+) -> None:
+    """A query worker that dies without posting its result message must not
+    leave the run bar stuck in the non-responsive state."""
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        app.run_query_bar.set_not_responsive()
+        app.results_viewer.show_loading()
+        await app.handle_worker_error(
+            worker_error_message(worker_name, RuntimeError("boom"))
+        )
+        await pilot.pause()
+        assert app.is_running
+        assert isinstance(app.screen, ErrorModal)
+        assert "boom" in str(app.screen.error)
+        assert "non-responsive" not in app.run_query_bar.classes
+        assert "non-responsive" not in app.results_viewer.classes
+
+
+@pytest.mark.asyncio
+async def test_execute_query_worker_error_is_not_silent_and_app_survives(
+    app: Harlequin,
+    monkeypatch: pytest.MonkeyPatch,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """An error in the code around _execute_query's per-statement handling
+    shows a modal and restores the UI, instead of silently sticking it.
+
+    Regression test for #1117, against the real worker machinery.
+    """
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        assert app.connection is not None
+
+        def broken_execute(
+            connection: object,
+            statements: object,
+            limit: object = None,
+            on_error: object = "stop",
+        ) -> object:
+            raise RuntimeError("boom inside execute core")
+
+        monkeypatch.setattr("harlequin.app.execute", broken_execute)
+
+        app.editor.text = "select 1"
+        await pilot.press("ctrl+a")
+        await pilot.press("ctrl+j")
+        for _ in range(100):
+            if isinstance(app.screen, ErrorModal):
+                break
+            await pilot.pause(0.05)
+        assert app.is_running
+        assert isinstance(app.screen, ErrorModal)
+        assert "boom inside execute core" in str(app.screen.error)
+        assert "non-responsive" not in app.run_query_bar.classes
+
+        await pilot.press("space")
+        assert len(app.screen_stack) == 1
+
+
+@pytest.mark.asyncio
+async def test_toggle_transaction_mode_worker_error_shows_modal(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await app.handle_worker_error(
+            worker_error_message("toggle_transaction_mode", RuntimeError("boom"))
+        )
+        await pilot.pause()
+        assert app.is_running
+        assert isinstance(app.screen, ErrorModal)
+        assert app.screen.title == "Transaction Error"
+        assert "boom" in str(app.screen.error)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("worker_name", "expected_message"),
+    [
+        (
+            "_load_catalog_cache",
+            "Harlequin could not load its cache; your query history may be missing.",
+        ),
+        ("_extend_and_merge_completers", "Harlequin could not update completions."),
+        ("_build_completers", "Harlequin could not build completions."),
+    ],
+)
+async def test_partial_failure_workers_notify_without_modal(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    worker_name: str,
+    expected_message: str,
+) -> None:
+    """A worker whose failure leaves the app usable warns instead of modaling."""
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await app.handle_worker_error(
+            worker_error_message(worker_name, RuntimeError("boom"))
+        )
+        await pilot.pause()
+        assert app.is_running
+        assert not _modal_errors_on_screen(app)
+        warnings = [
+            notification
+            for notification in list(app._notifications)
+            if notification.severity == "warning"
+        ]
+        assert [n.message for n in warnings] == [expected_message]
+
+
+@pytest.mark.asyncio
+async def test_worker_errors_are_ignored_while_app_is_exiting(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """An error that lands during the exit drain is noise, not a modal."""
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        app._exit = True
+        try:
+            await app.handle_worker_error(
+                worker_error_message("some_future_worker", RuntimeError("boom"))
+            )
+        finally:
+            app._exit = False
+        await pilot.pause()
+        assert len(app.screen_stack) == 1
+        assert app.is_running
+
+
+@pytest.mark.asyncio
+async def test_worker_state_change_without_error_is_ignored(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await app.handle_worker_error(worker_error_message("some_future_worker", None))
+        await pilot.pause()
+        assert len(app.screen_stack) == 1
+        assert app.is_running

--- a/tests/functional_tests/test_data_catalog.py
+++ b/tests/functional_tests/test_data_catalog.py
@@ -9,6 +9,7 @@ from typing import (
     NamedTuple,
     Set,
     Type,
+    cast,
 )
 from unittest.mock import MagicMock
 
@@ -16,18 +17,25 @@ import duckdb
 import pytest
 from rich.style import Style
 from rich.text import Text
+from textual import work
 from textual.geometry import Offset
 from textual.widgets import Input, Tooltip
+from textual.worker import WorkerState
 
 from harlequin import Harlequin
 from harlequin.autocomplete.completers import BUFFER_TYPE_LABEL
 from harlequin.catalog import CatalogItem, InteractiveCatalogItem
-from harlequin.components import ExportScreen
+from harlequin.components import ErrorModal, ExportScreen
+from harlequin.components.data_catalog.database_tree import DatabaseTree
 from harlequin_duckdb.adapter import DuckDbAdapter
 
 
 class MockS3Object(NamedTuple):
     key: str
+
+
+class SimpleCatalogItem(InteractiveCatalogItem):
+    """An interactive item whose children fetch as an empty list."""
 
 
 @pytest.fixture
@@ -598,3 +606,142 @@ async def test_buffer_symbols_load_the_items_they_name(
         (column_label, column_value), *_ = member_completer("my_table.my_c")
         assert column_value == "my_table.my_col"
         assert column_label[1] != BUFFER_TYPE_LABEL
+
+
+@pytest.mark.asyncio
+async def test_child_worker_failure_is_surfaced_and_loader_continues(
+    duckdb_adapter: Type[DuckDbAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected failure in the loader's per-item worker shows one catalog
+    modal, and the loader goes on to the next item.
+
+    _load_children catches adapter failures itself; a child worker that fails
+    anyway reaches the loader's WorkerFailed path, and its StateChanged ERROR
+    is surfaced by DatabaseTree rather than crashing Harlequin (regression
+    test for #1117).
+    """
+    poison_item = SimpleCatalogItem(
+        qualified_identifier="poison",
+        query_name="poison",
+        label="poison",
+        type_label="t",
+    )
+    good_item = SimpleCatalogItem(
+        qualified_identifier="good",
+        query_name="good",
+        label="good",
+        type_label="t",
+    )
+    original_load_children = cast(
+        Callable[[DatabaseTree, CatalogItem], list[CatalogItem]],
+        getattr(DatabaseTree._load_children, "__wrapped__"),  # noqa: B009
+    )
+
+    @work(thread=True, exit_on_error=False, description="_load_children")
+    def patched_load_children(
+        tree: DatabaseTree, item: CatalogItem
+    ) -> list[CatalogItem]:
+        if item is poison_item:
+            raise RuntimeError("boom in _load_children")
+        return original_load_children(tree, item)
+
+    monkeypatch.setattr(DatabaseTree, "_load_children", patched_load_children)
+
+    app = Harlequin(duckdb_adapter((":memory:",)), connection_hash="child-failure")
+    async with app.run_test(size=(120, 36)) as pilot:
+        tree = app.data_catalog.database_tree
+        while tree.loading or app.editor is None:
+            await pilot.pause()
+
+        tree.root.add("poison", data=poison_item)
+        tree._add_to_load_queue(poison_item, priority=0)
+        for _ in range(200):
+            if any(isinstance(screen, ErrorModal) for screen in app.screen_stack):
+                break
+            await pilot.pause(0.05)
+        assert isinstance(app.screen, ErrorModal)
+        assert "boom in _load_children" in str(app.screen.error)
+        assert app._exception is None
+        await pilot.press("space")
+        await pilot.pause()
+        assert len(app.screen_stack) == 1
+
+        # the loader survived the failed item and still processes the queue
+        tree.root.add("good", data=good_item)
+        tree._add_to_load_queue(good_item, priority=0)
+        for _ in range(200):
+            if good_item.loaded:
+                break
+            await pilot.pause(0.05)
+        assert good_item.loaded
+        assert len(app.screen_stack) == 1
+        assert app._exception is None
+
+
+@pytest.mark.asyncio
+async def test_background_loader_failure_is_surfaced_without_crashing(
+    duckdb_adapter: Type[DuckDbAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected failure inside the background loader stops that loader
+    with one catalog modal, and does not crash Harlequin.
+
+    Regression test for #1117: the loader used Textual's default
+    exit_on_error=True, so anything escaping its loop took the whole app down.
+    """
+
+    def raise_on_named_items(tree: DatabaseTree) -> None:
+        raise RuntimeError("boom in the loader")
+
+    monkeypatch.setattr(DatabaseTree, "_queue_named_items", raise_on_named_items)
+    # the editor's own symbol scans reach _queue_named_items on the message
+    # pump (via load_items_named); record their names without queuing, so the
+    # raiser above only ever fires from inside the background loader.
+    monkeypatch.setattr(
+        DatabaseTree,
+        "load_items_named",
+        lambda tree, names: setattr(
+            tree, "_symbol_names", frozenset(name.casefold() for name in names)
+        ),
+    )
+    # no prefetch work either: the loader must still be waiting on an empty
+    # queue when the test captures it, not already dead on a queued item.
+    monkeypatch.setattr(DatabaseTree, "_schedule_prefetch_scan", lambda self: None)
+    app = Harlequin(duckdb_adapter((":memory:",)), connection_hash="loader-failure")
+    async with app.run_test(size=(120, 36)) as pilot:
+        tree = app.data_catalog.database_tree
+        while tree.loading or app.editor is None:
+            await pilot.pause()
+        for _ in range(200):
+            loaders = [
+                worker
+                for worker in app.workers
+                if worker.name == "_database_tree_background_loader"
+                and worker.state == WorkerState.RUNNING
+            ]
+            if loaders:
+                break
+            await pilot.pause(0.05)
+        assert len(loaders) == 1
+        loader = loaders[0]
+
+        item = SimpleCatalogItem(
+            qualified_identifier="x",
+            query_name="x",
+            label="x",
+            type_label="t",
+        )
+        tree.root.add("x", data=item)
+        tree._add_to_load_queue(item, priority=0)
+        for _ in range(200):
+            if any(isinstance(screen, ErrorModal) for screen in app.screen_stack):
+                break
+            await pilot.pause(0.05)
+        assert isinstance(app.screen, ErrorModal)
+        assert "boom in the loader" in str(app.screen.error)
+        assert app._exception is None
+
+        # the failure stopped the loader: it is terminal, not waiting for work
+        assert loader.state == WorkerState.ERROR
+        assert app.is_running

--- a/tests/functional_tests/test_query_editor.py
+++ b/tests/functional_tests/test_query_editor.py
@@ -4,10 +4,14 @@ import sys
 from typing import Awaitable, Callable, List
 
 import pytest
+from textual.widgets import TextArea
 from textual.widgets.text_area import Selection
+from textual.worker import WorkerFailed
 
 from harlequin import Harlequin
 from harlequin.autocomplete import BufferSymbols
+from harlequin.autocomplete import find_symbols as real_find_symbols
+from harlequin.components.code_editor import CodeEditor
 from harlequin.statements import find_separators, split
 
 
@@ -411,6 +415,83 @@ async def test_selected_queries(
         await pilot.pause()
         app.editor.selection = Selection((0, 0), (0, 0))
         assert app.editor.selected_queries() == ["select 'a;b'"]
+
+
+@pytest.mark.asyncio
+async def test_symbol_scan_failure_warns_once_per_failure_streak(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed symbol scan warns instead of crashing the app.
+
+    Regression test for #1117: read_symbols used Textual's default
+    exit_on_error=True, so a buffer the scanner couldn't parse (or any bug in
+    the scanner) took the whole app down with it. The failure warns once per
+    streak -- repeated failures on the same buffer stay quiet until a scan
+    succeeds again.
+    """
+    WARNING = "Harlequin could not read this buffer's identifiers."
+    outcomes: list[str] = ["fail", "fail", "ok", "fail"]
+    # the editor schedules a scan of the buffer shortly after mounting; it
+    # would cancel (exclusive group) whichever direct scan below it landed on,
+    # so drop that handler from the registry before the app mounts.
+    monkeypatch.setitem(CodeEditor._decorated_handlers, TextArea.Changed, [])
+
+    def flaky_scan(text: str) -> BufferSymbols:
+        outcome = outcomes.pop(0)
+        if outcome == "fail":
+            raise RuntimeError("symbol scan boom")
+        return real_find_symbols(text)
+
+    def warning_count() -> int:
+        return len(
+            [
+                notification
+                for notification in list(app._notifications)
+                if notification.severity == "warning"
+                and notification.message == WARNING
+            ]
+        )
+
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+        editor = app.editor
+        assert editor is not None
+        monkeypatch.setattr("harlequin.components.code_editor.find_symbols", flaky_scan)
+
+        # the first failure of a streak warns ...
+        with pytest.raises(WorkerFailed):
+            await editor.read_symbols("select 1").wait()
+        await pilot.pause()
+        assert warning_count() == 1
+
+        # ... a repeated failure on the same buffer does not
+        with pytest.raises(WorkerFailed):
+            await editor.read_symbols("select 1").wait()
+        await pilot.pause()
+        assert warning_count() == 1
+
+        # a successful scan resets the streak
+        await editor.read_symbols("select 1").wait()
+        for _ in range(20):
+            if not editor._symbol_scan_failed:
+                break
+            await pilot.pause(0.05)
+        assert not editor._symbol_scan_failed
+        assert warning_count() == 1
+
+        # so the next failure warns again
+        with pytest.raises(WorkerFailed):
+            await editor.read_symbols("select 1").wait()
+        await pilot.pause()
+        assert warning_count() == 2
+
+        # and the app never saw an unhandled exception
+        assert app._exception is None
+        assert app.is_running
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`_handle_worker_error` handled only `update_schema_data` and `_connect`. Errors from every other app-owned worker disappeared without a modal, notification, or log. Query worker failures could also leave the run bar stuck in its non-responsive state.

`DatabaseTree._loader` and `CodeEditor.read_symbols` also inherited Textual's default `exit_on_error=True`, allowing failures in these background tasks to crash the entire app.

Closes #1117

**What** are the key elements of this solution?

* Route query worker failures to a "Query Error" modal and restore the run bar and results viewer.
* Route transaction-mode failures to a "Transaction Error" modal.
* Show warning notifications for cache and completion failures because these are partial failures and the app remains usable.
* Show a generic error modal for unknown worker failures, making future workers loud by default.
* Ignore errors delivered while the app is already exiting.
* Set `exit_on_error=False` for symbol scanning and the database-tree loader.
* Handle component-owned worker failures within their owning widgets because their `Worker.StateChanged` messages do not bubble to the app.
* Suppress repeated symbol-scan warnings until a scan succeeds.
* Preserve the database loader's existing per-item recovery while stopping and reporting unexpected failures in the outer loader.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The response depends on how much functionality failed. Query execution, transaction changes, and unexpected workers use modals because the requested operation failed completely. Cache, completion, and symbol-scan failures use warnings because Harlequin remains usable.

A single generic modal for every worker was considered, but it would make optional background failures unnecessarily disruptive. Allowing unknown failures to remain silent was also rejected because newly added workers would repeat the original bug.

The database loader deliberately does not broadly catch and continue after an unexpected infrastructure failure. Expected per-item failures already have their own recovery path. Continuing after an unexpected queue or tree-state failure could produce repeated modals or operate on inconsistent state.

Does this PR require a change to Harlequin's docs?

* [x] No.
* [ ] Yes, and I have opened a PR at https://github.com/tconbeer/harlequin-web.
* [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?

* [x] Yes.
* [ ] No, I believe tests aren't necessary.
* [ ] No, I need help with testing this change.

Added functional coverage for:

* Existing `_connect` and `update_schema_data` behavior.
* Query UI recovery for both query workers, including a real worker failure.
* Transaction and partial-failure routing.
* Unknown-worker fallback and shutdown guards.
* Symbol-scan survival and once-per-failure-streak warnings.
* Child catalog-load recovery and unexpected outer-loader failure handling.

Please complete the following checklist:

* [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
* [x] I acknowledge Harlequin's MIT license. I do not own my contribution.
