### PR TITLE
fix: refresh the Data Catalog after an SSH tunnel reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Harlequin now refreshes the Data Catalog after an SSH tunnel drops and is reopened, so expanding a node no longer raises a Catalog Error until you press `ctrl+r` ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
+- Harlequin now refreshes the Data Catalog when an SSH tunnel reconnects, so expanding a node no longer raises a Catalog Error ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
 
 ## [2.13.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Harlequin now refreshes the Data Catalog after an SSH tunnel drops and is reopened, so expanding a node no longer raises a Catalog Error until you press `ctrl+r` ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
+
 ## [2.13.0] - 2026-09-02
 
 ### Features

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -176,9 +176,11 @@ class TunnelClosed(Message):
 class TunnelReconnected(Message):
     """The dropped tunnel is back, and what runs through it is a new session."""
 
-    def __init__(self, connection: HarlequinConnection) -> None:
+    def __init__(self, connection: HarlequinConnection, stale_catalog: bool) -> None:
         super().__init__()
         self.connection = connection
+        self.stale_catalog = stale_catalog
+        """Whether the tree still holds items bound to the connection that died."""
 
 
 class TunnelUnrecoverable(Message):
@@ -922,6 +924,12 @@ class Harlequin(AppBase):
         self.post_message(
             TransactionModeChanged(new_mode=message.connection.transaction_mode)
         )
+        if message.stale_catalog:
+            # the tree's items load their children on the connection the adapter
+            # captured when it built them, so expanding an unloaded node would
+            # reach the socket that died with the old forward
+            self.data_catalog.database_tree.loading = True
+            self.update_schema_data()
         self.notify(
             "The tunnel dropped and has been reopened, so this is a new "
             "session: an open transaction, a temp table, and anything set with "
@@ -1298,7 +1306,9 @@ class Harlequin(AppBase):
             )
         self.post_message(QueriesCanceled())
 
-    def _connection_for_worker(self) -> HarlequinConnection | None:
+    def _connection_for_worker(
+        self, rebuilds_catalog: bool = False
+    ) -> HarlequinConnection | None:
         """The connection to run on, reopening a dropped tunnel first.
 
         Called on a worker's thread, ahead of the database work it was about to
@@ -1309,6 +1319,10 @@ class Harlequin(AppBase):
         None is a worker that must not run: a recovery that failed leaves a
         connection whose socket died with the forward, and running on it would
         raise a second modal behind the one that said why.
+
+        `rebuilds_catalog` is the caller about to build a tree on the connection
+        it gets back, so a recovery here does not ask for a second one -- two
+        `get_catalog()` calls at once are two threads inside one adapter.
         """
         tunnel = self.ssh_tunnel
         if tunnel is None or self.connection is None:
@@ -1332,7 +1346,9 @@ class Harlequin(AppBase):
             # what a worker still inside this method runs on; the handler is
             # what makes it the app's, once the message lands
             self._recovered_connection = connection
-        self.post_message(TunnelReconnected(connection=connection))
+        self.post_message(
+            TunnelReconnected(connection=connection, stale_catalog=not rebuilds_catalog)
+        )
         return connection
 
     def _get_selected_queries(self) -> list[str]:
@@ -1467,7 +1483,7 @@ class Harlequin(AppBase):
 
     @work(thread=True, exclusive=True, exit_on_error=False, group="schema_updaters")
     def update_schema_data(self) -> None:
-        connection = self._connection_for_worker()
+        connection = self._connection_for_worker(rebuilds_catalog=True)
         if connection is None:
             return
         catalog = connection.get_catalog()

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -176,11 +176,11 @@ class TunnelClosed(Message):
 class TunnelReconnected(Message):
     """The dropped tunnel is back, and what runs through it is a new session."""
 
-    def __init__(self, connection: HarlequinConnection, stale_catalog: bool) -> None:
+    def __init__(self, connection: HarlequinConnection, rebuild_catalog: bool) -> None:
         super().__init__()
         self.connection = connection
