### PR TITLE
Crash recovery and bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,7 @@ assignees: ''
 - [ ] I have consulted the [Troubleshooting guide](https://harlequin.sh/docs/troubleshooting/index).
 - [ ] I have searched Issues and Discussions in this repo.
 - [ ] Feature requests should be initiated as Discussions. This is a bug report.
+- [ ] Did Harlequin exit with an error and print a crash report path? Use the Crash Report template instead.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -1,0 +1,49 @@
+---
+name: Crash Report
+about: Harlequin or hsql exited unexpectedly and wrote a crash report.
+title: 'Crash: '
+labels: 'bug'
+assignees: ''
+
+---
+**Before proceeding, please acknowledge**:
+- [ ] I have searched Issues and Discussions in this repo for this error.
+
+**Paste your crash report below.**
+
+Harlequin and `hsql` write a crash report and print its path when they exit
+unexpectedly. If you still have that message on screen, the path is in it.
+Otherwise, the reports are here:
+
+| OS | Location |
+|---|---|
+| macOS | `~/Library/Logs/harlequin/` |
+| Linux | `~/.local/state/harlequin/log/` |
+| Windows | `%LOCALAPPDATA%\harlequin\Logs\` |
+
+The newest `crash-*.log` is the one you want.
+
+> [!IMPORTANT]
+> Please read the report before pasting it. It contains your configuration
+> (with passwords masked) and the SQL that was in your active buffer.
+
+<details>
+<summary>Crash report</summary>
+
+```
+PASTE YOUR CRASH REPORT HERE
+```
+
+</details>
+
+**What were you doing when it crashed?**
+Steps to reproduce it, if you know them.
+
+**Anything else?**
+Screenshots, or anything the report doesn't cover.
+
+**Contributing**
+Are you interested in contributing a fix?
+- [ ] Yes
+- [ ] Maybe
+- [ ] No

--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -8,6 +8,7 @@ assignees: ''
 ---
 **Before proceeding, please acknowledge**:
 - [ ] I have searched Issues and Discussions in this repo for this error.
+- [ ] I have redacted secrets and PII from the crash report pasted below.
 
 **Paste your crash report below.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - Press `alt+e` in the Query Editor to edit the current buffer in the editor named by `$VISUAL` or `$EDITOR`; quitting the editor with a non-zero status (like `:cq`) discards the changes ([#1102](https://github.com/tconbeer/harlequin/issues/1102)).
+- Harlequin now saves your open buffers every minute, and offers them back the next time you start if it exited without a clean quit ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file.
 - Press `alt+e` in the Query Editor to edit the current buffer in the editor named by `$VISUAL` or `$EDITOR`; quitting the editor with a non-zero status (like `:cq`) discards the changes ([#1102](https://github.com/tconbeer/harlequin/issues/1102)).
 - Harlequin now saves your open buffers every minute, and offers them back the next time you start if it exited without a clean quit ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 
+- When Harlequin hits a bug in itself, it now exits with a short message instead of a traceback, saves your buffers, and writes a crash report you can attach to an issue ([#687](https://github.com/tconbeer/harlequin/issues/687)).
+
 ### Bug Fixes
 
+- `harlequin` now exits non-zero when it fails: 1 after a crash, and 2 for a config or connection error it used to report as success ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - Harlequin now refreshes the Data Catalog when an SSH tunnel reconnects, so expanding a node no longer raises a Catalog Error ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
 
 ## [2.13.0] - 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Press `alt+e` in the Query Editor to edit the current buffer in the editor named by `$VISUAL` or `$EDITOR`; quitting the editor with a non-zero status (like `:cq`) discards the changes ([#1102](https://github.com/tconbeer/harlequin/issues/1102)).
 - Harlequin now saves your open buffers every minute, and offers them back the next time you start if it exited without a clean quit ([#687](https://github.com/tconbeer/harlequin/issues/687)).
-
 - When Harlequin hits a bug in itself, it now exits with a short message instead of a traceback, saves your buffers, and writes a crash report you can attach to an issue ([#687](https://github.com/tconbeer/harlequin/issues/687)).
+- `hsql` now exits `70` and writes a crash report when it hits a bug in itself, instead of printing a traceback and exiting `1`, which is the code for SQL the database rejected ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 
 ### Bug Fixes
 

--- a/docs/generated/hsql-reference.md
+++ b/docs/generated/hsql-reference.md
@@ -104,4 +104,5 @@ names a file with.
 | `2` | A bad flag, a bad profile, or a config file hsql could not read. |
 | `3` | hsql could not connect. |
 | `4` | `--timeout` ran out, and hsql stopped the run. |
+| `70` | hsql hit a bug in itself and wrote a crash report. |
 | `130` | Interrupted. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ source_modules = [
     "harlequin.autocomplete",
     "harlequin.catalog",
     "harlequin.config",
+    "harlequin.environment",
     "harlequin.exception",
     "harlequin.keymap",
     "harlequin.navigate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ source_modules = [
     "harlequin.autocomplete",
     "harlequin.catalog",
     "harlequin.config",
+    "harlequin.crash",
     "harlequin.environment",
     "harlequin.exception",
     "harlequin.keymap",

--- a/scripts/profile_buffers.py
+++ b/scripts/profile_buffers.py
@@ -17,7 +17,13 @@ async def wait_for_filtered_workers(app: Harlequin) -> None:
 
 
 async def load_lots_of_buffers() -> None:
-    with patch("harlequin.components.code_editor.load_cache") as mock_load_cache:
+    with (
+        patch("harlequin.components.code_editor.load_cache") as mock_load_cache,
+        patch(
+            "harlequin.components.code_editor.adopt_recovery",
+            return_value=(None, None),
+        ),
+    ):
         buff = BufferState(
             selection=Selection((0, 0), (0, 0)),
             text="select 1; " * 20,

--- a/scripts/profile_fast_query.py
+++ b/scripts/profile_fast_query.py
@@ -9,7 +9,13 @@ from harlequin_duckdb import DuckDbAdapter
 
 
 async def load_lots_of_buffers() -> None:
-    with patch("harlequin.components.code_editor.load_cache") as mock_load_cache:
+    with (
+        patch("harlequin.components.code_editor.load_cache") as mock_load_cache,
+        patch(
+            "harlequin.components.code_editor.adopt_recovery",
+            return_value=(None, None),
+        ),
+    ):
         buff = BufferState(
             selection=Selection((0, 0), (0, 0)),
             text="select 1000; ",

--- a/scripts/write_cli_reference.py
+++ b/scripts/write_cli_reference.py
@@ -68,6 +68,7 @@ EXIT_CODES = {
     ExitCode.USAGE: "A bad flag, a bad profile, or a config file hsql could not read.",
     ExitCode.CONNECTION: "hsql could not connect.",
     ExitCode.TIMEOUT: "`--timeout` ran out, and hsql stopped the run.",
+    ExitCode.CRASH: "hsql hit a bug in itself and wrote a crash report.",
     ExitCode.INTERRUPT: "Interrupted.",
 }
 """What each code means, in a sentence. A copy of what the enum's own docstrings

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -77,7 +77,12 @@ from harlequin.config import (
 )
 from harlequin.copy_formats import HARLEQUIN_COPY_FORMATS, WINDOWS_COPY_FORMATS
 from harlequin.driver import HarlequinDriver
-from harlequin.editor_cache import Cache, clear_recovery
+from harlequin.editor_cache import (
+    CHECKPOINT_INTERVAL_SECONDS,
+    Cache,
+    clear_recovery,
+    write_recovery,
+)
 from harlequin.editor_cache import write_cache as write_editor_cache
 from harlequin.exception import (
     HarlequinBindingError,
@@ -305,6 +310,8 @@ class Harlequin(AppBase):
                 ),
             )
         self.query_timer: Union[float, None] = None
+        self._last_checkpointed_cache: Cache | None = None
+        """What the recovery file holds, so an idle session stops rewriting it."""
         self.connection: HarlequinConnection | None = None
         self._recovery_lock = threading.Lock()
         """Held across reopening the tunnel and the connection through it.
@@ -421,6 +428,7 @@ class Harlequin(AppBase):
         self._connect()
         self._load_catalog_cache()
         self.action_bind_keymaps(*self.keymap_names)
+        self.set_interval(CHECKPOINT_INTERVAL_SECONDS, self._checkpoint_editor_cache)
 
     @on(Button.Pressed, "#run_query")
     def submit_query_from_run_query_bar(self, message: Button.Pressed) -> None:
@@ -1122,6 +1130,38 @@ class Harlequin(AppBase):
 
     def action_focus_results_viewer(self) -> None:
         self.results_viewer.focus()
+
+    def _build_editor_cache(self) -> Cache | None:
+        """The open buffers, or None when there is nothing worth writing.
+
+        Blank buffers are nothing: a crash before the editor mounts leaves the
+        collection empty, and writing that over a recovery file would destroy
+        exactly the work this exists to save.
+        """
+        editor_collection = getattr(self, "editor_collection", None)
+        if editor_collection is None or not editor_collection.is_mounted:
+            return None
+        cache = Cache(
+            focus_index=editor_collection.active_buffer_index,
+            buffers=editor_collection.buffers,
+        )
+        if not any(buffer.text.strip() for buffer in cache.buffers):
+            return None
+        return cache
+
+    def _checkpoint_editor_cache(self) -> None:
+        """Write the open buffers to this session's recovery file, if they moved.
+
+        Synchronously, on the message pump: pickling a few SQL buffers is
+        microseconds, and a thread worker would only add the hazard of two
+        checkpoints racing. `Cache` compares by content, so no dirty flag has
+        to stay in sync with tab swaps.
+        """
+        cache = self._build_editor_cache()
+        if cache is None or cache == self._last_checkpointed_cache:
+            return
+        if write_recovery(cache):
+            self._last_checkpointed_cache = cache
 
     async def action_quit(self) -> None:
         write_editor_cache(

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -77,7 +77,7 @@ from harlequin.config import (
 )
 from harlequin.copy_formats import HARLEQUIN_COPY_FORMATS, WINDOWS_COPY_FORMATS
 from harlequin.driver import HarlequinDriver
-from harlequin.editor_cache import Cache
+from harlequin.editor_cache import Cache, clear_recovery
 from harlequin.editor_cache import write_cache as write_editor_cache
 from harlequin.exception import (
     HarlequinBindingError,
@@ -1130,6 +1130,7 @@ class Harlequin(AppBase):
                 buffers=self.editor_collection.buffers,
             )
         )
+        clear_recovery()
         update_catalog_cache(
             connection_hash=self.connection_hash,
             catalog=None,  # TODO: cache completions instead.

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -6,10 +6,12 @@ import os
 import sys
 import threading
 import time
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     Optional,
@@ -76,11 +78,13 @@ from harlequin.config import (
     load_profile_and_keymaps,
 )
 from harlequin.copy_formats import HARLEQUIN_COPY_FORMATS, WINDOWS_COPY_FORMATS
+from harlequin.crash import ACTIVE_BUFFER
 from harlequin.driver import HarlequinDriver
 from harlequin.editor_cache import (
     CHECKPOINT_INTERVAL_SECONDS,
     Cache,
     clear_recovery,
+    get_recovery_file,
     write_recovery,
 )
 from harlequin.editor_cache import write_cache as write_editor_cache
@@ -215,6 +219,17 @@ class CompletersReady(Message):
         self.member_completer = member_completer
 
 
+def _distribution_version(adapter_cls: type[HarlequinAdapter]) -> str | None:
+    """The version of the distribution an adapter class came from, if it has one."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    package = adapter_cls.__module__.split(".")[0]
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return None
+
+
 _PARTIAL_FAILURE_WORKER_NOTIFICATIONS: dict[str, str] = {
     "_load_catalog_cache": (
         "Harlequin could not load its cache; your query history may be missing."
@@ -242,6 +257,7 @@ class Harlequin(AppBase):
         adapter: HarlequinAdapter,
         profile_name: str | None = None,
         *,
+        adapter_name: str | None = None,
         keymap_names: Sequence[str] | None = None,
         user_defined_keymaps: Sequence[HarlequinKeyMap] | None = None,
         connection_hash: str | None = None,
@@ -263,6 +279,7 @@ class Harlequin(AppBase):
             watch_css=watch_css,
         )
         self.adapter = adapter
+        self.adapter_name = adapter_name
         self.profile_name = profile_name
         self.connection_hash = connection_hash
         self.history: History | None = None
@@ -1162,6 +1179,70 @@ class Harlequin(AppBase):
             return
         if write_recovery(cache):
             self._last_checkpointed_cache = cache
+
+    def _save_work_on_crash(self) -> bool:
+        """Save the buffers and the query history a crash would otherwise lose.
+
+        The buffers go to a `recovered-` file rather than this session's
+        recovery file, so the next start adopts them however old they are. The
+        cache the last clean quit wrote is left alone: if the recovered content
+        is itself what crashed, that is still on disk.
+        """
+        saved = False
+        try:
+            # the crash may be *in* the editor, and building this reads it
+            cache = self._build_editor_cache()
+        except Exception:
+            cache = self._last_checkpointed_cache
+        if cache is not None and write_recovery(cache):
+            try:
+                os.replace(get_recovery_file(), self._crash_recovery_file())
+                saved = True
+            except OSError:
+                pass
+        try:
+            update_catalog_cache(
+                connection_hash=self.connection_hash,
+                catalog=None,
+                s3_tree=self.data_catalog.s3_tree,
+                history=self.history,
+            )
+        except Exception:
+            pass
+        return saved
+
+    def _crash_recovery_file(self) -> Path:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return get_recovery_file().with_name(f"recovered-{stamp}-{os.getpid()}.pickle")
+
+    def _crash_context(self) -> dict[str, Any]:
+        """What this session was, for the crash report.
+
+        Every fact is cheap and separately wrapped. It deliberately does not
+        call `adapter_facts()`: importing every installed adapter mid-crash is
+        slow, and a fresh place to crash.
+        """
+        context: dict[str, Any] = {}
+        adapter_cls = type(self.adapter)
+        for key, get_fact in (
+            ("adapter", lambda: self.adapter_name),
+            ("adapter_class", lambda: adapter_cls.__qualname__),
+            ("adapter_module", lambda: adapter_cls.__module__),
+            ("adapter_version", lambda: _distribution_version(adapter_cls)),
+            ("profile", lambda: self.profile_name),
+            ("keymaps", lambda: ", ".join(self.keymap_names)),
+            ("theme", lambda: self.theme),
+            ("connected", lambda: self.connection is not None),
+            ("buffers", lambda: self.editor_collection.tab_count),
+            ("size", lambda: str(self.size)),
+            ("recovery_file", lambda: str(self._crash_recovery_file())),
+            (ACTIVE_BUFFER, lambda: self.editor.text if self.editor else None),
+        ):
+            try:
+                context[key] = get_fact()
+            except Exception:
+                context[key] = "unknown"
+        return context
 
     async def action_quit(self) -> None:
         write_editor_cache(

--- a/src/harlequin/app.py
+++ b/src/harlequin/app.py
@@ -219,15 +219,22 @@ class CompletersReady(Message):
         self.member_completer = member_completer
 
 
-def _distribution_version(adapter_cls: type[HarlequinAdapter]) -> str | None:
-    """The version of the distribution an adapter class came from, if it has one."""
-    from importlib.metadata import PackageNotFoundError, version
+def _adapter_distribution(adapter_name: str | None) -> str | None:
+    """The distribution an adapter came from, and its version.
 
-    package = adapter_cls.__module__.split(".")[0]
-    try:
-        return version(package)
-    except PackageNotFoundError:
+    Read off the entry point rather than the class: an adapter's module name
+    is not its distribution name, and both bundled adapters ship inside
+    `harlequin` itself. Importing nothing, which is what makes it safe to ask
+    mid-crash.
+    """
+    from harlequin.plugins import adapter_distributions, adapter_versions
+
+    if adapter_name is None:
         return None
+    distribution = adapter_distributions().get(adapter_name)
+    if distribution is None:
+        return None
+    return f"{distribution} {adapter_versions().get(adapter_name)}"
 
 
 _PARTIAL_FAILURE_WORKER_NOTIFICATIONS: dict[str, str] = {
@@ -1151,9 +1158,12 @@ class Harlequin(AppBase):
     def _build_editor_cache(self) -> Cache | None:
         """The open buffers, or None when there is nothing worth writing.
 
-        Blank buffers are nothing: a crash before the editor mounts leaves the
-        collection empty, and writing that over a recovery file would destroy
-        exactly the work this exists to save.
+        `editor_collection` is assigned in `compose()`, so before the app
+        mounts the attribute does not exist at all -- and a crash before that
+        is one of the crashes the caller runs for.
+
+        Blank buffers are nothing either: writing them over a recovery file
+        would destroy exactly the work this exists to save.
         """
         editor_collection = getattr(self, "editor_collection", None)
         if editor_collection is None or not editor_collection.is_mounted:
@@ -1228,7 +1238,7 @@ class Harlequin(AppBase):
             ("adapter", lambda: self.adapter_name),
             ("adapter_class", lambda: adapter_cls.__qualname__),
             ("adapter_module", lambda: adapter_cls.__module__),
-            ("adapter_version", lambda: _distribution_version(adapter_cls)),
+            ("adapter_distribution", lambda: _adapter_distribution(self.adapter_name)),
             ("profile", lambda: self.profile_name),
             ("keymaps", lambda: ", ".join(self.keymap_names)),
             ("theme", lambda: self.theme),

--- a/src/harlequin/app_base.py
+++ b/src/harlequin/app_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Type, Union
 
 from textual.app import App, InvalidThemeError
@@ -15,6 +16,23 @@ from harlequin.exception import (
     HarlequinThemeError,
     pretty_error_message,
 )
+
+_URL = re.compile(r"https?://[^\s\]]*[^\s.,;:!?)\]]")
+
+
+def _as_markup(message: str) -> str:
+    """The crash message with its URLs clickable and nothing else interpreted.
+
+    Terminals make an OSC-8 link clickable, which is what `[link=]` renders
+    to. The rest is escaped because the message quotes an exception, and a
+    driver that put brackets in one would otherwise lose them to the markup
+    parser.
+    """
+    from rich.markup import escape
+
+    return _URL.sub(
+        lambda match: f"[link={match.group()}]{match.group()}[/link]", escape(message)
+    )
 
 
 class ScreenBase(Screen):
@@ -126,7 +144,7 @@ class AppBase(App, inherit_bindings=False):
             self.panic(
                 pretty_error_message(
                     HarlequinCrashError(
-                        crash_message(report_path, error, saved),
+                        _as_markup(crash_message(report_path, error, saved)),
                         title="Harlequin crashed.",
                     )
                 )

--- a/src/harlequin/app_base.py
+++ b/src/harlequin/app_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Type, Union
+from typing import Any, Type, Union
 
 from textual.app import App, InvalidThemeError
 from textual.binding import ActiveBinding
@@ -9,7 +9,9 @@ from textual.screen import Screen
 from textual.types import CSSPathType
 
 from harlequin.colors import HARLEQUIN_TEXTUAL_THEME
+from harlequin.crash import build_crash_report, crash_message, write_crash_report
 from harlequin.exception import (
+    HarlequinCrashError,
     HarlequinThemeError,
     pretty_error_message,
 )
@@ -41,6 +43,9 @@ class AppBase(App, inherit_bindings=False):
         watch_css: bool = False,
     ):
         super().__init__(driver_class, css_path, watch_css)
+        # before the theme below, which can call self.exit() and so reach the
+        # handler that reads it
+        self._crash_handled = False
         self.register_theme(HARLEQUIN_TEXTUAL_THEME)
         try:
             self.theme = theme or "harlequin"
@@ -65,12 +70,72 @@ class AppBase(App, inherit_bindings=False):
         """
         return ScreenBase(id="_default")
 
+    def _save_work_on_crash(self) -> bool:
+        """Persist anything the user would lose. False if there was nothing to save."""
+        return False
+
+    def _crash_context(self) -> dict[str, Any]:
+        """What this app was doing, for the crash report."""
+        return {}
+
     def _handle_exception(self, error: Exception) -> None:
+        """Write a crash report and print a panel, instead of a raw traceback.
+
+        Textual renders an uncaught exception with `show_locals=True`, which
+        puts connection strings, tokens and query results on the terminal, and
+        tells the user nothing about what to do next.
+
+        The order is by value: save the user's work first, report second,
+        render last, each stage wrapped on its own. This runs inside an
+        `except` block, so it must not be able to raise -- raising here is how
+        a fix for crashes becomes the crash. `_exit` is Textual's own guard
+        against exceptions raised after `exit()`
+        (https://github.com/Textualize/textual/issues/5325); a second
+        exception returns without reporting again.
         """
-        Prevents tracebacks from being printed due to exceptions that
-        occur after App.exit() is called.
-        See https://github.com/Textualize/textual/issues/5325
-        """
-        if self._exit:
+        if self._exit or self._crash_handled:
             return
-        return super()._handle_exception(error)
+        self._crash_handled = True
+
+        saved = False
+        try:
+            saved = self._save_work_on_crash()
+        except BaseException:
+            pass
+
+        report_path = None
+        try:
+            report_path = write_crash_report(
+                build_crash_report(error, self._crash_context())
+            )
+        except BaseException:
+            pass
+
+        try:
+            self.bell()
+            # so the command that ran this app can forward a failure
+            self._return_code = 1
+            # `run_test` re-raises from these; a crashing functional test that
+            # did not set them would silently pass
+            if self._exception is None:
+                self._exception = error
+                self._exception_event.set()
+            # panic() closes the message pump, so a modal is unreachable from
+            # here anyway: this lands at _exit_renderables[0] and prints to
+            # stderr once the terminal is restored
+            self.panic(
+                pretty_error_message(
+                    HarlequinCrashError(
+                        crash_message(report_path, error, saved),
+                        title="Harlequin crashed.",
+                    )
+                )
+            )
+        except BaseException:
+            # last resort: the user gets *something*
+            super()._handle_exception(error)
+            return
+
+        # `textual run --dev`: append the full traceback for whoever is developing
+        if "debug" in self.features:
+            super()._handle_exception(error)

--- a/src/harlequin/cli.py
+++ b/src/harlequin/cli.py
@@ -269,7 +269,7 @@ def _keys_app_callback(ctx: click.Context, param: Any, value: bool) -> None:
         keymap_name=ctx.params.get("keymap_name", None),
     )
     app.run()
-    ctx.exit(0)
+    ctx.exit(app.return_code or 0)
 
 
 def _adapter_option_group(
@@ -692,6 +692,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             tui = Harlequin(
                 adapter=adapter_instance,
                 profile_name=profile,
+                adapter_name=adapter_name,
                 keymap_names=keymap_names,
                 user_defined_keymaps=user_defined_keymaps,
                 connection_hash=connection_id,
@@ -704,6 +705,10 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 ssh_tunnel=tunnel,
             )
             tui.run()
+
+        # a crash exits 1 and a config or connection error exits 2; without
+        # this, both of those exited 0
+        ctx.exit(tui.return_code or 0)
 
     # this command's own options, before any adapter's are added to it
     harlequin_options = {param.name for param in inner_cli.params}

--- a/src/harlequin/components/code_editor.py
+++ b/src/harlequin/components/code_editor.py
@@ -25,7 +25,7 @@ from harlequin.autocomplete import (
     find_symbols,
 )
 from harlequin.components.text_modal import ErrorModal
-from harlequin.editor_cache import BufferState, load_cache
+from harlequin.editor_cache import BufferState, adopt_recovery, load_cache
 from harlequin.exception import HarlequinExternalError
 from harlequin.external import launch_external_editor
 from harlequin.messages import WidgetMounted
@@ -333,6 +333,7 @@ class EditorCollection(Vertical):
         self._member_completer: MemberCompleter | None = None
         self._buffer_symbols: BufferSymbols = NO_SYMBOLS
         self.startup_cache = load_cache()
+        self.recovered_cache, self.recovered_from = adopt_recovery()
         self.buffer_states: dict[str, EditorState] = {}
         self.loaded_buffer_id: str | None = None
         self.tabs = Tabs()
@@ -407,12 +408,19 @@ class EditorCollection(Vertical):
                 completer.update_buffer_symbols(message.symbols)
 
     async def on_mount(self) -> None:
-        if self.startup_cache is not None and self.startup_cache.buffers:
-            for buffer in self.startup_cache.buffers:
+        # a recovered session started from the cache, so it is strictly newer
+        cache = self.recovered_cache or self.startup_cache
+        if cache is not None and cache.buffers:
+            for buffer in cache.buffers:
                 await self.action_new_buffer(state=buffer, activate=False)
-            self._activate_cached_buffer(self.startup_cache.focus_index)
+            self._activate_cached_buffer(cache.focus_index)
         else:
             await self.action_new_buffer()
+        if self.recovered_cache is not None:
+            self.notify(
+                "Recovered buffers from a session that ended unexpectedly.",
+                title="Buffers recovered",
+            )
         self.editor.theme = self.theme
         self.editor.word_completer = self.word_completer
         self.editor.member_completer = self.member_completer

--- a/src/harlequin/crash.py
+++ b/src/harlequin/crash.py
@@ -1,0 +1,174 @@
+"""The file Harlequin and hsql write when they hit a bug in themselves.
+
+A user should never see a raw traceback: it is intimidating, it says nothing
+about what to do next, and Textual renders it with `show_locals=True`, which
+puts connection strings, tokens and query results on the terminal. Instead both
+commands write everything worth having to a file, print where it is, and point
+at an issue template built to receive it.
+
+Headless, because `hsql` writes one too, and because a crash handler that has
+to import the world to report a crash is a fresh place to crash.
+"""
+
+from __future__ import annotations
+
+import os
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from platformdirs import user_log_path
+
+from harlequin.environment import runtime_report
+from harlequin.redact import redact_text
+
+CRASH_REPORT_KEEP = 10
+"""How many reports are kept. Distinct filenames, so a crash loop cannot
+destroy the evidence of the first crash."""
+
+ISSUE_URL = "https://github.com/tconbeer/harlequin/issues/new?template=crash_report.md"
+
+ACTIVE_BUFFER = "active_buffer"
+"""The one context key that is rendered as its own section rather than a fact."""
+
+_RULE = "=" * 72
+
+
+def get_crash_report_dir() -> Path:
+    """Where reports are written: the log dir, not the cache dir.
+
+    A cache is what a user is told to delete when things go wrong, and this is
+    the file we are asking them to keep.
+    """
+    return user_log_path(appname="harlequin", appauthor=False)
+
+
+def root_cause(error: BaseException) -> BaseException:
+    """The error a report should be about, unwrapping Textual's `WorkerFailed`.
+
+    By attribute rather than by class, so this module stays headless. A report
+    naming `WorkerFailed` is a useless report.
+    """
+    wrapped = getattr(error, "error", None)
+    if isinstance(wrapped, BaseException):
+        return wrapped
+    return error
+
+
+def build_crash_report(
+    error: BaseException,
+    context: Mapping[str, Any],
+    program: str = "harlequin",
+) -> str:
+    """The whole report, as the plain text it is written and pasted as.
+
+    Not markdown: the user pastes this into a fenced block in an issue, and a
+    report's own fences would break out of it. Everything goes through
+    `redact_text()` once at the end -- one choke point, rather than a
+    redaction each section has to remember.
+    """
+    cause = root_cause(error)
+    facts = {key: value for key, value in context.items() if key != ACTIVE_BUFFER}
+    sections = [
+        _header(program),
+        _section("ENVIRONMENT", _lines(runtime_report())),
+        _section("CONTEXT", _lines(facts)),
+        _section("TRACEBACK", _traceback(cause)),
+    ]
+    if cause is not error:
+        sections.append(_section("RAISED AS", _traceback(error)))
+    active_buffer = context.get(ACTIVE_BUFFER)
+    if active_buffer:
+        # usually what is needed to reproduce a TUI bug. Last, and under a
+        # heading that says what it is, because SQL holds table names and
+        # literals: the user decides whether to paste it.
+        sections.append(_section("SQL IN THE ACTIVE BUFFER", str(active_buffer)))
+    return redact_text("\n".join(sections))
+
+
+def write_crash_report(report: str) -> Path | None:
+    """Write a report and prune the old ones. None if it could not be written.
+
+    Raises nothing: it is called from a handler that must not be able to fail.
+    """
+    directory = get_crash_report_dir()
+    now = datetime.now(timezone.utc)
+    path = directory / f"crash-{now:%Y%m%dT%H%M%SZ}-{os.getpid()}.log"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        path.write_text(report, encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    _prune(directory)
+    return path
+
+
+def crash_message(
+    report_path: Path | None,
+    error: BaseException,
+    saved: bool,
+    program: str = "harlequin",
+) -> str:
+    """What the user reads on their terminal: what broke, and what to do now."""
+    cause = root_cause(error)
+    lines = [f"{type(cause).__name__}: {cause}", ""]
+    if saved:
+        lines.append(
+            "Your open buffers were saved, and Harlequin will offer them back "
+            "the next time you start it."
+        )
+    if report_path is not None:
+        lines.extend(
+            [
+                f"A crash report was written to {report_path}.",
+                "",
+                f"Please review that file, then report this bug with it at {ISSUE_URL}",
+            ]
+        )
+    else:
+        lines.append(f"Please report this at {ISSUE_URL}.")
+    return "\n".join(lines)
+
+
+def _header(program: str) -> str:
+    written = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    return (
+        f"{program} crash report, written {written}.\n"
+        "\n"
+        "Please review this file before sharing it: it holds your configuration\n"
+        "(with passwords masked) and the SQL that was in your active buffer.\n"
+        f"Report this at {ISSUE_URL}\n"
+    )
+
+
+def _section(title: str, body: str) -> str:
+    return f"\n{_RULE}\n=== {title} ===\n{_RULE}\n\n{body.rstrip()}\n"
+
+
+def _lines(facts: Mapping[str, Any], indent: str = "") -> str:
+    """A mapping as `key: value` lines, one level of nesting indented under it."""
+    rendered = []
+    for key, value in facts.items():
+        if isinstance(value, Mapping):
+            rendered.append(f"{indent}{key}:")
+            rendered.append(_lines(value, indent + "  "))
+        else:
+            rendered.append(f"{indent}{key}: {value}")
+    return "\n".join(rendered)
+
+
+def _traceback(error: BaseException) -> str:
+    """The frames, and never the locals: that is what this replaces."""
+    return "".join(traceback.format_exception(type(error), error, error.__traceback__))
+
+
+def _prune(directory: Path) -> None:
+    try:
+        reports = sorted(
+            directory.glob("crash-*.log"), key=lambda p: p.name, reverse=True
+        )
+        for stale in reports[CRASH_REPORT_KEEP:]:
+            stale.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/src/harlequin/crash.py
+++ b/src/harlequin/crash.py
@@ -13,6 +13,7 @@ to import the world to report a crash is a fresh place to crash.
 from __future__ import annotations
 
 import os
+import textwrap
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,7 +33,11 @@ ISSUE_URL = "https://github.com/tconbeer/harlequin/issues/new?template=crash_rep
 ACTIVE_BUFFER = "active_buffer"
 """The one context key that is rendered as its own section rather than a fact."""
 
-_RULE = "=" * 72
+_WIDTH = 72
+"""What the report wraps its own prose at. The sections it quotes -- a
+traceback, the user's SQL -- are never rewrapped."""
+
+_RULE = "=" * _WIDTH
 
 
 def get_crash_report_dir() -> Path:
@@ -110,27 +115,31 @@ def crash_message(
     saved: bool,
     program: str = "harlequin",
 ) -> str:
-    """What the user reads on their terminal: what broke, and what to do now."""
+    """What the user reads on their terminal: what broke, and what to do now.
+
+    The ask comes before the path, because reporting the crash is the thing
+    the user is being asked to do and the file is only what it needs.
+    """
     cause = root_cause(error)
     lines = [f"{type(cause).__name__}: {cause}", ""]
     if saved:
         lines.extend(
             [
-                "Your open buffers were saved, and Harlequin will offer them "
+                "Your buffers have been saved, and Harlequin will offer them "
                 "back the next time you start it.",
                 "",
             ]
         )
+    lines.extend(
+        [
+            f"Please report this crash to help improve {program.capitalize()}.",
+            ISSUE_URL,
+        ]
+    )
     if report_path is not None:
         lines.extend(
-            [
-                f"A crash report was written to {report_path}.",
-                "",
-                f"Please review that file, then report this bug with it at {ISSUE_URL}",
-            ]
+            ["", "The file you will need for the crash report is at:", str(report_path)]
         )
-    else:
-        lines.append(f"Please report this at {ISSUE_URL}.")
     return "\n".join(lines)
 
 
@@ -138,11 +147,15 @@ def _header(program: str, includes_sql: bool) -> str:
     written = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
     holds = "your configuration, with passwords masked"
     if includes_sql:
-        holds += ",\nand the SQL that was in your active buffer"
+        holds += ", and the SQL that was in your active buffer"
+    warning = textwrap.fill(
+        f"Review and redact as necessary before sharing this file: it holds {holds}.",
+        width=_WIDTH,
+    )
     return (
         f"{program} crash report, written {written}.\n"
         "\n"
-        f"Please review this file before sharing it: it holds {holds}.\n"
+        f"{warning}\n"
         f"Report this at {ISSUE_URL}\n"
     )
 

--- a/src/harlequin/crash.py
+++ b/src/harlequin/crash.py
@@ -70,15 +70,15 @@ def build_crash_report(
     """
     cause = root_cause(error)
     facts = {key: value for key, value in context.items() if key != ACTIVE_BUFFER}
+    active_buffer = context.get(ACTIVE_BUFFER)
     sections = [
-        _header(program),
+        _header(program, includes_sql=bool(active_buffer)),
         _section("ENVIRONMENT", _lines(runtime_report())),
         _section("CONTEXT", _lines(facts)),
         _section("TRACEBACK", _traceback(cause)),
     ]
     if cause is not error:
         sections.append(_section("RAISED AS", _traceback(error)))
-    active_buffer = context.get(ACTIVE_BUFFER)
     if active_buffer:
         # usually what is needed to reproduce a TUI bug. Last, and under a
         # heading that says what it is, because SQL holds table names and
@@ -131,13 +131,15 @@ def crash_message(
     return "\n".join(lines)
 
 
-def _header(program: str) -> str:
+def _header(program: str, includes_sql: bool) -> str:
     written = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    holds = "your configuration, with passwords masked"
+    if includes_sql:
+        holds += ",\nand the SQL that was in your active buffer"
     return (
         f"{program} crash report, written {written}.\n"
         "\n"
-        "Please review this file before sharing it: it holds your configuration\n"
-        "(with passwords masked) and the SQL that was in your active buffer.\n"
+        f"Please review this file before sharing it: it holds {holds}.\n"
         f"Report this at {ISSUE_URL}\n"
     )
 

--- a/src/harlequin/crash.py
+++ b/src/harlequin/crash.py
@@ -114,9 +114,12 @@ def crash_message(
     cause = root_cause(error)
     lines = [f"{type(cause).__name__}: {cause}", ""]
     if saved:
-        lines.append(
-            "Your open buffers were saved, and Harlequin will offer them back "
-            "the next time you start it."
+        lines.extend(
+            [
+                "Your open buffers were saved, and Harlequin will offer them "
+                "back the next time you start it.",
+                "",
+            ]
         )
     if report_path is not None:
         lines.extend(

--- a/src/harlequin/editor_cache.py
+++ b/src/harlequin/editor_cache.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 import pickle
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Union
@@ -8,6 +11,17 @@ from platformdirs import user_cache_dir
 from textual.widgets.text_area import Selection
 
 CACHE_VERSION = 1
+
+CHECKPOINT_INTERVAL_SECONDS = 60.0
+"""How often a running Harlequin writes its buffers to its recovery file."""
+
+RECOVERY_STALE_SECONDS = 3 * CHECKPOINT_INTERVAL_SECONDS
+"""How long a recovery file must go untouched before another process adopts it.
+
+A live sibling checkpoints well inside this window, so its file is left alone
+without a PID-liveness check, which would be wrong on Windows and wrong under
+PID reuse.
+"""
 
 
 @dataclass
@@ -26,9 +40,23 @@ def get_cache_file() -> Path:
     """
     Returns the path to the cache file on disk
     """
-    cache_dir = Path(user_cache_dir(appname="harlequin"))
-    cache_file = cache_dir / f"cache-{CACHE_VERSION}.pickle"
-    return cache_file
+    return _get_cache_dir() / f"cache-{CACHE_VERSION}.pickle"
+
+
+def get_recovery_file() -> Path:
+    """
+    Returns the path to this process's recovery file on disk.
+
+    One file per process, so two Harlequins keep the shared cache's
+    comprehensible "last clean quit wins" semantics instead of thrashing it,
+    and a checkpoint can never overwrite what another process wrote on its way
+    out.
+    """
+    return _get_cache_dir() / f"recovery-{os.getpid()}.pickle"
+
+
+def _get_cache_dir() -> Path:
+    return Path(user_cache_dir(appname="harlequin"))
 
 
 def load_cache() -> Union[Cache, None]:
@@ -86,3 +114,75 @@ def write_cache(cache: Cache) -> bool:
     Dumps buffer contents to disk. Returns False if they could not be written.
     """
     return _write_pickle(cache, get_cache_file())
+
+
+def write_recovery(cache: Cache) -> bool:
+    """
+    Checkpoints buffer contents. Returns False if they could not be written.
+    """
+    return _write_pickle(cache, get_recovery_file())
+
+
+def clear_recovery() -> None:
+    """
+    Drops this process's recovery file, after a clean quit saved the cache.
+    """
+    try:
+        get_recovery_file().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def adopt_recovery() -> tuple[Union[Cache, None], Union[Path, None]]:
+    """
+    Takes over the buffers of a session that ended unexpectedly, if there are any.
+
+    The chosen file is renamed to `.replayed` *before* it is unpickled, so a
+    crash while replaying it cannot repeat: the next start finds nothing to
+    take over. That is the whole crash-loop guard, and it is correct across
+    concurrent processes by construction.
+    """
+    for candidate in _recovery_candidates():
+        replayed = candidate.with_suffix(".replayed")
+        try:
+            os.replace(candidate, replayed)
+        except OSError:
+            continue
+        try:
+            with replayed.open("rb") as f:
+                cache = pickle.load(f)
+            assert isinstance(cache, Cache)
+        except Exception:
+            continue
+        return cache, replayed
+    return None, None
+
+
+def _recovery_candidates() -> List[Path]:
+    """
+    Recovery files this process may adopt, most recently written first.
+
+    A crash handler's `recovered-*` file is always adopted; a `recovery-*` file
+    is only adopted once it has gone stale, which is how a sibling process that
+    is still running keeps its own.
+    """
+    cache_dir = _get_cache_dir()
+    stale_before = time.time() - RECOVERY_STALE_SECONDS
+    candidates: List[Path] = []
+    try:
+        for pattern, cutoff in (
+            ("recovered-*.pickle", None),
+            ("recovery-*.pickle", stale_before),
+        ):
+            matches = []
+            for path in cache_dir.glob(pattern):
+                try:
+                    mtime = path.stat().st_mtime
+                except OSError:
+                    continue
+                if cutoff is None or mtime < cutoff:
+                    matches.append((mtime, path))
+            candidates.extend(path for _, path in sorted(matches, reverse=True))
+    except OSError:
+        return []
+    return candidates

--- a/src/harlequin/editor_cache.py
+++ b/src/harlequin/editor_cache.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,11 +53,36 @@ def load_cache() -> Union[Cache, None]:
         return cache
 
 
-def write_cache(cache: Cache) -> None:
+def _write_pickle(cache: Cache, path: Path) -> bool:
     """
-    Updates dumps buffer contents to to disk
+    Pickles a Cache to path, atomically. Returns False if it could not be written.
+
+    The write goes to a temp file in the same directory and is renamed into
+    place, so a reader never sees a partial file; the fsync is what keeps a
+    power loss from leaving a zero-length one. The temp name carries the pid,
+    so a killed process leaves at most one stray behind. It never raises: the
+    callers run where an exception would itself take the app down.
     """
-    cache_file = get_cache_file()
-    cache_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(cache_file, "wb") as f:
-        pickle.dump(cache, f)
+    temp_file = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(temp_file, "wb") as f:
+            pickle.dump(cache, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(temp_file, path)
+    except (OSError, pickle.PicklingError):
+        try:
+            temp_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    else:
+        return True
+
+
+def write_cache(cache: Cache) -> bool:
+    """
+    Dumps buffer contents to disk. Returns False if they could not be written.
+    """
+    return _write_pickle(cache, get_cache_file())

--- a/src/harlequin/environment.py
+++ b/src/harlequin/environment.py
@@ -1,0 +1,165 @@
+"""Facts about the running installation, for the diagnostics that report them.
+
+`hsql --info` answers "what is installed and what can it do"; a crash report
+answers "what was this running on". They are the same questions, so they read
+the same facts from here rather than each building their own -- and a fact
+worth adding gets added once.
+
+Headless, and it has to stay that way: `hsql` imports it, and a crash report is
+built after the app is gone. `adapter_facts()` defers `harlequin.plugins` into
+its body for the same reason `--info` does -- importing every installed adapter
+is the most expensive thing this module can do, and most callers want none of
+it.
+"""
+
+from __future__ import annotations
+
+import locale
+import os
+import platform
+import shutil
+import sys
+from importlib.metadata import PackageNotFoundError, distribution, version
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from harlequin.adapter import HarlequinAdapter
+
+UNKNOWN = "unknown"
+"""What an adapter that would not import declares, in place of a capability map."""
+
+
+def harlequin_version() -> str:
+    return version("harlequin")
+
+
+def python_facts() -> dict[str, str]:
+    return {
+        "version": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "executable": sys.executable,
+    }
+
+
+def platform_facts() -> dict[str, str]:
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+    }
+
+
+def terminal_facts() -> dict[str, Any]:
+    """What the TUI is drawing into, which is half of every rendering bug.
+
+    `ssh` is a bool and never the value of `SSH_CONNECTION`, which holds IP
+    addresses: whether the session is remote explains a bug, and where it came
+    from does not.
+    """
+    size = shutil.get_terminal_size()
+    return {
+        "term": os.environ.get("TERM"),
+        "term_program": os.environ.get("TERM_PROGRAM"),
+        "term_program_version": os.environ.get("TERM_PROGRAM_VERSION"),
+        "colorterm": os.environ.get("COLORTERM"),
+        "shell": os.environ.get("SHELL") or os.environ.get("COMSPEC"),
+        "wsl_distro": os.environ.get("WSL_DISTRO_NAME"),
+        "ssh": bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY")),
+        "locale": _locale(),
+        "size": f"{size.columns}x{size.lines}",
+    }
+
+
+def install_facts() -> dict[str, Any]:
+    """How harlequin got onto this machine, which the bug template used to ask.
+
+    pip, uv and pipx all write the `INSTALLER` file; a build that has none is
+    reported as null rather than guessed at.
+    """
+    try:
+        installer = distribution("harlequin").read_text("INSTALLER")
+    except (PackageNotFoundError, OSError):
+        installer = None
+    return {
+        "installer": installer.strip() if installer else None,
+        "in_venv": sys.prefix != sys.base_prefix,
+    }
+
+
+def adapter_facts(only: str | None = None) -> dict[str, dict[str, Any]]:
+    """Every installed adapter's declarations, or one's, keyed by adapter name.
+
+    Keyed rather than a list, because the question a caller has is about a name
+    they already hold: what can `duckdb` do. An adapter that will not import is
+    reported with its capabilities `"unknown"` and the import error beside
+    them. Never `false`: guessing false about what an adapter implements is the
+    direction that gets someone hurt.
+    """
+    from harlequin.exception import HarlequinConfigError
+    from harlequin.plugins import (
+        adapter_distributions,
+        adapter_names,
+        adapter_versions,
+        load_adapter,
+    )
+
+    distributions = adapter_distributions()
+    versions = adapter_versions()
+    names = [only] if only is not None else adapter_names()
+    adapters: dict[str, dict[str, Any]] = {}
+    for name in names:
+        capabilities: dict[str, bool] | str = UNKNOWN
+        error: str | None = None
+        try:
+            adapter_cls = load_adapter(name)
+        except HarlequinConfigError as e:
+            error = e.msg
+        else:
+            capabilities = adapter_capabilities(adapter_cls)
+        adapters[name] = {
+            "distribution": distributions.get(name),
+            "version": versions.get(name),
+            "capabilities": capabilities,
+            "error": error,
+        }
+    return adapters
+
+
+def adapter_capabilities(adapter_cls: type[HarlequinAdapter]) -> dict[str, bool]:
+    """What one adapter declares, read off the class and never called.
+
+    The names come from the contract rather than a list kept here, so a
+    capability added to `HarlequinAdapter` is reported as soon as it exists.
+    """
+    from harlequin.adapter import HarlequinAdapter
+
+    return {
+        name.lower(): bool(getattr(adapter_cls, name, False))
+        for name in sorted(vars(HarlequinAdapter))
+        if name.startswith("IMPLEMENTS_")
+    }
+
+
+def runtime_report() -> dict[str, Any]:
+    """Everything cheap: no adapter is imported and no subprocess is run.
+
+    That is what makes it safe to call from a crash handler, where an import of
+    every installed adapter is both slow and a fresh place to crash.
+    """
+    return {
+        "version": harlequin_version(),
+        "python": python_facts(),
+        "platform": platform_facts(),
+        "terminal": terminal_facts(),
+        "install": install_facts(),
+    }
+
+
+def _locale() -> str | None:
+    try:
+        language, encoding = locale.getlocale()
+    except ValueError:
+        return None
+    if language is None and encoding is None:
+        return None
+    return ".".join(part for part in (language, encoding) if part)

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -35,6 +35,12 @@ class HarlequinConnectionError(HarlequinError):
     pass
 
 
+class HarlequinCrashError(HarlequinError):
+    """A bug in Harlequin itself, as the panel that replaces the traceback."""
+
+    pass
+
+
 class HarlequinCopyError(HarlequinError):
     pass
 

--- a/src/harlequin/hsql/__init__.py
+++ b/src/harlequin/hsql/__init__.py
@@ -17,36 +17,48 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Sequence
+from typing import Any, NoReturn, Sequence
 
 __all__ = ["main"]
 
 
 def main() -> None:
     """The `hsql` console script."""
+    argv = sys.argv[1:]
+    try:
+        code = _run_warm(argv)
+    except BaseException as e:
+        _report_crash(e, argv)
+    if code is not None:
+        sys.exit(code)
+    _run_cold(argv)
+
+
+def _run_warm(argv: list[str]) -> int | None:
+    """What the session that answered exited with, or None to run cold.
+
+    None where this invocation names no session at all, and where it names an
+    ambient one that is not running -- the client has warned by then, and a
+    cold run is what the caller wanted either way.
+    """
     from harlequin.hsql.session import requested_session
 
-    argv = sys.argv[1:]
     session = requested_session(argv, os.environ)
-    if session is not None:
-        from harlequin.hsql.client import INTERRUPT, run
+    if session is None:
+        return None
 
-        try:
-            code = run(session, argv, os.environ)
-        except KeyboardInterrupt:
-            sys.exit(INTERRUPT)
-        if code is not None:
-            sys.exit(code)
-        # an ambient session that is not running: warned, and running cold
+    from harlequin.hsql.client import INTERRUPT, run
 
-    _run_cold(argv)
+    try:
+        return run(session, argv, os.environ)
+    except KeyboardInterrupt:
+        return INTERRUPT
 
 
 def _run_cold(argv: list[str]) -> None:
     """A fresh process, a fresh connection, and no memory of the last one."""
     import click
 
-    from harlequin.hsql import diagnostics
     from harlequin.hsql.cli import PROGRAM, build_cli
     from harlequin.hsql.diagnostics import ExitCode
 
@@ -62,22 +74,32 @@ def _run_cold(argv: list[str]) -> None:
     except (click.Abort, KeyboardInterrupt):
         sys.exit(ExitCode.INTERRUPT)
     except BaseException as e:
-        # a bug in hsql, rather than anything the run was asked to do. Python's
-        # own handler would print a traceback and exit 1, which is the code for
-        # a query the database rejected: a caller scripting against these could
-        # not tell the two apart.
-        from harlequin.crash import build_crash_report, write_crash_report
-
-        report_path = None
-        try:
-            report_path = write_crash_report(
-                build_crash_report(e, _crash_context(argv), program=PROGRAM)
-            )
-        except BaseException:
-            pass
-        diagnostics.report_crash(report_path)
-        sys.exit(ExitCode.CRASH)
+        _report_crash(e, argv)
     sys.exit(code if isinstance(code, int) else ExitCode.OK)
+
+
+def _report_crash(error: BaseException, argv: Sequence[str]) -> NoReturn:
+    """Exit `CRASH` over a bug in hsql, having written a report about it.
+
+    Python's own handler would print a traceback and exit 1, which is the code
+    for a query the database rejected: a caller scripting against these could
+    not tell the two apart. Both entry points end here, since a bug in the
+    client is as much hsql's as a bug in the command.
+    """
+    from harlequin.crash import build_crash_report, write_crash_report
+    from harlequin.hsql import diagnostics
+    from harlequin.hsql.cli import PROGRAM
+    from harlequin.hsql.diagnostics import ExitCode
+
+    report_path = None
+    try:
+        report_path = write_crash_report(
+            build_crash_report(error, _crash_context(argv), program=PROGRAM)
+        )
+    except BaseException:
+        pass
+    diagnostics.report_crash(report_path)
+    sys.exit(ExitCode.CRASH)
 
 
 def _crash_context(argv: Sequence[str]) -> dict[str, Any]:

--- a/src/harlequin/hsql/__init__.py
+++ b/src/harlequin/hsql/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import Any, Sequence
 
 __all__ = ["main"]
 
@@ -45,6 +46,7 @@ def _run_cold(argv: list[str]) -> None:
     """A fresh process, a fresh connection, and no memory of the last one."""
     import click
 
+    from harlequin.hsql import diagnostics
     from harlequin.hsql.cli import PROGRAM, build_cli
     from harlequin.hsql.diagnostics import ExitCode
 
@@ -59,4 +61,58 @@ def _run_cold(argv: list[str]) -> None:
         sys.exit(e.exit_code)
     except (click.Abort, KeyboardInterrupt):
         sys.exit(ExitCode.INTERRUPT)
+    except BaseException as e:
+        # a bug in hsql, rather than anything the run was asked to do. Python's
+        # own handler would print a traceback and exit 1, which is the code for
+        # a query the database rejected: a caller scripting against these could
+        # not tell the two apart.
+        from harlequin.crash import build_crash_report, write_crash_report
+
+        report_path = None
+        try:
+            report_path = write_crash_report(
+                build_crash_report(e, _crash_context(argv), program=PROGRAM)
+            )
+        except BaseException:
+            pass
+        diagnostics.report_crash(report_path)
+        sys.exit(ExitCode.CRASH)
     sys.exit(code if isinstance(code, int) else ExitCode.OK)
+
+
+def _crash_context(argv: Sequence[str]) -> dict[str, Any]:
+    """What the run was, for the crash report.
+
+    The argv is masked by `redact_conn_str()` before the report's own pass: a
+    crash during parsing happens before `hide_secrets_in()` runs, so the
+    registered-secret set is empty and span-masking is the only thing that
+    catches a DSN typed on the command line.
+    """
+    from harlequin.redact import redact_conn_str
+
+    context: dict[str, Any] = {}
+    try:
+        context["argv"] = " ".join(redact_conn_str(list(argv)))
+    except Exception:
+        context["argv"] = "unknown"
+    for key, flags in (
+        ("adapter", ("-a", "--adapter")),
+        ("profile", ("-P", "--profile")),
+    ):
+        context[key] = _value_after(argv, flags)
+    return context
+
+
+def _value_after(argv: Sequence[str], flags: Sequence[str]) -> str | None:
+    """What a flag was given on the command line, read off argv.
+
+    Read here rather than taken from the parsed command: a crash during parsing
+    is one of the crashes this reports, and there is nothing parsed to ask.
+    """
+    for index, arg in enumerate(argv):
+        if arg in flags and index + 1 < len(argv):
+            return argv[index + 1]
+        for flag in flags:
+            if arg.startswith(f"{flag}="):
+                return arg[len(flag) + 1 :]
+    return None

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -80,6 +80,14 @@ class ExitCode(IntEnum):
     TIMEOUT = 4
     """`--timeout` ran out, and hsql stopped the run."""
 
+    CRASH = 70
+    """hsql hit a bug in itself. `sysexits.h`'s EX_SOFTWARE.
+
+    70 rather than the next free small integer: it cannot be confused with the
+    codes above, and a caller scripting against them could not otherwise tell a
+    bug in hsql from a query the database rejected.
+    """
+
     INTERRUPT = 130
 
 
@@ -116,6 +124,20 @@ def report_error(exception: BaseException) -> None:
 
 def note(message: str) -> None:
     _write(f"note: {message}")
+
+
+def report_crash(report_path: Path | None) -> None:
+    """Say that this was a bug in hsql, and where the report is.
+
+    Plain text, no panel: hsql writes no box drawing, and this leaves through
+    `_write()` like everything else on this stream.
+    """
+    from harlequin.crash import ISSUE_URL
+
+    error("hsql hit a bug in itself and could not finish the run.")
+    if report_path is not None:
+        note(f"a crash report was written to {report_path}")
+    note(f"please review it, then report this bug at {ISSUE_URL}")
 
 
 def report_theme_confusion(conn_str: Sequence[str]) -> None:

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -135,9 +135,9 @@ def report_crash(report_path: Path | None) -> None:
     from harlequin.crash import ISSUE_URL
 
     error("hsql hit a bug in itself and could not finish the run.")
+    note(f"please report this crash to help improve Harlequin: {ISSUE_URL}")
     if report_path is not None:
-        note(f"a crash report was written to {report_path}")
-    note(f"please review it, then report this bug at {ISSUE_URL}")
+        note(f"the file you will need for the crash report is at {report_path}")
 
 
 def report_theme_confusion(conn_str: Sequence[str]) -> None:

--- a/src/harlequin/hsql/modes/info.py
+++ b/src/harlequin/hsql/modes/info.py
@@ -29,21 +29,22 @@ adapter implements is the direction that gets someone hurt.
 from __future__ import annotations
 
 import json
-import platform
 import subprocess
-import sys
-from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from harlequin.config import DEFAULT_ADAPTER, discover_config_files, resolve_profile
+from harlequin.environment import (
+    adapter_facts,
+    harlequin_version,
+    platform_facts,
+    python_facts,
+)
 from harlequin.exception import HarlequinConfigError
 from harlequin.hsql import diagnostics
 from harlequin.hsql.diagnostics import ExitCode
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from harlequin.adapter import HarlequinAdapter
 
 FILENAME = "info.json"
 """What this document is called when `-o` names a folder to write it into."""
@@ -52,10 +53,6 @@ JSON = "json"
 """The one `--format` a document mode answers to. `none` writes nothing."""
 
 NONE = "none"
-
-UNKNOWN = "unknown"
-"""What an adapter that would not import declares, in place of a capability map."""
-
 
 _VERSION_SECONDS = 5.0
 """How long `ssh -V` has to answer. It reads no config and opens no socket."""
@@ -87,17 +84,9 @@ def report(
     profile["options"] = _redacted(profile["options"], adapter_in_use["name"])
     document = {
         "program": "hsql",
-        "version": version("harlequin"),
-        "python": {
-            "version": platform.python_version(),
-            "implementation": platform.python_implementation(),
-            "executable": sys.executable,
-        },
-        "platform": {
-            "system": platform.system(),
-            "release": platform.release(),
-            "machine": platform.machine(),
-        },
+        "version": harlequin_version(),
+        "python": python_facts(),
+        "platform": platform_facts(),
         "ssh": _ssh_client(),
         "config": _config_files(config_path),
         "profile": profile,
@@ -217,58 +206,17 @@ def _redacted(options: Any, adapter: str) -> Any:
 
 
 def _adapters(only: str | None) -> dict[str, Any]:
-    """Every installed adapter's declarations, or one's, keyed by adapter name.
+    """Every installed adapter's declarations, or one's, and a note about each
+    one that would not import.
 
-    Keyed rather than a list, because the question a caller has is about a name
-    they already hold: what can `duckdb` do.
+    Both halves are worth reporting: an agent reading the document sees why the
+    capabilities are unknown, and a human sees it on stderr.
     """
-    from harlequin.plugins import (
-        adapter_distributions,
-        adapter_names,
-        adapter_versions,
-        load_adapter,
-    )
-
-    distributions = adapter_distributions()
-    versions = adapter_versions()
-    names = [only] if only is not None else adapter_names()
-    adapters: dict[str, Any] = {}
-    for name in names:
-        capabilities: dict[str, bool] | str = UNKNOWN
-        error: str | None = None
-        try:
-            adapter_cls = load_adapter(name)
-        except HarlequinConfigError as e:
-            # both halves are worth reporting: an agent reading the document
-            # sees why the capabilities are unknown, and a human sees it on
-            # stderr
-            error = e.msg
+    adapters = adapter_facts(only)
+    for name, facts in adapters.items():
+        if facts["error"] is not None:
             diagnostics.note(f"{name} is installed, but could not be imported.")
-        else:
-            capabilities = _capabilities(adapter_cls)
-        adapters[name] = {
-            "distribution": distributions.get(name),
-            "version": versions.get(name),
-            "capabilities": capabilities,
-            "error": error,
-        }
-    return adapters
-
-
-def _capabilities(adapter_cls: type[HarlequinAdapter]) -> dict[str, bool]:
-    """What one adapter declares, read off the class and never called.
-
-    The names come from the contract rather than a list kept here, so a
-    capability added to `HarlequinAdapter` is reported by this mode as soon as
-    it exists.
-    """
-    from harlequin.adapter import HarlequinAdapter
-
-    return {
-        name.lower(): bool(getattr(adapter_cls, name, False))
-        for name in sorted(vars(HarlequinAdapter))
-        if name.startswith("IMPLEMENTS_")
-    }
+    return dict(adapters)
 
 
 def _text(value: Any) -> str | None:

--- a/src/harlequin/hsql/skill/SKILL.md
+++ b/src/harlequin/hsql/skill/SKILL.md
@@ -72,9 +72,10 @@ time, and never run hsql with `2>/dev/null`: truncation notices and errors both 
 ## 7. Branch on the exit code
 
 `0` success, `1` the database rejected the SQL, `2` a bad flag or a config problem, `3`
-could not connect, `4` `--timeout` ran out, `130` interrupted. A `2` is your bug, a `1`
-is the SQL's, a `3` the environment's — and stdout is empty on all of them, so read the
-code before the output. `references/troubleshooting.md` goes code by code.
+could not connect, `4` `--timeout` ran out, `70` a bug in hsql itself, `130` interrupted.
+A `2` is your bug, a `1` is the SQL's, a `3` the environment's, a `70` ours — and stdout
+is empty on all of them, so read the code before the output.
+`references/troubleshooting.md` goes code by code.
 
 ## 8. Ask before you write
 

--- a/src/harlequin/hsql/skill/references/troubleshooting.md
+++ b/src/harlequin/hsql/skill/references/troubleshooting.md
@@ -65,6 +65,13 @@ Either the query is slower than the bound, or the bound is too tight. Do not sim
 it: check the query with `explain`, add the filter you forgot, or aggregate in SQL rather
 than fetching rows to count them.
 
+## `70` — a bug in hsql
+
+hsql failed at something that is not your run's fault. It wrote a crash report and
+printed the path on stderr; nothing you change about the SQL or the flags will help.
+Please report it, with that file, at
+<https://github.com/tconbeer/harlequin/issues/new?template=crash_report.md>.
+
 ## `130` — interrupted
 
 Someone or something sent an interrupt. Nothing to fix.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,18 @@ def set_locale_to_enUS() -> None:
 
 
 @pytest.fixture(autouse=True)
+def crash_reports_go_to_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Every crash a test causes writes here, not into the developer's log dir.
+
+    `run_test` re-raises through `_handle_exception`, so without this every
+    failing functional test in the suite leaves a crash report behind.
+    """
+    report_dir = tmp_path / "crash-reports"
+    monkeypatch.setattr("harlequin.crash.get_crash_report_dir", lambda: report_dir)
+    return report_dir
+
+
+@pytest.fixture(autouse=True)
 def no_discovered_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the machine running the tests out of them.
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -37,6 +37,7 @@ def no_use_buffer_cache(
         "harlequin.components.code_editor.adopt_recovery", lambda: (None, None)
     )
     monkeypatch.setattr("harlequin.app.write_editor_cache", lambda *_: None)
+    monkeypatch.setattr("harlequin.app.write_recovery", lambda *_: True)
     monkeypatch.setattr("harlequin.app.clear_recovery", lambda *_: None)
 
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -33,7 +33,11 @@ def no_use_buffer_cache(
     if "use_cache" in request.keywords:
         return
     monkeypatch.setattr("harlequin.components.code_editor.load_cache", lambda: None)
+    monkeypatch.setattr(
+        "harlequin.components.code_editor.adopt_recovery", lambda: (None, None)
+    )
     monkeypatch.setattr("harlequin.app.write_editor_cache", lambda *_: None)
+    monkeypatch.setattr("harlequin.app.clear_recovery", lambda *_: None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/functional_tests/test_cache.py
+++ b/tests/functional_tests/test_cache.py
@@ -134,3 +134,29 @@ async def test_harlequin_clears_its_recovery_file_on_quit(app: Harlequin) -> Non
 
     assert not recovery_file.exists()
     assert get_cache_file().exists()
+
+
+@pytest.mark.use_cache
+@pytest.mark.asyncio
+async def test_harlequin_checkpoints_buffers(app: Harlequin) -> None:
+    recovery_file = get_recovery_file()
+    async with app.run_test() as pilot:
+        while app.editor is None:
+            await pilot.pause()
+        app._checkpoint_editor_cache()
+        # a blank buffer is not work, so there is nothing to save yet
+        assert not recovery_file.exists()
+
+        app.editor.text = "select 1"
+        app._checkpoint_editor_cache()
+        assert pickle.loads(recovery_file.read_bytes()).buffers[0].text == "select 1"
+
+        # and an idle session does not rewrite what it already wrote
+        written_at = recovery_file.stat().st_mtime_ns
+        app._checkpoint_editor_cache()
+        assert recovery_file.stat().st_mtime_ns == written_at
+
+        # a blank buffer cannot destroy a good checkpoint, either
+        app.editor.text = ""
+        app._checkpoint_editor_cache()
+        assert pickle.loads(recovery_file.read_bytes()).buffers[0].text == "select 1"

--- a/tests/functional_tests/test_cache.py
+++ b/tests/functional_tests/test_cache.py
@@ -10,6 +10,7 @@ from harlequin.editor_cache import (
     BufferState,
     Cache,
     get_cache_file,
+    get_recovery_file,
     load_cache,
     write_cache,
 )
@@ -96,3 +97,40 @@ async def test_harlequin_writes_cache(app: Harlequin) -> None:
     assert isinstance(cache, Cache)
     assert [buffer.text for buffer in cache.buffers] == ["first", "second"]
     assert cache.focus_index == 1
+
+
+@pytest.mark.use_cache
+@pytest.mark.asyncio
+async def test_harlequin_recovers_buffers(cache: Cache, app: Harlequin) -> None:
+    """A recovered session started from the cache, so it wins over one."""
+    write_cache(Cache(focus_index=0, buffers=[BufferState(Selection(), "stale\n")]))
+    recovery_file = get_cache_file().with_name("recovered-20260904T120000Z-99.pickle")
+    recovery_file.write_bytes(pickle.dumps(cache))
+
+    async with app.run_test() as pilot:
+        while app.editor is None:
+            await pilot.pause()
+        assert app.editor_collection is not None
+        assert [buffer.text for buffer in app.editor_collection.buffers] == [
+            buffer.text for buffer in cache.buffers
+        ]
+
+    # the poisoned-buffer guard: replayed once, whatever happened during the replay
+    assert not recovery_file.exists()
+    assert recovery_file.with_suffix(".replayed").exists()
+
+
+@pytest.mark.use_cache
+@pytest.mark.asyncio
+async def test_harlequin_clears_its_recovery_file_on_quit(app: Harlequin) -> None:
+    recovery_file = get_recovery_file()
+    recovery_file.parent.mkdir(parents=True, exist_ok=True)
+    recovery_file.write_bytes(pickle.dumps(Cache(focus_index=0, buffers=[])))
+
+    async with app.run_test() as pilot:
+        while app.editor is None:
+            await pilot.pause()
+        await pilot.press("ctrl+q")
+
+    assert not recovery_file.exists()
+    assert get_cache_file().exists()

--- a/tests/functional_tests/test_crash.py
+++ b/tests/functional_tests/test_crash.py
@@ -102,8 +102,14 @@ async def test_a_crash_saves_the_open_buffers(
 
 @pytest.mark.asyncio
 async def test_the_report_holds_what_the_session_was(
-    app: Harlequin, crash_reports_go_to_tmp: Path
+    duckdb_adapter: type[HarlequinAdapter], crash_reports_go_to_tmp: Path
 ) -> None:
+    """Built the way `cli.py` builds it, which is where the adapter gets a name."""
+    app = Harlequin(
+        duckdb_adapter([":memory:"], no_init=True),
+        adapter_name="duckdb",
+        profile_name="warehouse",
+    )
     with pytest.raises(RuntimeError):
         async with app.run_test() as pilot:
             while app.editor is None:
@@ -114,7 +120,12 @@ async def test_the_report_holds_what_the_session_was(
 
     (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
     text = report.read_text()
+    assert "adapter: duckdb" in text
     assert "adapter_class: DuckDbAdapter" in text
+    # the distribution, not the module: both bundled adapters ship inside
+    # `harlequin`, whose name their module never spells
+    assert "adapter_distribution: harlequin " in text
+    assert "profile: warehouse" in text
     assert "connected: True" in text
     assert "buffers: 1" in text
     # the SQL is last, under a heading that says what it is

--- a/tests/functional_tests/test_crash.py
+++ b/tests/functional_tests/test_crash.py
@@ -1,0 +1,235 @@
+"""What a user sees, and what survives, when Harlequin hits a bug in itself.
+
+Injected through `_handle_exception` directly: the handler is the contract, and
+finding a real crash to provoke would pin the test to whichever bug it used.
+The assertions are on stderr, because that is where the message lands -- the
+message pump is gone by then, so there is no screen to look at.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+from textual.widgets.text_area import Selection
+
+from harlequin import Harlequin
+from harlequin.adapter import HarlequinAdapter
+from harlequin.editor_cache import BufferState, Cache, get_cache_file
+
+
+@pytest.fixture(autouse=True)
+def mock_user_cache_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("harlequin.editor_cache.user_cache_dir", lambda **_: cache_dir)
+    return cache_dir
+
+
+def crash(app: Harlequin, error: Exception) -> None:
+    """Hand the handler an exception the way the message pump does.
+
+    From inside an `except` block: Textual's own renderer reads
+    `sys.exc_info()`, so an exception injected from outside one would exercise
+    a path no crash takes.
+    """
+    try:
+        raise error
+    except Exception as caught:
+        app._handle_exception(caught)
+
+
+def panel_text(capsys: pytest.CaptureFixture[str]) -> str:
+    """What was printed, with the box drawn around it taken off."""
+    return "\n".join(
+        line.strip("│╭╮╰╯─ \t") for line in capsys.readouterr().err.splitlines()
+    )
+
+
+def unwrapped(text: str) -> str:
+    """The same, on one line: rich folds a long path across two of them."""
+    return "".join(text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_a_crash_prints_a_panel_and_not_a_traceback(
+    app: Harlequin, crash_reports_go_to_tmp: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            crash(app, RuntimeError("boom"))
+            await pilot.pause()
+
+    assert app.return_code == 1
+
+    (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
+    assert "RuntimeError" in report.read_text()
+
+    printed = panel_text(capsys)
+    assert "Harlequin crashed." in printed
+    assert "RuntimeError: boom" in printed
+    assert str(report) in unwrapped(printed)
+    assert "Traceback (most recent call last)" not in printed
+
+
+@pytest.mark.use_cache
+@pytest.mark.asyncio
+async def test_a_crash_saves_the_open_buffers(
+    app: Harlequin,
+    mock_user_cache_dir: Path,
+    crash_reports_go_to_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            app.editor.text = "select 'work in progress'"
+            crash(app, RuntimeError("boom"))
+            await pilot.pause()
+
+    (recovered,) = list(mock_user_cache_dir.glob("recovered-*.pickle"))
+    cache = pickle.loads(recovered.read_bytes())
+    assert cache.buffers[0].text == "select 'work in progress'"
+    # the last clean quit's cache is untouched: if the recovered buffers are
+    # themselves the problem, that is still on disk
+    assert not get_cache_file().exists()
+
+    assert "saved" in panel_text(capsys)
+
+
+@pytest.mark.asyncio
+async def test_the_report_holds_what_the_session_was(
+    app: Harlequin, crash_reports_go_to_tmp: Path
+) -> None:
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            app.editor.text = "select 'reproduce me'"
+            crash(app, RuntimeError("boom"))
+            await pilot.pause()
+
+    (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
+    text = report.read_text()
+    assert "adapter_class: DuckDbAdapter" in text
+    assert "connected: True" in text
+    assert "buffers: 1" in text
+    # the SQL is last, under a heading that says what it is
+    assert text.rstrip().endswith("select 'reproduce me'")
+
+
+@pytest.mark.asyncio
+async def test_a_crash_report_is_written_once(
+    app: Harlequin, crash_reports_go_to_tmp: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The handler runs inside an `except` block, so it must not be able to
+    raise. A second exception returns without reporting again."""
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            crash(app, RuntimeError("boom"))
+            crash(app, RuntimeError("and again"))
+            await pilot.pause()
+
+    assert len(list(crash_reports_go_to_tmp.glob("crash-*.log"))) == 1
+    printed = panel_text(capsys)
+    assert printed.count("Harlequin crashed.") == 1
+    assert "and again" not in printed
+
+
+@pytest.mark.asyncio
+async def test_a_crash_is_reported_even_when_the_report_cannot_be_written(
+    app: Harlequin,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise OSError("the log dir is gone")
+
+    monkeypatch.setattr("harlequin.app_base.write_crash_report", _raise)
+
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            crash(app, RuntimeError("boom"))
+            await pilot.pause()
+
+    assert app.return_code == 1
+    printed = panel_text(capsys)
+    assert "RuntimeError: boom" in printed
+    assert "Traceback (most recent call last)" not in printed
+
+
+@pytest.mark.asyncio
+async def test_the_traceback_is_still_printed_in_dev_mode(
+    app: Harlequin, crash_reports_go_to_tmp: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`make serve`, i.e. `textual run --dev`: one code path, both audiences."""
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            while app.editor is None:
+                await pilot.pause()
+            app.features = frozenset({*app.features, "debug"})
+            crash(app, RuntimeError("boom"))
+            await pilot.pause()
+
+    printed = panel_text(capsys)
+    assert "Harlequin crashed." in printed
+    assert "Traceback (most recent call last)" in printed
+
+
+def test_a_crash_before_the_app_is_mounted_saves_nothing(
+    duckdb_adapter: type[HarlequinAdapter],
+) -> None:
+    """`editor_collection` is created in compose(), not __init__."""
+    app = Harlequin(duckdb_adapter([":memory:"], no_init=True))
+
+    assert app._save_work_on_crash() is False
+    assert isinstance(app._crash_context(), dict)
+
+
+@pytest.mark.use_cache
+@pytest.mark.asyncio
+async def test_a_crash_while_replaying_recovered_buffers_cannot_repeat(
+    app: Harlequin,
+    app_all_adapters: Harlequin,
+    mock_user_cache_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crash_reports_go_to_tmp: Path,
+) -> None:
+    """The crash-loop guard, end to end: the poisoned file is spent by the
+    start that choked on it."""
+    poisoned = mock_user_cache_dir / "recovered-20260904T120000Z-99.pickle"
+    poisoned.parent.mkdir(parents=True, exist_ok=True)
+    poisoned.write_bytes(
+        pickle.dumps(
+            Cache(focus_index=0, buffers=[BufferState(Selection(), "select 1\n")])
+        )
+    )
+
+    async def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("crash while replaying")
+
+    monkeypatch.setattr(
+        "harlequin.components.code_editor.EditorCollection.action_new_buffer", _boom
+    )
+    with pytest.raises(RuntimeError):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+    assert not poisoned.exists()
+    assert poisoned.with_suffix(".replayed").exists()
+
+    monkeypatch.undo()
+    async with app_all_adapters.run_test() as pilot:
+        while app_all_adapters.editor is None:
+            await pilot.pause()
+        assert app_all_adapters.editor_collection is not None
+        assert app_all_adapters.editor_collection.tab_count == 1
+        assert app_all_adapters.editor.text == ""

--- a/tests/functional_tests/test_crash.py
+++ b/tests/functional_tests/test_crash.py
@@ -12,11 +12,15 @@ import pickle
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 from textual.widgets.text_area import Selection
 
 from harlequin import Harlequin
 from harlequin.adapter import HarlequinAdapter
+from harlequin.app_base import _as_markup
+from harlequin.crash import ISSUE_URL, crash_message
 from harlequin.editor_cache import BufferState, Cache, get_cache_file
+from harlequin.exception import HarlequinCrashError, pretty_error_message
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +74,7 @@ async def test_a_crash_prints_a_panel_and_not_a_traceback(
     printed = panel_text(capsys)
     assert "Harlequin crashed." in printed
     assert "RuntimeError: boom" in printed
+    assert "Please report this crash to help improve Harlequin." in printed
     assert str(report) in unwrapped(printed)
     assert "Traceback (most recent call last)" not in printed
 
@@ -97,7 +102,7 @@ async def test_a_crash_saves_the_open_buffers(
     # themselves the problem, that is still on disk
     assert not get_cache_file().exists()
 
-    assert "saved" in panel_text(capsys)
+    assert "Your buffers have been saved" in panel_text(capsys)
 
 
 @pytest.mark.asyncio
@@ -244,3 +249,35 @@ async def test_a_crash_while_replaying_recovered_buffers_cannot_repeat(
         assert app_all_adapters.editor_collection is not None
         assert app_all_adapters.editor_collection.tab_count == 1
         assert app_all_adapters.editor.text == ""
+
+
+def render_panel(message: str) -> str:
+    """The panel as a terminal receives it, escape sequences and all."""
+    console = Console(width=100, force_terminal=True, legacy_windows=False)
+    with console.capture() as capture:
+        console.print(
+            pretty_error_message(
+                HarlequinCrashError(_as_markup(message), title="Harlequin crashed.")
+            )
+        )
+    return capture.get()
+
+
+def test_the_reporting_url_is_a_clickable_link() -> None:
+    """A bare URL is not clickable in every terminal; an OSC-8 link is."""
+    message = crash_message(Path("/tmp/crash.log"), RuntimeError("boom"), saved=False)
+
+    assert f"[link={ISSUE_URL}]{ISSUE_URL}[/link]" in _as_markup(message)
+
+    rendered = render_panel(message)
+    assert "\x1b]8;" in rendered  # the escape a terminal makes clickable
+    assert ISSUE_URL in rendered  # and the URL still readable where it isn't
+
+
+def test_an_exception_whose_text_looks_like_markup_survives() -> None:
+    """The message quotes a driver, and a driver may put brackets in one."""
+    message = crash_message(
+        None, RuntimeError("no column [amount] in orders"), saved=False
+    )
+
+    assert "[amount]" in render_panel(message)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -65,6 +65,8 @@ def mock_sqlite_adapter(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 @pytest.fixture()
 def mock_harlequin(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     mock = MagicMock(spec=Harlequin)
+    # the command exits with it, and a MagicMock is not an exit code
+    mock.return_value.return_code = 0
     monkeypatch.setattr("harlequin.cli.Harlequin", mock)
     return mock
 
@@ -131,6 +133,7 @@ def test_default(
     mock_harlequin.assert_called_once_with(
         adapter=mock_adapter.return_value,
         profile_name=None,
+        adapter_name="duckdb",
         connection_hash=mock_adapter.return_value.connection_id,
         viewer_max_rows=DEFAULT_VIEWER_MAX_ROWS,
         query_limit=None,

--- a/tests/unit_tests/test_crash.py
+++ b/tests/unit_tests/test_crash.py
@@ -144,14 +144,19 @@ def test_write_crash_report_returns_none_when_it_cannot_write(
 
 
 def test_the_message_says_what_to_do_next(tmp_path: Path) -> None:
+    report_path = tmp_path / "crash.log"
     error = raise_and_catch(ValueError("boom"))
 
-    message = crash_message(tmp_path / "crash.log", error, saved=True)
+    message = crash_message(report_path, error, saved=True)
 
     assert "ValueError: boom" in message
-    assert str(tmp_path / "crash.log") in message
-    assert ISSUE_URL in message
-    assert "saved" in message
+    assert "Your buffers have been saved" in message
+    assert "Please report this crash to help improve Harlequin." in message
+    # the ask comes before the file it needs
+    assert message.index(ISSUE_URL) < message.index(str(report_path))
+    # and nothing tells the user to review either one; the report says that
+    # itself, where they can act on it
+    assert "review" not in message.lower()
 
 
 def test_the_message_claims_no_save_that_did_not_happen() -> None:
@@ -161,3 +166,12 @@ def test_the_message_claims_no_save_that_did_not_happen() -> None:
 
     assert "saved" not in message
     assert ISSUE_URL in message
+
+
+def test_the_report_asks_the_user_to_redact_it() -> None:
+    """The masking reaches registered secrets and DSNs. The rest is theirs."""
+    error = raise_and_catch(ValueError("boom"))
+
+    report = build_crash_report(error, {ACTIVE_BUFFER: "select 1"})
+
+    assert "Review and redact as necessary" in report.splitlines()[2]

--- a/tests/unit_tests/test_crash.py
+++ b/tests/unit_tests/test_crash.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from harlequin.crash import (
+    ACTIVE_BUFFER,
+    CRASH_REPORT_KEEP,
+    ISSUE_URL,
+    build_crash_report,
+    crash_message,
+    root_cause,
+    write_crash_report,
+)
+from harlequin.redact import REDACTED, hide_secrets_in
+
+
+def raise_and_catch(error: BaseException) -> BaseException:
+    """An exception with a real traceback on it, as a handler would receive."""
+    try:
+        raise error
+    except BaseException as caught:
+        return caught
+
+
+def test_the_report_names_what_a_maintainer_needs() -> None:
+    error = raise_and_catch(ValueError("no such column: foo"))
+
+    report = build_crash_report(error, {"adapter": "duckdb"})
+
+    assert "ValueError" in report
+    assert "no such column: foo" in report
+    assert "adapter: duckdb" in report
+    assert "raise error" in report  # the frames
+    assert "version" in report
+    assert ISSUE_URL in report
+
+
+def test_the_report_prints_no_local_variables() -> None:
+    """Textual's own handler renders with show_locals=True. That is what this
+    replaces."""
+
+    def frame_with_a_secret_local() -> None:
+        connection_string = "postgres://u:hunter2-and-more@host/db"  # noqa: F841
+        raise ValueError("boom")
+
+    try:
+        frame_with_a_secret_local()
+    except ValueError as e:
+        report = build_crash_report(e, {})
+
+    assert "hunter2-and-more" not in report
+    assert "connection_string" not in report
+
+
+def test_the_report_prints_no_registered_secret() -> None:
+    hide_secrets_in({"conn_str": ["postgres://u:hunter2-and-more@host/db"]})
+    error = raise_and_catch(
+        ValueError("could not connect to postgres://u:hunter2-and-more@host/db")
+    )
+
+    report = build_crash_report(error, {})
+
+    assert "hunter2-and-more" not in report
+    assert REDACTED in report
+
+
+def test_the_report_pastes_into_a_fenced_block() -> None:
+    """A report that carried its own fences would break out of the issue's."""
+    error = raise_and_catch(ValueError("boom"))
+
+    report = build_crash_report(error, {ACTIVE_BUFFER: "select 1"})
+
+    assert "```" not in report
+
+
+def test_the_report_ends_with_the_active_buffer() -> None:
+    """Under a heading that says what it is: the user decides whether to paste it."""
+    error = raise_and_catch(ValueError("boom"))
+
+    report = build_crash_report(error, {"adapter": "duckdb", ACTIVE_BUFFER: "select 1"})
+
+    assert report.index("SQL IN THE ACTIVE BUFFER") > report.index("TRACEBACK")
+    assert report.rstrip().endswith("select 1")
+    # and not a second time, among the facts
+    assert report.count("select 1") == 1
+
+
+def test_root_cause_unwraps_a_worker_failure() -> None:
+    """Two `@work` decorators reach the handler wrapped. A report naming
+    `WorkerFailed` is a useless report."""
+
+    class WorkerFailed(Exception):
+        def __init__(self, error: BaseException) -> None:
+            super().__init__("Worker raised exception")
+            self.error = error
+
+    cause = ValueError("the real problem")
+
+    assert root_cause(WorkerFailed(cause)) is cause
+    assert root_cause(cause) is cause
+
+
+def test_the_report_names_both_halves_of_a_wrapped_error() -> None:
+    class WorkerFailed(Exception):
+        def __init__(self, error: BaseException) -> None:
+            super().__init__("Worker raised exception")
+            self.error = error
+
+    error = raise_and_catch(WorkerFailed(raise_and_catch(ValueError("boom"))))
+
+    report = build_crash_report(error, {})
+
+    assert report.index("boom") < report.index("RAISED AS")
+    assert "WorkerFailed" in report
+
+
+def test_write_crash_report_keeps_the_newest(
+    crash_reports_go_to_tmp: Path,
+) -> None:
+    crash_reports_go_to_tmp.mkdir(parents=True, exist_ok=True)
+    for n in range(CRASH_REPORT_KEEP + 5):
+        (crash_reports_go_to_tmp / f"crash-2020010{n:02d}T000000Z-1.log").touch()
+
+    path = write_crash_report("a report")
+
+    assert path is not None
+    assert path.read_text() == "a report"
+    assert len(list(crash_reports_go_to_tmp.glob("crash-*.log"))) == CRASH_REPORT_KEEP
+    # a crash loop cannot destroy the evidence of the crash that started it
+    assert path.exists()
+
+
+def test_write_crash_report_returns_none_when_it_cannot_write(
+    monkeypatch: pytest.MonkeyPatch, crash_reports_go_to_tmp: Path
+) -> None:
+    def _deny(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("nope")
+
+    monkeypatch.setattr(Path, "mkdir", _deny)
+
+    assert write_crash_report("a report") is None
+
+
+def test_the_message_says_what_to_do_next(tmp_path: Path) -> None:
+    error = raise_and_catch(ValueError("boom"))
+
+    message = crash_message(tmp_path / "crash.log", error, saved=True)
+
+    assert "ValueError: boom" in message
+    assert str(tmp_path / "crash.log") in message
+    assert ISSUE_URL in message
+    assert "saved" in message
+
+
+def test_the_message_claims_no_save_that_did_not_happen() -> None:
+    error = raise_and_catch(ValueError("boom"))
+
+    message = crash_message(None, error, saved=False)
+
+    assert "saved" not in message
+    assert ISSUE_URL in message

--- a/tests/unit_tests/test_editor_cache.py
+++ b/tests/unit_tests/test_editor_cache.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
+import os
 import pickle
+import time
 from pathlib import Path
 
 import pytest
 from textual.widgets.text_area import Selection
 
 from harlequin.editor_cache import (
+    RECOVERY_STALE_SECONDS,
     BufferState,
     Cache,
+    adopt_recovery,
+    clear_recovery,
     get_cache_file,
+    get_recovery_file,
     load_cache,
     write_cache,
+    write_recovery,
 )
 
 
@@ -74,3 +81,125 @@ def test_write_cache_returns_false_when_the_cache_dir_is_unwritable(
     mock_user_cache_dir.parent.mkdir(parents=True, exist_ok=True)
     mock_user_cache_dir.write_text("not a directory")
     assert write_cache(cache) is False
+
+
+def test_write_recovery_does_not_touch_the_shared_cache(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    assert write_cache(cache) is True
+    before = get_cache_file().read_bytes()
+
+    assert write_recovery(Cache(focus_index=0, buffers=[])) is True
+
+    assert get_recovery_file().exists()
+    assert get_recovery_file() != get_cache_file()
+    assert get_cache_file().read_bytes() == before
+
+    clear_recovery()
+    assert not get_recovery_file().exists()
+    assert get_cache_file().read_bytes() == before
+
+
+def test_clear_recovery_when_there_is_nothing_to_clear(
+    mock_user_cache_dir: Path,
+) -> None:
+    clear_recovery()
+
+
+def test_adopt_recovery_finds_nothing(mock_user_cache_dir: Path, cache: Cache) -> None:
+    assert write_cache(cache) is True
+    assert adopt_recovery() == (None, None)
+
+
+def test_adopt_recovery_replays_a_crash_handlers_file(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    planted = _plant(mock_user_cache_dir, "recovered-20260904T120000Z-99.pickle", cache)
+
+    recovered, replayed = adopt_recovery()
+
+    assert recovered == cache
+    assert replayed == planted.with_suffix(".replayed")
+    assert not planted.exists()
+
+
+def test_adopt_recovery_replays_each_file_once(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    """The crash-loop guard: a file is renamed before it is unpickled."""
+    _plant(mock_user_cache_dir, "recovered-20260904T120000Z-99.pickle", cache)
+
+    assert adopt_recovery()[0] == cache
+    assert adopt_recovery() == (None, None)
+
+
+def test_adopt_recovery_consumes_a_file_it_cannot_unpickle(
+    mock_user_cache_dir: Path,
+) -> None:
+    """A file that poisons the replay is spent by the attempt, not left to repeat."""
+    planted = mock_user_cache_dir / "recovered-20260904T120000Z-99.pickle"
+    planted.parent.mkdir(parents=True, exist_ok=True)
+    planted.write_bytes(b"not a pickle")
+
+    assert adopt_recovery() == (None, None)
+
+    assert not planted.exists()
+    assert planted.with_suffix(".replayed").exists()
+
+
+def test_adopt_recovery_leaves_a_live_sessions_file_alone(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    _plant(mock_user_cache_dir, "recovery-99.pickle", cache)
+
+    assert adopt_recovery() == (None, None)
+
+    assert (mock_user_cache_dir / "recovery-99.pickle").exists()
+
+
+def test_adopt_recovery_takes_over_a_stale_file(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    planted = _plant(
+        mock_user_cache_dir,
+        "recovery-99.pickle",
+        cache,
+        age_seconds=RECOVERY_STALE_SECONDS + 1,
+    )
+
+    recovered, replayed = adopt_recovery()
+
+    assert recovered == cache
+    assert replayed == planted.with_suffix(".replayed")
+
+
+def test_adopt_recovery_prefers_the_newest_crash(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    newest = Cache(focus_index=0, buffers=[BufferState(Selection(), "select 2\n")])
+    _plant(
+        mock_user_cache_dir,
+        "recovered-20260904T120000Z-98.pickle",
+        cache,
+        age_seconds=60,
+    )
+    _plant(mock_user_cache_dir, "recovered-20260904T130000Z-99.pickle", newest)
+    _plant(
+        mock_user_cache_dir,
+        "recovery-97.pickle",
+        cache,
+        age_seconds=RECOVERY_STALE_SECONDS + 1,
+    )
+
+    assert adopt_recovery()[0] == newest
+
+
+def _plant(cache_dir: Path, name: str, cache: Cache, age_seconds: float = 0.0) -> Path:
+    """Write a recovery file as another process would have left it."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / name
+    path.write_bytes(pickle.dumps(cache))
+    if age_seconds:
+        mtime = time.time() - age_seconds
+        os.utime(path, (mtime, mtime))
+    return path

--- a/tests/unit_tests/test_editor_cache.py
+++ b/tests/unit_tests/test_editor_cache.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+from textual.widgets.text_area import Selection
+
+from harlequin.editor_cache import (
+    BufferState,
+    Cache,
+    get_cache_file,
+    load_cache,
+    write_cache,
+)
+
+
+@pytest.fixture
+def cache() -> Cache:
+    return Cache(
+        focus_index=0,
+        buffers=[BufferState(selection=Selection((0, 3), (0, 3)), text="select 1\n")],
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_user_cache_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("harlequin.editor_cache.user_cache_dir", lambda **_: cache_dir)
+    return cache_dir
+
+
+@pytest.fixture
+def failing_dump(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _dump(*_args: object, **_kwargs: object) -> None:
+        raise pickle.PicklingError("no")
+
+    monkeypatch.setattr("harlequin.editor_cache.pickle.dump", _dump)
+
+
+def test_write_cache_round_trips(mock_user_cache_dir: Path, cache: Cache) -> None:
+    assert write_cache(cache) is True
+    assert load_cache() == cache
+
+
+def test_write_cache_leaves_no_temp_file(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    assert write_cache(cache) is True
+    assert [path.name for path in mock_user_cache_dir.iterdir()] == [
+        get_cache_file().name
+    ]
+
+
+@pytest.mark.usefixtures("failing_dump")
+def test_a_failed_write_leaves_the_last_cache_alone(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    """The point of the temp file: a write that dies cannot destroy what is there."""
+    good_cache = get_cache_file()
+    good_cache.parent.mkdir(parents=True, exist_ok=True)
+    good_cache.write_bytes(pickle.dumps(cache))
+    before = good_cache.read_bytes()
+
+    assert write_cache(Cache(focus_index=0, buffers=[])) is False
+
+    assert good_cache.read_bytes() == before
+    assert [path.name for path in mock_user_cache_dir.iterdir()] == [good_cache.name]
+
+
+def test_write_cache_returns_false_when_the_cache_dir_is_unwritable(
+    mock_user_cache_dir: Path, cache: Cache
+) -> None:
+    mock_user_cache_dir.parent.mkdir(parents=True, exist_ok=True)
+    mock_user_cache_dir.write_text("not a directory")
+    assert write_cache(cache) is False

--- a/tests/unit_tests/test_environment.py
+++ b/tests/unit_tests/test_environment.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from harlequin.environment import (
+    UNKNOWN,
+    adapter_facts,
+    install_facts,
+    runtime_report,
+    terminal_facts,
+)
+
+
+def test_runtime_report_is_json_serializable() -> None:
+    """A crash report and `--info` both render it as JSON."""
+    report = runtime_report()
+    assert json.loads(json.dumps(report)) == report
+    assert set(report) == {"version", "python", "platform", "terminal", "install"}
+    assert report["python"]["executable"] == sys.executable
+
+
+def test_runtime_report_imports_no_adapter() -> None:
+    """It runs inside a crash handler, where importing the world is a fresh crash."""
+    loaded_before = set(sys.modules)
+    runtime_report()
+    assert not {name for name in set(sys.modules) - loaded_before if "adapter" in name}
+
+
+def test_terminal_facts_report_that_a_session_is_remote_and_nothing_more(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whether the session is remote explains a bug; where it came from does not."""
+    monkeypatch.setenv("SSH_CONNECTION", "10.1.2.3 55555 10.1.2.4 22")
+
+    facts = terminal_facts()
+
+    assert facts["ssh"] is True
+    assert "10.1.2.3" not in json.dumps(facts)
+
+
+def test_terminal_facts_when_the_environment_says_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "TERM",
+        "TERM_PROGRAM",
+        "TERM_PROGRAM_VERSION",
+        "COLORTERM",
+        "SHELL",
+        "COMSPEC",
+        "WSL_DISTRO_NAME",
+        "SSH_CONNECTION",
+        "SSH_TTY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    facts = terminal_facts()
+
+    assert facts["term"] is None
+    assert facts["ssh"] is False
+    assert "x" in facts["size"]
+
+
+def test_install_facts_answer_the_bug_templates_checkbox() -> None:
+    facts = install_facts()
+    assert facts["installer"] in (None, "pip", "uv", "pipx", "hatch")
+    assert isinstance(facts["in_venv"], bool)
+
+
+def test_adapter_facts_report_what_an_adapter_declares() -> None:
+    facts = adapter_facts("duckdb")
+
+    assert list(facts) == ["duckdb"]
+    assert facts["duckdb"]["error"] is None
+    assert facts["duckdb"]["capabilities"]["implements_cancel"] is True
+
+
+def test_adapter_facts_never_guess_false_about_an_adapter_that_will_not_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from harlequin.exception import HarlequinConfigError
+
+    def _raise(name: str) -> None:
+        raise HarlequinConfigError("boom")
+
+    monkeypatch.setattr("harlequin.plugins.load_adapter", _raise)
+
+    facts = adapter_facts("duckdb")
+
+    assert facts["duckdb"]["capabilities"] == UNKNOWN
+    assert facts["duckdb"]["error"] == "boom"

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -4449,3 +4449,24 @@ def test_an_interrupt_is_not_a_crash(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("harlequin.hsql.cli.build_cli", _interrupt)
 
     assert run_main(monkeypatch, "-c", "select 1") == ExitCode.INTERRUPT
+
+
+def test_a_bug_in_the_session_client_is_a_crash_too(
+    monkeypatch: pytest.MonkeyPatch,
+    crash_reports_go_to_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The warm path is hsql's too, so a bug in it exits 70 rather than 1."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("a bug in the client")
+
+    monkeypatch.setattr("harlequin.hsql.session.requested_session", _boom)
+
+    assert (
+        run_main(monkeypatch, "--session", "warm", "-c", "select 1") == ExitCode.CRASH
+    )
+
+    (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
+    assert "a bug in the client" in report.read_text()
+    assert "hsql hit a bug in itself" in capsys.readouterr().err

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -4362,3 +4362,86 @@ def test_a_real_duckdb_query_times_out_and_says_so(tmp_path: Path) -> None:
     # the empty result set a cancelled DuckDB cursor returns, not printed
     assert proc.stdout == ""
     assert "timed out after 1s" in proc.stderr
+
+
+# --- a bug in hsql itself ----------------------------------------------------
+
+
+def run_main(monkeypatch: pytest.MonkeyPatch, *argv: str) -> int:
+    """Call the console script's entry point, which is where crashes are caught."""
+    from harlequin.hsql import main
+
+    monkeypatch.setattr(sys, "argv", ["hsql", *argv])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    return cast(int, exit_info.value.code)
+
+
+@pytest.fixture
+def hsql_crashes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bug in hsql, before anything it runs has had a chance to catch it."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("a bug in hsql")
+
+    monkeypatch.setattr("harlequin.hsql.cli.build_cli", _boom)
+
+
+def test_a_bug_in_hsql_is_not_reported_as_a_failed_query(
+    monkeypatch: pytest.MonkeyPatch,
+    hsql_crashes: None,
+    crash_reports_go_to_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """1 is what a database rejecting the SQL means. A caller scripting against
+    these could not otherwise tell the two apart."""
+    code = run_main(monkeypatch, "-c", "select 1")
+
+    assert code == ExitCode.CRASH
+    assert code != ExitCode.QUERY
+
+    (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
+    assert "a bug in hsql" in report.read_text()
+
+    stderr = capsys.readouterr().err
+    assert "hsql hit a bug in itself" in stderr
+    assert str(report) in stderr
+
+
+def test_a_crash_report_masks_a_dsn_typed_on_the_command_line(
+    monkeypatch: pytest.MonkeyPatch,
+    hsql_crashes: None,
+    crash_reports_go_to_tmp: Path,
+) -> None:
+    """A crash during parsing happens before `hide_secrets_in()` runs, so the
+    span-masking is the only thing that catches it."""
+    run_main(monkeypatch, "postgres://tco:hunter2-and-more@warehouse:5432/analytics")
+
+    (report,) = list(crash_reports_go_to_tmp.glob("crash-*.log"))
+    text = report.read_text()
+    assert "hunter2-and-more" not in text
+    # and the rest of the DSN survives, which is what makes the argv worth having
+    assert "warehouse:5432/analytics" in text
+
+
+def test_a_crash_report_that_cannot_be_written_still_exits_70(
+    monkeypatch: pytest.MonkeyPatch,
+    hsql_crashes: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise OSError("the log dir is gone")
+
+    monkeypatch.setattr("harlequin.crash.write_crash_report", _raise)
+
+    assert run_main(monkeypatch, "-c", "select 1") == ExitCode.CRASH
+    assert "hsql hit a bug in itself" in capsys.readouterr().err
+
+
+def test_an_interrupt_is_not_a_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _interrupt(*_args: object, **_kwargs: object) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("harlequin.hsql.cli.build_cli", _interrupt)
+
+    assert run_main(monkeypatch, "-c", "select 1") == ExitCode.INTERRUPT

--- a/tests/unit_tests/test_hsql.py
+++ b/tests/unit_tests/test_hsql.py
@@ -20,6 +20,7 @@ import click
 import pytest
 from click.testing import CliRunner, Result
 
+from harlequin.crash import ISSUE_URL
 from harlequin.exception import (
     HarlequinConfigError,
     HarlequinConnectionError,
@@ -4405,7 +4406,10 @@ def test_a_bug_in_hsql_is_not_reported_as_a_failed_query(
 
     stderr = capsys.readouterr().err
     assert "hsql hit a bug in itself" in stderr
-    assert str(report) in stderr
+    assert "please report this crash to help improve Harlequin" in stderr
+    # the ask comes before the file it needs, and neither is called a review
+    assert stderr.index(ISSUE_URL) < stderr.index(str(report))
+    assert "review" not in stderr.lower()
 
 
 def test_a_crash_report_masks_a_dsn_typed_on_the_command_line(

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -23,6 +23,7 @@ HEADLESS_IMPORTS = [
     "import harlequin.autocomplete",
     "import harlequin.catalog",
     "import harlequin.config",
+    "import harlequin.crash",
     "import harlequin.environment",
     "import harlequin.exception",
     "import harlequin.export",

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -23,6 +23,7 @@ HEADLESS_IMPORTS = [
     "import harlequin.autocomplete",
     "import harlequin.catalog",
     "import harlequin.config",
+    "import harlequin.environment",
     "import harlequin.exception",
     "import harlequin.export",
     "import harlequin.hsql",

--- a/tests/unit_tests/test_ssh.py
+++ b/tests/unit_tests/test_ssh.py
@@ -872,6 +872,8 @@ def test_the_ide_opens_the_tunnel_before_it_starts(
     ssh_on_path: Path, no_discovered_config: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     app = MagicMock()
+    # the command exits with it, and a MagicMock is not an exit code
+    app.return_value.return_code = 0
     monkeypatch.setattr("harlequin.cli.Harlequin", app)
     port = free_port()
     result = run_harlequin(
@@ -897,6 +899,8 @@ def test_two_bastions_do_not_share_a_catalog_cache(
 ) -> None:
     """Both look like `localhost:15439`, and the details cannot tell them apart."""
     app = MagicMock()
+    # the command exits with it, and a MagicMock is not an exit code
+    app.return_value.return_code = 0
     monkeypatch.setattr("harlequin.cli.Harlequin", app)
     forward = f"{free_port()}:data.example.com:5439"
     hashes = []


### PR DESCRIPTION
Closes #687

**What** are the key elements of this solution?

Implements `docs/plans/crash-recovery-design.md`, as its seven ordered commits. Each is independently green under `make check`.

1. **`write_cache` is atomic and never raises.** Both writers go through `_write_pickle()`: a pid-named temp file in the same directory, `fsync`, then `os.replace`. It returns a bool, because the two new callers write from places where an exception would itself take the app down.
2. **A per-process recovery file, and rename-before-replay.** Checkpoints go to `recovery-<pid>.pickle`, never to `cache-1.pickle`, so two Harlequins keep today's "last clean quit wins" semantics. `adopt_recovery()` renames the file it picks to `.replayed` *before* unpickling it — that one line is the whole crash-loop guard. It adopts a crash handler's `recovered-*` always, and a `recovery-*` only once its mtime has gone stale, which is how a live sibling keeps its own.
3. **A 60s checkpoint timer**, so a `kill -9`, a closed terminal or a dropped ssh session no longer loses every open buffer. Skipped when the content hasn't changed, and skipped when every buffer is blank.
4. **`environment.py`**, the facts a diagnostic reports, shared by `hsql --info` and the crash report. `--info`'s document is byte-identical; `terminal_facts()` and `install_facts()` are new and outside it.
5. **The handler.** `AppBase._handle_exception` saves the user's work, writes a crash report, and prints the same panel every other Harlequin error uses. `cli.py` forwards the app's return code.
6. **`hsql` exits 70** (`sysexits.h`'s `EX_SOFTWARE`) and writes a report, instead of letting Python print a traceback and exit 1 — which is the code for SQL the database rejected.
7. **`.github/ISSUE_TEMPLATE/crash_report.md`**, which the message and `crash.ISSUE_URL` point at.

Beyond the design: the exit code is also added to hsql's generated CLI reference and to the skill's exit-code list and troubleshooting reference, which are agent-facing contracts that would otherwise be wrong.

### What a user sees

A real crash, provoked by raising `KeyError("column_index")` from a key handler with a `warehouse` profile whose password is `hunter2-and-more`:

```
╭─ Harlequin crashed. ─────────────────────────────────────────────────────────────────────────────╮
│ KeyError: 'column_index'                                                                         │
│                                                                                                  │
│ Your buffers have been saved, and Harlequin will offer them back the next time you start it.     │
│                                                                                                  │
│ Please report this crash to help improve Harlequin.                                              │
│ https://github.com/tconbeer/harlequin/issues/new?template=crash_report.md                        │
│                                                                                                  │
│ The file you will need for the crash report is at:                                               │
│ /home/tco/.local/state/harlequin/log/crash-20260904T123337Z-1746.log                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

The URL is an OSC-8 hyperlink, so it is clickable in a terminal that supports one and still readable as a URL in one that doesn't. The rest of the message is escaped before rendering, so a driver that puts `[brackets]` in an exception doesn't lose them to rich's markup parser. `echo $?` is `1`.

And the report at that path, in full — this is what pastes into the template's fenced block:

```
harlequin crash report, written 2026-09-04 12:33:53Z.

Review and redact as necessary before sharing this file: it holds your
configuration, with passwords masked, and the SQL that was in your
active buffer.
Report this at https://github.com/tconbeer/harlequin/issues/new?template=crash_report.md


========================================================================
=== ENVIRONMENT ===
========================================================================

version: 2.13.0
python:
  version: 3.10.15
  implementation: CPython
  executable: /home/tco/.local/share/uv/tools/harlequin/bin/python3
platform:
  system: Linux
  release: 6.18.44
  machine: x86_64
terminal:
  term: xterm-256color
  term_program: WezTerm
  term_program_version: 20240203-110809
  colorterm: truecolor
  shell: /bin/bash
  wsl_distro: None
  ssh: False
  locale: en_US.UTF-8
  size: 120x36
install:
  installer: uv
  in_venv: True


========================================================================
=== CONTEXT ===
========================================================================

adapter: duckdb
adapter_class: DuckDbAdapter
adapter_module: harlequin_duckdb.adapter
adapter_distribution: harlequin 2.13.0
profile: warehouse
keymaps: vscode
theme: harlequin
connected: True
buffers: 1
size: Size(width=120, height=36)
recovery_file: /home/tco/.cache/harlequin/recovered-20260904T123337Z-1746.pickle


========================================================================
=== TRACEBACK ===
========================================================================

Traceback (most recent call last):
  File "/home/tco/.local/share/uv/tools/harlequin/lib/python3.10/site-packages/harlequin/app.py", line 19, in go
    raise KeyError("column_index")
KeyError: 'column_index'


========================================================================
=== SQL IN THE ACTIVE BUFFER ===
========================================================================

select customer_id, sum(amount)
from orders
group by 1
```

Nothing in it names `hunter2-and-more`, and there are no locals. (The paths and terminal above are edited to read like a user's machine; everything else is verbatim from a real run in CI's container.)

hsql's is the same file under a different program name, and its stderr is three plain lines rather than a panel — `hsql` writes no box drawing, and no escape sequences either, so no link markup there:

```
hsql: error: hsql hit a bug in itself and could not finish the run.
note: please report this crash to help improve Harlequin: https://github.com/tconbeer/harlequin/issues/new?template=crash_report.md
note: the file you will need for the crash report is at /home/tco/.local/state/harlequin/log/crash-20260904T123400Z-1815.log
```

`echo $?` is `70`. Its report has no buffer section (hsql has no buffers) and a `CONTEXT` of the argv, adapter and profile, with a DSN typed on the command line masked in place:

```
argv: postgres://tco:********@warehouse:5432/analytics -c select 1
adapter: None
profile: None
```

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The design doc has the full reasoning. The three decisions worth repeating here:

- **A per-process recovery file rather than checkpointing into the shared cache.** A shared file would be thrashed every minute by every running Harlequin, and a checkpoint could overwrite what another process wrote when it quit cleanly. The separate file also means the last clean-quit state stays on disk: if the recovered buffers are themselves what crashed, `cache-1.pickle` is untouched.
- **Rename before replay, rather than a session sentinel or a PID-liveness check.** #745 crashed *inside* `EditorCollection.on_mount` while replaying cached buffers, so saving buffers on crash without a guard would turn a one-time crash into a crash loop — worse than what we have now. Renaming first is one line, needs no state, and is correct across concurrent processes by construction. Staleness by mtime does the same job for the liveness question, which a PID check would get wrong on Windows and under PID reuse.
- **The message is a `panic()` panel on stderr, not a modal.** `panic()` calls `_close_messages_no_wait()`, so the pump is gone by the time we handle the exception; an in-app modal is unreachable, and attempting one re-enters an app that has already proven it is broken.

Tradeoffs, all deliberate and covered in the doc's "Known risks":

- **The active buffer's SQL is in the report.** It is usually what is needed to reproduce a TUI bug, and the file is local — but SQL holds table names and literals, so it goes last, under an explicit heading, and the report's own header asks the reporter to review and redact as necessary. The whole report goes through `redact.redact_text()` once at the end, and there is no `show_locals`.
- **Both commands now exit non-zero where they exited 0.** `harlequin` returns 1 on a crash and 2 on a config or connection error (which previously exited 0 — a live bug this closes); `hsql` returns 70 where Python let it exit 1. User-visible, so both have a changelog line.
- **Partial-replay convergence.** A crash partway through replaying recovered buffers can write a `recovered-*` file holding the subset that loaded. It converges and salvages what it can, but may take more than one restart.

This leans on five Textual internals (`textual==8.2.8`, pinned exactly). Each use site has a comment naming what it is for, and each has a test that fails loudly rather than silently reverting us to raw tracebacks — in particular the crash tests are written as `with pytest.raises(RuntimeError)`, because `run_test` re-raises from `_exception`/`_exception_event` and a handler that did not set them would turn every crashing functional test silently green.

Two places where the implementation departs from the doc, both in the tests:

- The doc's functional test asserts on `_exit_renderables[0]`, but `_print_error_renderables()` clears that list, so there is nothing to index by the time the test body resumes. The assertions are on captured stderr instead, which is what the user actually sees.
- Injecting through `_handle_exception` has to happen from inside an `except` block: Textual's own renderer reads `sys.exc_info()`, so an exception injected from outside one exercises a path no real crash takes.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the troubleshooting page should say that a crash writes a report, where the reports live per-OS, and to file it against the new Crash Report template; and `harlequin`'s and `hsql`'s exit codes are now documented as non-zero on failure (`harlequin`: 1 on a crash, 2 on a config or connection error; `hsql`: a new `70`).

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

New: `tests/unit_tests/test_editor_cache.py`, `test_environment.py`, `test_crash.py`, and `tests/functional_tests/test_crash.py`; plus recovery and checkpoint cases in `test_cache.py` and the hsql boundary cases in `test_hsql.py`.

Two pieces of test infrastructure worth calling out, because without them the suite would write into the developer's own directories: an autouse, session-wide `crash_reports_go_to_tmp` fixture (every failing functional test goes through `run_test`'s re-raise path, and so through `_handle_exception`), and `no_use_buffer_cache` extended to patch the new seams. `test_cli.py`'s and `test_ssh.py`'s `MagicMock(spec=Harlequin)` now set `return_code = 0`, since the command exits with it and a MagicMock is not an exit code.

Verified with `make check` — ruff, mypy (140 files), the full 3.10 suite (1548 passed, 7 skipped, 148 snapshots) and the 3.12 `py12` run — plus `lint-imports` (4/4 contracts kept, with `harlequin.crash` and `harlequin.environment` added to the headless contract and to `HEADLESS_IMPORTS`). Also ran the design's by-hand checks, which is where the examples above come from: an injected IDE crash writes `recovered-*.pickle` and a crash log, whose buffer the next start restores, leaving the file `.replayed`.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131Sdv9zwvjBkuqWxE1bqHG