### PR TITLE
fix(ssh): refresh the Data Catalog after a tunnel reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- When an SSH tunnel reconnects, Harlequin now refreshes the Data Catalog on the new connection, so lazy catalog nodes keep loading without a manual refresh ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
+
 ## [2.13.0] - 2026-09-02
 
 ### Features

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -922,6 +922,9 @@ class Harlequin(AppBase):
         self.post_message(
             TransactionModeChanged(new_mode=message.connection.transaction_mode)
         )
+        # the tree's items were built on the connection that died with the
+        # forward; rebuild the catalog on this one, or lazy nodes fail to load
+        self.update_schema_data()
         self.notify(
             "The tunnel dropped and has been reopened, so this is a new "
             "session: an open transaction, a temp table, and anything set with "

--- a/tests/functional_tests/test_ssh_recovery.py
+++ b/tests/functional_tests/test_ssh_recovery.py
@@ -14,8 +14,12 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 import pytest
+from textual.pilot import Pilot
+from textual.widgets._tree import TreeNode
 
 from harlequin import Harlequin
+from harlequin.catalog import CatalogItem, InteractiveCatalogItem
+from harlequin.components.data_catalog.database_tree import DatabaseTree
 from harlequin.components.text_modal import ErrorModal
 from harlequin.ssh import Forward, SshTunnel
 
@@ -103,6 +107,86 @@ async def test_a_dropped_tunnel_is_reopened_before_the_next_thing_that_needs_it(
             # both halves: a new session, on a forward that is open again
             assert app.connection is not None
             assert app.connection is not first_connection
+    finally:
+        dropping_tunnel.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_tunnel_rebuilds_the_catalog_on_the_new_connection(
+    app_small_sqlite: Harlequin,
+    dropping_tunnel: SshTunnel,
+    drop_trigger: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    expand_catalog_node: Callable[[Pilot, TreeNode[CatalogItem]], Awaitable[None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query that reopens a dropped tunnel leaves a catalog that still loads.
+
+    Regression test for #1127: the tree is built on the connection that died
+    with the forward, so an unloaded node's fetch fails with a Catalog Error
+    until a manual refresh. Recovering the tunnel must rebuild the catalog
+    itself. sqlite closes for real when the old connection is replaced, so a
+    stale item's fetch fails deterministically.
+    """
+    # no prefetch work: the root node must still be unloaded after startup, so
+    # the test can expand a node whose fetch runs after the drop
+    monkeypatch.setattr(DatabaseTree, "_schedule_prefetch_scan", lambda self: None)
+    app = app_small_sqlite
+    app.ssh_tunnel = dropping_tunnel
+    try:
+        async with app.run_test() as pilot:
+            await wait_for_workers(app)
+            while app.editor is None:
+                await pilot.pause()
+            first_connection = app.connection
+            first_catalog = app.data_catalog.database_tree.catalog
+            assert first_connection is not None
+            assert first_catalog is not None
+            first_node = app.data_catalog.database_tree.root.children[0]
+            assert isinstance(first_node.data, InteractiveCatalogItem)
+            assert not first_node.data.loaded
+            assert first_node.data.connection is first_connection
+
+            drop_trigger.touch()
+            assert wait_until(lambda: dropping_tunnel.needs_restart)
+            # the child that comes back stays up
+            monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
+
+            # the next database action is a query, not a refresh: a refresh
+            # would rebuild the tree itself (the manual workaround)
+            app.editor.text = "select 1"
+            await pilot.press("ctrl+a")
+            await pilot.press("ctrl+j")
+            await wait_for_workers(app)
+            for _ in range(200):
+                if app.connection is not first_connection:
+                    break
+                await pilot.pause(0.05)
+            assert dropping_tunnel.running
+            assert app.connection is not None
+            assert app.connection is not first_connection
+
+            # the catalog was rebuilt on the new connection, without ctrl+r
+            tree = app.data_catalog.database_tree
+            for _ in range(200):
+                root_data = tree.root.children[0].data if tree.root.children else None
+                if (
+                    tree.catalog is not first_catalog
+                    and isinstance(root_data, InteractiveCatalogItem)
+                    and root_data.connection is app.connection
+                ):
+                    break
+                await pilot.pause(0.05)
+            assert tree.catalog is not first_catalog
+            assert tree.root.children
+            db_node = tree.root.children[0]
+            assert isinstance(db_node.data, InteractiveCatalogItem)
+            assert db_node.data.connection is app.connection
+
+            # and a lazy node still loads, with no Catalog Error modal
+            await expand_catalog_node(pilot, db_node)
+            assert db_node.data.loaded
+            assert len(app.screen_stack) == 1
     finally:
         dropping_tunnel.stop()
 


### PR DESCRIPTION
Rebuild the catalog on the new connection when a dropped tunnel is reopened, so lazy catalog nodes keep loading without a manual refresh.

Closes #1127

**What** are the key elements of this solution?

- `Harlequin.report_tunnel_reconnected` now calls `update_schema_data()` after swapping in the recovered connection. That is the same worker `ctrl+r`, commit/rollback, and adapter-driven catalog refreshes use: it runs `get_catalog()` on the new connection and posts `NewCatalog`, so the DatabaseTree is rebuilt on the new session and the completers are reseeded. `DatabaseTree.watch_catalog` preserves expanded and highlighted nodes, so the rebuild is the same as a manual refresh.
- A functional regression test in `tests/functional_tests/test_ssh_recovery.py` drops the fake-ssh tunnel and recovers via a query (not a refresh, since a refresh-triggered recovery already rebuilt the tree). It asserts the catalog object was replaced with items bound to the new connection and that expanding an unloaded node still works with no Catalog Error modal. It uses the sqlite app because `HarlequinSqliteConnection.close()` really closes the driver connection, which makes a stale item's fetch fail deterministically.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

- Root cause: `InteractiveCatalogItem.fetch_children()` runs on the connection the adapter captured when `get_catalog()` built the tree. Recovery reopens the tunnel and reconnects, but nothing re-pointed or replaced those items, so expanding an unloaded node after a reconnect failed until a manual refresh.
- Alternative considered: hand the existing items a new connection. Catalog items are adapter subclasses that capture connections in their own fields, so core cannot re-point them generically without a new public adapter API. The design doc defers that change (`docs/plans/ssh-tunnels-design.md` section 8); rebuilding from the new connection's `get_catalog()` uses the mechanism a refresh already has.
- Alternative considered: refresh lazily when the first `CatalogError` appears. Rejected: the user sees an error modal first and completions stay stale.
- Tradeoffs: when recovery is itself triggered by a manual refresh, the handler's refresh adds a second `get_catalog()` round trip that converges to the same state. Expanded nodes are re-fetched during the rebuild, exactly as with `ctrl+r` today. The refresh is scoped to the database tree; the file and S3 panes are not touched, since they do not ride the tunnel. The one-attempt-per-drop recovery policy is unchanged.

Does this PR require a change to Harlequin's docs?
- [x] No.

Did you add or update tests for this change?
- [x] Yes.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.