-        self.stale_catalog = stale_catalog
-        """Whether the tree still holds items bound to the connection that died."""
+        self.rebuild_catalog = rebuild_catalog
+        """Whether this handler is the one that has to rebuild the tree."""
 
 
 class TunnelUnrecoverable(Message):
@@ -924,7 +924,7 @@ class Harlequin(AppBase):
         self.post_message(
             TransactionModeChanged(new_mode=message.connection.transaction_mode)
         )
-        if message.stale_catalog:
+        if message.rebuild_catalog:
             # the tree's items load their children on the connection the adapter
             # captured when it built them, so expanding an unloaded node would
             # reach the socket that died with the old forward
@@ -1322,7 +1322,9 @@ class Harlequin(AppBase):
 
         `rebuilds_catalog` is the caller about to build a tree on the connection
         it gets back, so a recovery here does not ask for a second one -- two
-        `get_catalog()` calls at once are two threads inside one adapter.
+        `get_catalog()` calls at once are two threads inside one adapter. It
+        reports the caller's own intent, which the worker that loses the lock
+        below cannot: a query and a refresh that hit the same drop rebuild twice.
         """
         tunnel = self.ssh_tunnel
         if tunnel is None or self.connection is None:
@@ -1347,7 +1349,9 @@ class Harlequin(AppBase):
             # what makes it the app's, once the message lands
             self._recovered_connection = connection
         self.post_message(
-            TunnelReconnected(connection=connection, stale_catalog=not rebuilds_catalog)
+            TunnelReconnected(
+                connection=connection, rebuild_catalog=not rebuilds_catalog
+            )
         )
         return connection
 
@@ -1485,6 +1489,11 @@ class Harlequin(AppBase):
     def update_schema_data(self) -> None:
         connection = self._connection_for_worker(rebuilds_catalog=True)
         if connection is None:
+            # no NewCatalog is coming, and a plain return is not a worker error,
+            # so nothing else stops the spinner a refresh started
+            self.call_from_thread(
+                setattr, self.data_catalog.database_tree, "loading", False
+            )
             return
         catalog = connection.get_catalog()
         self.post_message(NewCatalog(catalog=catalog))

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -150,6 +150,10 @@ class QueriesCanceled(Message):
     pass
 
 
+class CatalogRefreshAborted(Message):
+    """The catalog worker stopped without a connection to build a tree on."""
+
+
 class ResultsFetched(Message):
     def __init__(
         self,
@@ -741,6 +745,10 @@ class Harlequin(AppBase):
     def handle_new_catalog(self, message: NewCatalog) -> None:
         self.data_catalog.update_database_tree(message.catalog)
         self.update_completers(message.catalog)
+
+    @on(CatalogRefreshAborted)
+    def stop_catalog_loading(self) -> None:
+        self.data_catalog.database_tree.loading = False
 
     @on(NewCatalogItems)
     def handle_new_catalog_item(self, message: NewCatalogItems) -> None:
@@ -1491,9 +1499,7 @@ class Harlequin(AppBase):
         if connection is None:
             # no NewCatalog is coming, and a plain return is not a worker error,
             # so nothing else stops the spinner a refresh started
-            self.call_from_thread(
-                setattr, self.data_catalog.database_tree, "loading", False
-            )
+            self.post_message(CatalogRefreshAborted())
             return
         catalog = connection.get_catalog()
         self.post_message(NewCatalog(catalog=catalog))

--- a/tests/functional_tests/test_ssh_recovery.py
+++ b/tests/functional_tests/test_ssh_recovery.py
@@ -14,9 +14,13 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 import pytest
+from textual.pilot import Pilot
+from textual.widgets._tree import TreeNode
 
 from harlequin import Harlequin
 from harlequin.app import QuerySubmitted
+from harlequin.catalog import CatalogItem, InteractiveCatalogItem
+from harlequin.components.data_catalog.database_tree import DatabaseTree
 from harlequin.components.text_modal import ErrorModal
 from harlequin.ssh import Forward, SshTunnel
 
@@ -46,6 +50,20 @@ def wait_until(predicate: Callable[[], bool], *, seconds: float = 10) -> bool:
             return True
         time.sleep(0.02)
     return predicate()
+
+
+async def _first_database_node(pilot: Pilot, app: Harlequin) -> TreeNode[CatalogItem]:
+    """The tree's first database node, once the catalog has been rendered.
+
+    `wait_for_workers` returns when `get_catalog()` has answered, which is
+    before the message that reloads the tree has been handled.
+    """
+    tree = app.data_catalog.database_tree
+    for _ in range(200):
+        if tree.root.children:
+            return tree.root.children[0]
+        await pilot.pause(0.05)
+    raise AssertionError("the data catalog never rendered a database")
 
 
 def _modal_text(app: Harlequin) -> str:
@@ -123,7 +141,69 @@ def schema_updates(monkeypatch: pytest.MonkeyPatch) -> list[None]:
 
 
 @pytest.mark.asyncio
-async def test_a_reconnect_rebuilds_the_catalog_on_the_new_connection(
+async def test_a_reconnect_leaves_a_catalog_that_still_loads(
+    app_small_sqlite: Harlequin,
+    dropping_tunnel: SshTunnel,
+    drop_trigger: Path,
+    schema_updates: list[None],
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    expand_catalog_node: Callable[[Pilot, TreeNode[CatalogItem]], Awaitable[None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query that reopens a dropped tunnel leaves a catalog that still loads.
+
+    sqlite is the adapter here because its `close()` really closes the driver
+    connection, so an item left on the old one fails deterministically rather
+    than by luck.
+    """
+    # the node under test has to still be unloaded when the tunnel drops, and
+    # the prefetch scan would have loaded it during start-up
+    monkeypatch.setattr(DatabaseTree, "_schedule_prefetch_scan", lambda _self: None)
+    app = app_small_sqlite
+    app.ssh_tunnel = dropping_tunnel
+    try:
+        async with app.run_test() as pilot:
+            await wait_for_workers(app)
+            first_connection = app.connection
+            first_catalog = app.data_catalog.database_tree.catalog
+            assert first_connection is not None
+            assert first_catalog is not None
+            db_node = await _first_database_node(pilot, app)
+            assert isinstance(db_node.data, InteractiveCatalogItem)
+            assert not db_node.data.loaded
+
+            drop_trigger.touch()
+            assert wait_until(lambda: dropping_tunnel.needs_restart)
+            monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
+
+            # a query is the recovery's other trigger; a refresh would rebuild
+            # the tree on its own, which is the workaround this replaces
+            schema_updates.clear()
+            app.post_message(QuerySubmitted(queries=["select 1"], limit=None))
+            await pilot.pause()
+            await wait_for_workers(app)
+            for _ in range(200):
+                if app.data_catalog.database_tree.catalog is not first_catalog:
+                    break
+                await pilot.pause(0.05)
+
+            assert len(schema_updates) == 1
+            assert app.connection is not first_connection
+            assert app.data_catalog.database_tree.catalog is not first_catalog
+            db_node = await _first_database_node(pilot, app)
+            assert isinstance(db_node.data, InteractiveCatalogItem)
+            assert db_node.data.connection is app.connection
+
+            # the symptom in #1127: expanding a node that had not loaded yet
+            await expand_catalog_node(pilot, db_node)
+            assert db_node.data.loaded
+            assert len(app.screen_stack) == 1  # no Catalog Error modal
+    finally:
+        dropping_tunnel.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
     app: Harlequin,
     dropping_tunnel: SshTunnel,
     drop_trigger: Path,
