### PR TITLE
SSH tunnels 6/6: ask about the tunnel in the config wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Harlequin and hsql can now reach a database through an SSH tunnel, with any adapter: pass `--ssh-host` (and `--ssh-forward`, unless your ssh config already has a `LocalForward`), and point the connection details at the local end of the forward. Add `--ssh-batch-mode` in scripts and CI so ssh fails instead of prompting ([#545](https://github.com/tconbeer/harlequin/issues/545)).
+- Harlequin and hsql can now reach a database through an SSH tunnel, with any adapter: pass `--ssh-host` (and `--ssh-forward`, unless your ssh config already has a `LocalForward`), and point the connection details at the local end of the forward. The config wizard asks, too. Add `--ssh-batch-mode` in scripts and CI so ssh fails instead of prompting ([#545](https://github.com/tconbeer/harlequin/issues/545)).
 - Data Catalog items that are too wide for the catalog now show their full name and type in a tooltip on hover ([#1104](https://github.com/tconbeer/harlequin/issues/1104)).
 - Autocompletion now offers the members of the schemas and tables you type: naming an object in the Query Editor loads its children from the database, without expanding it in the Data Catalog first ([#752](https://github.com/tconbeer/harlequin/issues/752)).
 

--- a/src/harlequin/config_wizard.py
+++ b/src/harlequin/config_wizard.py
@@ -142,6 +142,8 @@ def _wizard(config_path: Path | None) -> None:
         style=HARLEQUIN_QUESTIONARY_STYLE,
     ).unsafe_ask()
 
+    ssh_options = _prompt_for_ssh_options(selected_profile)
+
     adapter_option_choices = (
         [
             questionary.Choice(
@@ -199,6 +201,7 @@ def _wizard(config_path: Path | None) -> None:
     if locale:
         new_profile["locale"] = locale
 
+    new_profile.update(ssh_options)
     new_profile.update(adapter_options)
 
     _confirm_profile_generation(
@@ -255,6 +258,71 @@ def _prompt_for_profile_name(profiles: dict[str, Profile]) -> str:
             validate=lambda x: True if x and x != "None" else "Cannot be empty or None",
         ).unsafe_ask()
     return profile_name
+
+
+def _prompt_for_ssh_options(selected_profile: Profile) -> dict[str, Any]:
+    """The tunnel's keys, asked for only when there is a tunnel.
+
+    Not `ssh_allow_reuse`: it turns off the check that the local port is not
+    already someone else's, and a run reads that one from the command line only.
+    """
+    tunneled = questionary.confirm(
+        message="Do you connect via SSH?",
+        default=bool(selected_profile.get("ssh_host")),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+    if not tunneled:
+        return {}
+
+    ssh_host = questionary.text(
+        message="What SSH destination should this profile tunnel through?",
+        instruction=(
+            "A Host alias from your ssh config, or host, user@host or "
+            "ssh://user@host:port."
+        ),
+        default=str(selected_profile.get("ssh_host", "")),
+        validate=lambda raw: bool(raw.strip()) or "Cannot be empty",
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+
+    existing_forwards = selected_profile.get("ssh_forward", [])
+    if isinstance(existing_forwards, str):
+        existing_forwards = [existing_forwards]
+    ssh_forward = questionary.text(
+        message="What should it forward?",
+        instruction=(
+            "LOCAL:HOST:REMOTE, as ssh -L takes it; separate several by a "
+            "space. Leave blank if your ssh config has a LocalForward. Point "
+            "this profile's connection details at the local end."
+        ),
+        default=" ".join(existing_forwards),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+
+    ssh_batch_mode = questionary.confirm(
+        message="Should ssh fail rather than prompt for a passphrase or password?",
+        default=bool(selected_profile.get("ssh_batch_mode", False)),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+
+    raw_timeout = questionary.text(
+        message="How many seconds should Harlequin wait for the forwards?",
+        instruction="Leave blank for app defaults.",
+        validate=_validate_seconds_or_blank,
+        default=str(selected_profile.get("ssh_timeout", "")),
+        style=HARLEQUIN_QUESTIONARY_STYLE,
+    ).unsafe_ask()
+
+    options: dict[str, Any] = {"ssh_host": ssh_host.strip()}
+    if ssh_forward.strip():
+        options["ssh_forward"] = shlex.split(ssh_forward)
+    if ssh_batch_mode:
+        options["ssh_batch_mode"] = ssh_batch_mode
+    if raw_timeout.strip():
+        seconds = float(raw_timeout)
+        # written the way it was typed: `30`, not `30.0`
+        options["ssh_timeout"] = int(seconds) if seconds.is_integer() else seconds
+    return options
 
 
 def _prompt_to_set_adapter_options(
@@ -357,6 +425,16 @@ def _validate_int(raw: str) -> bool:
 def _validate_int_or_blank(raw: str) -> bool:
     """The limit prompt accepts blank, which means the app's default."""
     return not raw or _validate_int(raw)
+
+
+def _validate_seconds_or_blank(raw: str) -> bool:
+    """Blank means the app's default; anything else is a positive duration."""
+    if not raw.strip():
+        return True
+    try:
+        return float(raw) > 0
+    except ValueError:
+        return False
 
 
 def _validate_dir_or_blank(raw: str) -> bool:

--- a/tests/unit_tests/test_config_wizard.py
+++ b/tests/unit_tests/test_config_wizard.py
@@ -552,3 +552,177 @@ class TestDefaults:
         )
 
         assert load_config(config_path=path).profiles["one"]["legacy_mode"] is False
+
+
+class TestSsh:
+    """The tunnel's keys, which only a profile that has one should carry."""
+
+    PROFILE = '[profiles.one]\nadapter = "duckdb"\n'
+
+    def test_saying_no_writes_no_ssh_keys(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Do you connect via SSH?": False,
+            },
+        )
+
+        profile = load_config(config_path=path).profiles["one"]
+        assert not [key for key in profile if key.startswith("ssh")]
+
+    def test_the_question_defaults_to_no(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """An unanswered confirm takes the default it offered."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+        record: list[tuple[str, dict[str, Any]]] = []
+
+        run_wizard(
+            path, {"Which profile would you like to update?": "one"}, record=record
+        )
+
+        asked = [kwargs for message, kwargs in record if "via SSH" in message]
+        assert asked and asked[0]["default"] is False
+        profile = load_config(config_path=path).profiles["one"]
+        assert not [key for key in profile if key.startswith("ssh")]
+
+    def test_saying_yes_writes_the_tunnel(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Do you connect via SSH?": True,
+                "What SSH destination": "redshift_prod",
+                "What should it forward?": "15439:data.example.com:5439",
+                "Should ssh fail rather than prompt": True,
+                "How many seconds should Harlequin wait": "30",
+            },
+        )
+
+        profile = load_config(config_path=path).profiles["one"]
+        assert profile["ssh_host"] == "redshift_prod"
+        assert profile["ssh_forward"] == ["15439:data.example.com:5439"]
+        assert profile["ssh_batch_mode"] is True
+        assert profile["ssh_timeout"] == 30
+
+    def test_a_forward_the_ssh_config_supplies_is_left_out(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """The motivating case: the Host block has the LocalForward."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Do you connect via SSH?": True,
+                "What SSH destination": "redshift_prod",
+                "What should it forward?": "",
+                "Should ssh fail rather than prompt": False,
+                "How many seconds should Harlequin wait": "",
+            },
+        )
+
+        profile = load_config(config_path=path).profiles["one"]
+        assert profile["ssh_host"] == "redshift_prod"
+        assert "ssh_forward" not in profile
+        assert "ssh_batch_mode" not in profile
+        assert "ssh_timeout" not in profile
+
+    def test_several_forwards_are_written_as_a_list(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Do you connect via SSH?": True,
+                "What SSH destination": "web-1",
+                "What should it forward?": "15439:one:5439 15440:two:5440",
+            },
+        )
+
+        assert load_config(config_path=path).profiles["one"]["ssh_forward"] == [
+            "15439:one:5439",
+            "15440:two:5440",
+        ]
+
+    def test_an_existing_tunnel_is_offered_back(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(
+            "[profiles.one]\n"
+            'adapter = "duckdb"\n'
+            'ssh_host = "redshift_prod"\n'
+            'ssh_forward = ["15439:data.example.com:5439"]\n'
+        )
+        record: list[tuple[str, dict[str, Any]]] = []
+
+        run_wizard(
+            path, {"Which profile would you like to update?": "one"}, record=record
+        )
+
+        offered = {
+            message: kwargs.get("default")
+            for message, kwargs in record
+            if "via SSH" in message or "SSH destination" in message
+        }
+        assert offered["Do you connect via SSH?"] is True
+        assert "redshift_prod" in str(offered)
+        profile = load_config(config_path=path).profiles["one"]
+        assert profile["ssh_host"] == "redshift_prod"
+        assert profile["ssh_forward"] == ["15439:data.example.com:5439"]
+
+    def test_the_wizard_never_writes_the_key_a_config_file_may_not_answer(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        """`ssh_allow_reuse` is read from the command line only."""
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+        record: list[tuple[str, dict[str, Any]]] = []
+
+        run_wizard(
+            path,
+            {
+                "Which profile would you like to update?": "one",
+                "Do you connect via SSH?": True,
+                "What SSH destination": "web-1",
+            },
+            record=record,
+        )
+
+        assert "reuse" not in " ".join(message for message, _ in record).lower()
+        assert "ssh_allow_reuse" not in load_config(config_path=path).profiles["one"]
+
+    def test_the_tunnel_is_asked_about_before_the_adapter_options(
+        self, tmp_path: Path, run_wizard: Callable[..., None]
+    ) -> None:
+        path = tmp_path / ".harlequin.toml"
+        path.write_text(self.PROFILE)
+        record: list[tuple[str, dict[str, Any]]] = []
+
+        run_wizard(
+            path, {"Which profile would you like to update?": "one"}, record=record
+        )
+
+        messages = [message for message, _ in record]
+        asked = next(i for i, m in enumerate(messages) if "via SSH" in m)
+        options = next(i for i, m in enumerate(messages) if "adapter options" in m)
+        assert asked < options


### PR DESCRIPTION
**Based on #1116**; review the stack in order.

Stack: 1/6 tunnel → 2/6 options → 3/6 keepalive & reporting → 4/6 reconnect → 5/6 changelog → **6/6 (this)**.

Part of #545

**What** are the key elements of this solution?

`harlequin --config` asks **"Do you connect via SSH?"** (default No) immediately before the adapter-options checkbox. On yes it prompts for the destination, the forwards, batch mode and the timeout, and writes the same profile keys the flags do:

```toml
[profiles.redshift]
adapter = "postgres"
host = "localhost"
port = 15439
ssh_host = "redshift_prod"
ssh_forward = ["15439:data.example.com:5439"]
```

- The forward prompt takes several space-separated, like the `conn_str` prompt, and its instruction says to leave it blank when the ssh config already has a `LocalForward` — and to point the connection details at the local end.
- A blank forward, an unset batch mode and a blank timeout write no key at all, so a profile carries only what was asked for.
- `ssh_timeout` is written the way it was typed: `30`, not `30.0`.
- An existing tunnel is offered back: the confirm defaults to yes, and each prompt to what the profile already says.

**Why** did you design your solution this way? Did you assess any alternatives?

- **One gate rather than four optional prompts.** The wizard is long already, and everyone who does not tunnel — which is most people — should pay one keystroke for the feature. That is also why the default is No rather than "whatever the profile says" for a fresh profile.
- **`ssh_allow_reuse` is not prompted for**, and there is a test asserting the wizard never writes it. It turns off the check that the local port is not already someone else's listener, and #1113 made that key a command-line answer only — so a wizard that wrote it would produce a profile a run refuses.
- **Before the adapter options** because that is where the question belongs in the story the wizard tells: how to reach the database, then how to talk to it. It is also where the reader still has the connection details in mind, which is what the forward has to line up with.

Does this PR require a change to Harlequin's docs?
- [x] Yes; the wizard section of the docs gains the SSH question. Folded into the [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web) change described on #1116.

Did you add or update tests for this change?
- [x] Yes.

Eight, in `TestSsh`: no writes no keys; the question defaults to No; yes writes the four keys; a forward the ssh config supplies is left out; several forwards become a list; an existing tunnel is offered back; the wizard never writes `ssh_allow_reuse`; and the question comes before the adapter options.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md` — 5/6's entry, extended here to say the wizard asks.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD

---
_Generated by [Claude Code](https://claude.ai/code/session_012MXGx9GVHmuqYhZit3eHdD)_