@@ -142,37 +222,6 @@ async def test_a_reconnect_rebuilds_the_catalog_on_the_new_connection(
             assert wait_until(lambda: dropping_tunnel.needs_restart)
             monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
 
-            # a query is the recovery's other trigger, and it leaves a tree
-            # whose items load their children on the connection that died
-            schema_updates.clear()
-            app.post_message(QuerySubmitted(queries=["select 1"], limit=None))
-            await pilot.pause()
-            await wait_for_workers(app)
-            await pilot.pause()
-
-            assert len(schema_updates) == 1
-            assert app.data_catalog.database_tree.catalog is not first_catalog
-    finally:
-        dropping_tunnel.stop()
-
-
-@pytest.mark.asyncio
-async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
-    app: Harlequin,
-    dropping_tunnel: SshTunnel,
-    drop_trigger: Path,
-    schema_updates: list[None],
-    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    app.ssh_tunnel = dropping_tunnel
-    try:
-        async with app.run_test() as pilot:
-            await wait_for_workers(app)
-            drop_trigger.touch()
-            assert wait_until(lambda: dropping_tunnel.needs_restart)
-            monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
-
             # the refresh builds the tree on the connection it recovered, so
             # two `get_catalog()` calls would be two threads inside one adapter
             schema_updates.clear()
@@ -181,7 +230,7 @@ async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
             await pilot.pause()
 
             assert len(schema_updates) == 1
-            assert app.data_catalog.database_tree.catalog is not None
+            assert app.data_catalog.database_tree.catalog is not first_catalog
     finally:
         dropping_tunnel.stop()
 
@@ -222,5 +271,7 @@ async def test_a_tunnel_that_will_not_come_back_is_not_tried_twice(
             await pilot.pause()
             assert not dropping_tunnel.running
             assert len(app.screen_stack) == 1
+            # no catalog is coming, so the refresh's spinner has to stop
+            assert not app.data_catalog.database_tree.loading
     finally:
         dropping_tunnel.stop()

--- a/tests/functional_tests/test_ssh_recovery.py
+++ b/tests/functional_tests/test_ssh_recovery.py
@@ -19,7 +19,7 @@ from textual.widgets._tree import TreeNode
 
 from harlequin import Harlequin
 from harlequin.app import QuerySubmitted
-from harlequin.catalog import CatalogItem, InteractiveCatalogItem
+from harlequin.catalog import Catalog, CatalogItem, InteractiveCatalogItem
 from harlequin.components.data_catalog.database_tree import DatabaseTree
 from harlequin.components.text_modal import ErrorModal
 from harlequin.ssh import Forward, SshTunnel
@@ -52,11 +52,32 @@ def wait_until(predicate: Callable[[], bool], *, seconds: float = 10) -> bool:
     return predicate()
 
 
+async def _rendered_catalog(
+    pilot: Pilot, app: Harlequin, replacing: object = None
+) -> Catalog:
+    """The catalog the tree is holding, once it is not `replacing`.
+
+    `wait_for_workers` returns when `get_catalog()` has answered, which is
+    before the app has handled the message carrying its result, so reading the
+    tree straight after it races the message pump.
+    """
+    tree = app.data_catalog.database_tree
+    for _ in range(200):
+        if tree.catalog is not None and tree.catalog is not replacing:
+            return tree.catalog
+        await pilot.pause(0.05)
+    raise AssertionError(
+        "the data catalog was never replaced"
+        if replacing
+        else "the data catalog never loaded"
+    )
+
+
 async def _first_database_node(pilot: Pilot, app: Harlequin) -> TreeNode[CatalogItem]:
     """The tree's first database node, once the catalog has been rendered.
 
-    `wait_for_workers` returns when `get_catalog()` has answered, which is
-    before the message that reloads the tree has been handled.
+    Setting the catalog and mounting its nodes are two steps, so a tree with a
+    catalog can still have no children.
     """
     tree = app.data_catalog.database_tree
     for _ in range(200):
@@ -165,9 +186,8 @@ async def test_a_reconnect_leaves_a_catalog_that_still_loads(
         async with app.run_test() as pilot:
             await wait_for_workers(app)
             first_connection = app.connection
-            first_catalog = app.data_catalog.database_tree.catalog
+            first_catalog = await _rendered_catalog(pilot, app)
             assert first_connection is not None
-            assert first_catalog is not None
             db_node = await _first_database_node(pilot, app)
             assert isinstance(db_node.data, InteractiveCatalogItem)
             assert not db_node.data.loaded
@@ -182,14 +202,13 @@ async def test_a_reconnect_leaves_a_catalog_that_still_loads(
             app.post_message(QuerySubmitted(queries=["select 1"], limit=None))
             await pilot.pause()
             await wait_for_workers(app)
-            for _ in range(200):
-                if app.data_catalog.database_tree.catalog is not first_catalog:
-                    break
-                await pilot.pause(0.05)
+            rebuilt_catalog = await _rendered_catalog(
+                pilot, app, replacing=first_catalog
+            )
 
             assert len(schema_updates) == 1
+            assert rebuilt_catalog is not first_catalog
             assert app.connection is not first_connection
-            assert app.data_catalog.database_tree.catalog is not first_catalog
             db_node = await _first_database_node(pilot, app)
             assert isinstance(db_node.data, InteractiveCatalogItem)
             assert db_node.data.connection is app.connection
@@ -215,8 +234,7 @@ async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
     try:
         async with app.run_test() as pilot:
             await wait_for_workers(app)
-            first_catalog = app.data_catalog.database_tree.catalog
-            assert first_catalog is not None
+            first_catalog = await _rendered_catalog(pilot, app)
 
             drop_trigger.touch()
             assert wait_until(lambda: dropping_tunnel.needs_restart)
@@ -227,10 +245,12 @@ async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
             schema_updates.clear()
             app.action_refresh_catalog()
             await wait_for_workers(app)
-            await pilot.pause()
+            rebuilt_catalog = await _rendered_catalog(
+                pilot, app, replacing=first_catalog
+            )
 
             assert len(schema_updates) == 1
-            assert app.data_catalog.database_tree.catalog is not first_catalog
+            assert rebuilt_catalog is not first_catalog
     finally:
         dropping_tunnel.stop()
 

--- a/tests/functional_tests/test_ssh_recovery.py
+++ b/tests/functional_tests/test_ssh_recovery.py
@@ -16,6 +16,7 @@ from typing import Awaitable, Callable
 import pytest
 
 from harlequin import Harlequin
+from harlequin.app import QuerySubmitted
 from harlequin.components.text_modal import ErrorModal
 from harlequin.ssh import Forward, SshTunnel
 
@@ -103,6 +104,84 @@ async def test_a_dropped_tunnel_is_reopened_before_the_next_thing_that_needs_it(
             # both halves: a new session, on a forward that is open again
             assert app.connection is not None
             assert app.connection is not first_connection
+    finally:
+        dropping_tunnel.stop()
+
+
+@pytest.fixture
+def schema_updates(monkeypatch: pytest.MonkeyPatch) -> list[None]:
+    """Every call to `update_schema_data`, so a double refresh is visible."""
+    calls: list[None] = []
+    start_worker = Harlequin.update_schema_data
+
+    def counted(app: Harlequin) -> None:
+        calls.append(None)
+        start_worker(app)
+
+    monkeypatch.setattr(Harlequin, "update_schema_data", counted)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_a_reconnect_rebuilds_the_catalog_on_the_new_connection(
+    app: Harlequin,
+    dropping_tunnel: SshTunnel,
+    drop_trigger: Path,
+    schema_updates: list[None],
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app.ssh_tunnel = dropping_tunnel
+    try:
+        async with app.run_test() as pilot:
+            await wait_for_workers(app)
+            first_catalog = app.data_catalog.database_tree.catalog
+            assert first_catalog is not None
+
+            drop_trigger.touch()
+            assert wait_until(lambda: dropping_tunnel.needs_restart)
+            monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
+
+            # a query is the recovery's other trigger, and it leaves a tree
+            # whose items load their children on the connection that died
+            schema_updates.clear()
+            app.post_message(QuerySubmitted(queries=["select 1"], limit=None))
+            await pilot.pause()
+            await wait_for_workers(app)
+            await pilot.pause()
+
+            assert len(schema_updates) == 1
+            assert app.data_catalog.database_tree.catalog is not first_catalog
+    finally:
+        dropping_tunnel.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_that_reconnects_does_not_ask_for_a_second_one(
+    app: Harlequin,
+    dropping_tunnel: SshTunnel,
+    drop_trigger: Path,
+    schema_updates: list[None],
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app.ssh_tunnel = dropping_tunnel
+    try:
+        async with app.run_test() as pilot:
+            await wait_for_workers(app)
+            drop_trigger.touch()
+            assert wait_until(lambda: dropping_tunnel.needs_restart)
+            monkeypatch.delenv("FAKE_SSH_DROP_WHEN")
+
+            # the refresh builds the tree on the connection it recovered, so
+            # two `get_catalog()` calls would be two threads inside one adapter
+            schema_updates.clear()
+            app.action_refresh_catalog()
+            await wait_for_workers(app)
+            await pilot.pause()
+
+            assert len(schema_updates) == 1
+            assert app.data_catalog.database_tree.catalog is not None
     finally:
         dropping_tunnel.stop()
 


### PR DESCRIPTION
Closes #1127

**What** are the key elements of this solution?

- `TunnelReconnected` carries a `rebuild_catalog` flag, and `report_tunnel_reconnected` rebuilds the Data Catalog when it is set — after it has swapped `self.connection` in, so the completers rebuild against the new connection too. It sets `database_tree.loading` first, matching what `action_refresh_catalog` already does.
- `_connection_for_worker()` takes `rebuilds_catalog`, and `update_schema_data` passes it. That worker is already about to build a tree on the connection it gets back, so a recovery that happens inside it does not ask for a second catalog.
- `update_schema_data` now clears the tree's spinner when it returns without a connection. That is a plain return rather than a worker error, so nothing else stopped it — pre-existing in `action_refresh_catalog`, and this fixes both callers.
- Two functional tests in `tests/functional_tests/test_ssh_recovery.py`: a query-triggered reconnect leaves a catalog whose unloaded nodes still expand, and a refresh-triggered reconnect rebuilds the tree exactly once. A third assertion pins the spinner on the existing unrecoverable-tunnel test.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The tree's `InteractiveCatalogItem`s call `fetch_children()` on the connection the adapter captured when it built them. After a drop, `_connection_for_worker()` restarts `ssh` and replaces `Harlequin.connection`, but the tree still holds items bound to the socket that died with the old forward — so expanding a node that had not loaded yet raised a Catalog Error. Rebuilding the tree on the new connection needs nothing from adapters.

The one subtlety is the flag. `_connection_for_worker()` has two callers, and one of them *is* the catalog rebuild. Refreshing unconditionally would start a second `schema_updaters` worker; since Textual cannot preempt a thread worker, the cancelled one keeps running, and the result is two concurrent `get_catalog()` calls inside one adapter. Passing the caller's intent down is what avoids that.

It does not cover every interleaving, and the docstring says so: a worker that loses `_recovery_lock` gets the recovered connection without posting, so a query and a refresh that hit the same drop still rebuild twice. Inspecting the `schema_updaters` group from the handler covers that case but is not a strict improvement — a schema worker that entered `get_catalog()` on the old connection before the drop was detected is still `RUNNING`, so the handler would stand down and leave a tree built on the dead connection behind the Catalog Error modal. A redundant `get_catalog()` is the milder failure of the two.

**Testing.** The regression test is lifted from #1128, which tested the symptom rather than the mechanism: it drives the recovery with a query, then expands a node that had not loaded and asserts no error modal. It uses the sqlite adapter because `HarlequinSqliteConnection.close()` really closes the driver connection, so an item left on the old one fails deterministically.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

---

Verification: 1478 passed / 7 skipped on 3.10, 3 passed on 3.12, `mypy` clean, `ruff` clean, `lint-imports` 4/4 kept. Each of the three fixes is pinned by an assertion that fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDVnAxw5MNrpaK8W7dm9v4
