### PR TITLE
Warm sessions 2/6: the server, the flag partition, and byte-equivalence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- hsql can now hold a database connection open between invocations: `hsql --serve NAME [CONN_STR] [connection options]` starts a session in the foreground, and `hsql --session NAME -c ...` (or `HSQL_SESSION=NAME`) sends queries to it, paying neither the start-up nor the connection cost again. A session keeps its temp tables, settings and open transactions between invocations; `hsql --session NAME --session-reset` reconnects it. Not available on native Windows.
+- `hsql --serve NAME [CONN_STR]` holds a database connection open as a named session, and `hsql --session NAME -c ...` (or `HSQL_SESSION=NAME`) sends queries to it without paying start-up or connection cost again. Temp tables, settings and open transactions persist between invocations; `--session-reset` reconnects. POSIX only.
 - Press `alt+e` in the Query Editor to edit the current buffer in the editor named by `$VISUAL` or `$EDITOR`; quitting the editor with a non-zero status (like `:cq`) discards the changes ([#1102](https://github.com/tconbeer/harlequin/issues/1102)).
 - Harlequin now saves your open buffers every minute, and offers them back the next time you start if it exited without a clean quit ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - When Harlequin hits a bug in itself, it now exits with a short message instead of a traceback, saves your buffers, and writes a crash report you can attach to an issue ([#687](https://github.com/tconbeer/harlequin/issues/687)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- hsql can now hold a database connection open between invocations: `hsql --serve NAME [CONN_STR] [connection options]` starts a session in the foreground, and `hsql --session NAME -c ...` (or `HSQL_SESSION=NAME`) sends queries to it, paying neither the start-up nor the connection cost again. A session keeps its temp tables, settings and open transactions between invocations; `hsql --session NAME --session-reset` reconnects it. Not available on native Windows.
 - Press `alt+e` in the Query Editor to edit the current buffer in the editor named by `$VISUAL` or `$EDITOR`; quitting the editor with a non-zero status (like `:cq`) discards the changes ([#1102](https://github.com/tconbeer/harlequin/issues/1102)).
 - Harlequin now saves your open buffers every minute, and offers them back the next time you start if it exited without a clean quit ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - When Harlequin hits a bug in itself, it now exits with a short message instead of a traceback, saves your buffers, and writes a crash report you can attach to an issue ([#687](https://github.com/tconbeer/harlequin/issues/687)).

--- a/docs/generated/hsql-reference.md
+++ b/docs/generated/hsql-reference.md
@@ -53,8 +53,12 @@ Alphabetical by name. Flags are off by default.
 | `-o`, `--output` | text | `PATH` |  |  | Write results to PATH instead of stdout. Accepts a file or directory. |
 | `--path` | text | `TEXT` |  |  | Where in the catalog --catalog looks, and what --catalog-search searches under. Dotted segments, named by the adapter; the top of the catalog by default. A trailing * filters a --catalog listing. |
 | `-P`, `--profile` | text |  |  |  | Load a profile from an available config file. Options passed here take precedence over the profile's. Use the profile named None for Harlequin's defaults instead of the config file's default profile. |
+| `--queue-timeout` | number | `SECONDS` |  |  | With --serve: a request waits at most SECONDS for the one before it, then exits 4 without reaching the database. [default: no limit] |
 | `-r`, `--read-only` | boolean |  |  |  | Connect read-only, and refuse to run at all if the adapter cannot. To check an adapter's capabilities, use --info. |
 | `--result` | text | `all\|last\|N` | `all` |  | Which result set(s) to emit. |
+| `--serve` | text | `NAME` |  |  | Connect, then hold the connection open as the session named NAME and answer `--session NAME` invocations from it until stopped. Takes connection options only. Not on native Windows. |
+| `--session` | text | `NAME` |  |  | Send this invocation to the running session named NAME, started with --serve. HSQL_SESSION=NAME does the same for every invocation, and runs without the session, with a warning, when none is up. |
+| `--session-reset` | boolean |  |  |  | Ask the session to close its connection and open a fresh one, and exit without running SQL. Temp tables, settings and an open transaction are gone. Needs --session. |
 | `--skill` | boolean |  |  |  | Write the Agent Skill for driving hsql, as markdown. -o installs it: 'hsql --skill -o ~/.claude/skills/hsql/'. |
 | `--spec` | boolean |  |  |  | Every option here, plus every installed adapter's, as JSON. -a narrows it to one adapter. |
 | `--ssh-allow-reuse` | boolean |  |  |  | When the local port is already bound, warn and connect through the listener that has it instead of failing. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,11 @@ markers = [
     "online: requeries internet connection (deselect with '-m \"not online\"')",
     "use_cache: override the autouse fixture the disables the buffer cache",
     "py12: Only run on Python 3.12 or higher",
+    # a test whose invocations are *meant* to see different bytes warm than
+    # cold -- because the session kept state between them -- and which asserts
+    # what the warm behavior is. The set carrying it is the enumerated version
+    # of docs/plans/hsql-warm-sessions-design.md's section 5.
+    "session_divergent: asserts behavior a warm session has and a cold run has not",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,11 +243,7 @@ markers = [
     "online: requeries internet connection (deselect with '-m \"not online\"')",
     "use_cache: override the autouse fixture the disables the buffer cache",
     "py12: Only run on Python 3.12 or higher",
-    # a test whose invocations are *meant* to see different bytes warm than
-    # cold -- because the session kept state between them -- and which asserts
-    # what the warm behavior is. The set carrying it is the enumerated version
-    # of docs/plans/hsql-warm-sessions-design.md's section 5.
-    "session_divergent: asserts behavior a warm session has and a cold run has not",
+    "session_divergent: asserts state a warm session keeps between invocations that a cold run does not",
 ]
 
 

--- a/src/harlequin/config.py
+++ b/src/harlequin/config.py
@@ -126,6 +126,16 @@ someone else's listener, and a default that fails closed has to stay the
 caller's to turn off.
 """
 
+CLI_ONLY_SESSION_KEYS = ("session", "serve")
+"""The keys that say which process runs an invocation, which a config file may
+not decide.
+
+`session` is read before any config file is, so a profile setting it would
+name a session the invocation was never sent to; and a profile that answered
+`serve` would turn a query into a server. Both are read from the command line
+alone, as `CLI_ONLY_SSH_KEYS` are.
+"""
+
 TUI_ONLY_KEYS = (
     "theme",
     "keymap_name",

--- a/src/harlequin/config_schema.py
+++ b/src/harlequin/config_schema.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Container, Mapping, Sequence
 import msgspec
 
 from harlequin.config import (
+    CLI_ONLY_SESSION_KEYS,
     CLI_ONLY_SSH_KEYS,
     DEFAULT_ADAPTER,
     TUI_ONLY_KEYS,
@@ -200,7 +201,7 @@ def _profile(
     }
     for key in TUI_ONLY_KEYS:
         properties.setdefault(key, {"description": IDE_ONLY})
-    for key in CLI_ONLY_SSH_KEYS:
+    for key in (*CLI_ONLY_SSH_KEYS, *CLI_ONLY_SESSION_KEYS):
         # refused from a profile at run time, so a file that sets one is wrong
         # however the editor validating it was told to read this document
         properties.pop(key, None)

--- a/src/harlequin/hsql/__init__.py
+++ b/src/harlequin/hsql/__init__.py
@@ -57,25 +57,15 @@ def _run_warm(argv: list[str]) -> int | None:
 
 def _run_cold(argv: list[str]) -> None:
     """A fresh process, a fresh connection, and no memory of the last one."""
-    import click
-
-    from harlequin.hsql.cli import PROGRAM, build_cli
-    from harlequin.hsql.diagnostics import ExitCode
+    from harlequin.hsql.cli import run
 
     try:
-        # the same arguments to both: which adapter's options the command
-        # carries is decided from them, and then click parses them.
-        code = build_cli(argv).main(args=argv, prog_name=PROGRAM, standalone_mode=False)
-    except click.ClickException as e:
-        # parse-level failures -- an unknown option, a bad choice. click already
-        # exits 2 for those, which is the code hsql documents for usage errors.
-        e.show()
-        sys.exit(e.exit_code)
-    except (click.Abort, KeyboardInterrupt):
-        sys.exit(ExitCode.INTERRUPT)
+        code = run(argv)
     except BaseException as e:
+        # a bug in hsql itself, rather than anything the run was asked to do:
+        # `run()` has already turned a bad flag and an interrupt into a code
         _report_crash(e, argv)
-    sys.exit(code if isinstance(code, int) else ExitCode.OK)
+    sys.exit(code)
 
 
 def _report_crash(error: BaseException, argv: Sequence[str]) -> NoReturn:

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -136,12 +136,20 @@ SHORTHANDS = {
 SOURCES = f"{__name__}.sources"
 """Context key under which `-c` and `-f` record themselves, in order."""
 
-CONNECTION_OPTIONS = frozenset(
-    {"conn_str", "adapter", "profile", "config_path", "read_only", *SSH_KEYS}
-)
+CONNECTION_OPTIONS = frozenset({"conn_str", "adapter", "read_only", *SSH_KEYS})
 """Answered once, when a connection is opened -- so `--serve` takes them and a
 served request may not. Every adapter option is one too, by
 `_is_connection_option()`: the command declares none of them itself."""
+
+CONFIG_OPTIONS = frozenset({"profile", "config_path"})
+"""Which file and which profile the other options are read from.
+
+Not connection-time, though a profile usually holds connection-time keys:
+these name where values come from rather than being values, so which group
+one belongs to is decided by what it resolves to. A profile of nothing but
+`format` and `limit` is per-request whichever way it was named, which is what
+lets a served `-P` behave the way a discovered `default_profile` does.
+"""
 
 SERVER_OPTIONS = frozenset({"queue_timeout"})
 """Answered once, and only a server has one to answer."""
@@ -636,7 +644,12 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             _refuse_unservable_name(ctx, serve)
         elif served is not None:
             _refuse_the_sessions_options(
-                ctx, served, typed=typed_options, connects=connects
+                ctx,
+                served,
+                typed=typed_options,
+                connects=connects,
+                profile=profile,
+                profile_config=profile_config,
             )
         elif "queue_timeout" in explicitly_set:
             diagnostics.error(
@@ -1276,8 +1289,7 @@ def _serve(
 ) -> ExitCode:
     """Connect, and answer for the session called `name` until stopped.
 
-    The server is what `--session-reset` reconnects through, so it is handed
-    the adapter and not just the connection.
+    The server reconnects for `--session-reset`, so it is handed the adapter.
     """
     # here rather than at module scope: sockets and threads are the one
     # invocation in many that serves, and every other one would pay for them
@@ -1319,7 +1331,7 @@ def _is_connection_option(name: str) -> bool:
     an adapter's options are all connection-time.
     """
     return name in CONNECTION_OPTIONS or name not in (
-        PER_REQUEST_OPTIONS | SERVER_OPTIONS | ROLE_OPTIONS
+        PER_REQUEST_OPTIONS | SERVER_OPTIONS | ROLE_OPTIONS | CONFIG_OPTIONS
     )
 
 
@@ -1371,14 +1383,26 @@ def _refuse_unservable_name(ctx: click.Context, name: str) -> None:
 
 
 def _refuse_the_sessions_options(
-    ctx: click.Context, served: "Served", *, typed: set[str], connects: bool
+    ctx: click.Context,
+    served: "Served",
+    *,
+    typed: set[str],
+    connects: bool,
+    profile: str | None,
+    profile_config: Mapping[str, Any],
 ) -> None:
-    """Exit with an error if a served request typed an option the session owns.
+    """Exit with an error if a served request asked for what the session owns.
 
     A connection option describes a connection the session already opened,
-    so a request that typed one either agrees with it, and asked for nothing,
-    or differs, and asked for a different session. A server-lifetime option
-    describes the server, which is up.
+    and a server-lifetime option describes a server that is up. A typed `-P`
+    is judged by the keys its profile holds rather than by being one: a
+    profile of per-request keys applies, and one that names a database is
+    refused under the key that names it.
+
+    Only a *typed* profile, because that is the caller asserting this profile
+    for this invocation -- the rule `merge_profile_with_cli()` reads a command
+    line by. One discovered in the caller's directory says nothing about the
+    session, so its connection-time keys are moot rather than wrong.
     """
     for key in sorted(typed):
         spelling = _spelling(ctx, key)
@@ -1393,6 +1417,17 @@ def _refuse_the_sessions_options(
                 f"{spelling} is a connection option, and the session named "
                 f"{served.name!r} connected when it started. Drop it, or start "
                 f"a session with it: '{PROGRAM} --serve NAME {spelling} ...'."
+            )
+            ctx.exit(ExitCode.USAGE)
+    if profile is None or "profile" not in typed:
+        return
+    for key in sorted(profile_config):
+        if key in SERVER_OPTIONS or (connects and _is_connection_option(key)):
+            diagnostics.error(
+                f"the profile {profile!r} sets {key}, which the session named "
+                f"{served.name!r} answered when it started. Use a profile of "
+                f"per-request options here, or start a session with this one: "
+                f"'{PROGRAM} --serve NAME -P {profile}'."
             )
             ctx.exit(ExitCode.USAGE)
 

--- a/src/harlequin/hsql/cli.py
+++ b/src/harlequin/hsql/cli.py
@@ -27,6 +27,19 @@ because `CONN_STR` is positional: `hsql catalog` and a DuckDB file named
 `catalog` would have needed a rule, and `--catalog` needs none. They are
 mutually exclusive, and each lives in `harlequin.hsql.modes`, imported by the
 callback when it is chosen.
+
+A **session** is the fourth shape, and it is two roles of this one command.
+`--serve NAME` connects and then holds the connection, answering invocations
+sent to it over a socket; `--session NAME` is such an invocation, and it is the
+client in `harlequin.hsql.client` that carries it there, forwarding argv
+verbatim. So the server parses every served request with this same command,
+and what tells the callback it is answering for a session is `ctx.obj`. Every
+option here is in exactly one of three groups, decided by when its question
+can be answered: connection-time (`CONN_STR`, `-a`, `-P`, the SSH options,
+every adapter's), per-request (`-c`, `--format`, every mode), and
+server-lifetime (`--queue-timeout`). `--serve` refuses the second group and a
+served request refuses the third, and each refusal names the invocation the
+option belongs on.
 """
 
 from __future__ import annotations
@@ -54,9 +67,11 @@ from typing import (
 import click
 
 from harlequin.config import (
+    CLI_ONLY_SESSION_KEYS,
     CLI_ONLY_SSH_KEYS,
     DEFAULT_ADAPTER,
     DEFAULT_SSH_TIMEOUT,
+    SSH_KEYS,
     TUI_ONLY_KEYS,
     UNLIMITED,
     merge_profile_with_cli,
@@ -86,6 +101,7 @@ from harlequin.redact import hide_secrets_in
 
 if TYPE_CHECKING:
     from harlequin.adapter import HarlequinAdapter, HarlequinConnection
+    from harlequin.hsql.server import Served
     from harlequin.hsql.timeout import Deadline
     from harlequin.layout import LayoutOptions
     from harlequin.navigate import CatalogPath
@@ -120,6 +136,54 @@ SHORTHANDS = {
 SOURCES = f"{__name__}.sources"
 """Context key under which `-c` and `-f` record themselves, in order."""
 
+CONNECTION_OPTIONS = frozenset(
+    {"conn_str", "adapter", "profile", "config_path", "read_only", *SSH_KEYS}
+)
+"""Answered once, when a connection is opened -- so `--serve` takes them and a
+served request may not. Every adapter option is one too, by
+`_is_connection_option()`: the command declares none of them itself."""
+
+SERVER_OPTIONS = frozenset({"queue_timeout"})
+"""Answered once, and only a server has one to answer."""
+
+ROLE_OPTIONS = frozenset({"serve", "session"})
+"""The two spellings that say which process an invocation is."""
+
+PER_REQUEST_OPTIONS = frozenset(
+    {
+        "command",
+        "file",
+        "output",
+        "format",
+        *SHORTHANDS,
+        "vertical",
+        "tuples_only",
+        "no_align",
+        "no_header",
+        "no_footer",
+        "null_string",
+        "timeout",
+        "config_mode",
+        "catalog",
+        "catalog_search",
+        "path",
+        "spec",
+        "info",
+        "skill",
+        "session_reset",
+        "limit",
+        "display_rows",
+        "result",
+        "on_error",
+        "stats",
+        "color",
+        "version",
+    }
+)
+"""Answered on every invocation, so a session's client sends them and
+`--serve` takes none. `tests/unit_tests/test_hsql_serve.py` pins the four
+groups to the command: every parameter is in exactly one."""
+
 
 def build_cli(argv: Sequence[str]) -> click.Command:
     """Build the hsql command, importing at most one adapter to do it.
@@ -140,6 +204,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             click.Option(["--spec"], is_flag=True),
             click.Option(["--info"], is_flag=True),
             click.Option(["--skill"], is_flag=True),
+            click.Option(["--session-reset"], is_flag=True),
         ],
         # A mode reports on what is installed or configured rather than
         # connecting with it, so there is no profile to read for one. `--config`
@@ -148,12 +213,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         # about the first file it stumbled on, and `--info` reports one as part
         # of its answer; `--spec` describes the command, which a config file it
         # could not read has no bearing on.
+        # `--session-reset` asks a running session to reconnect with whatever
+        # it connected with, so it takes no profile and no adapter either.
         needs_profile=lambda params: (
             not (
                 params.get("config") is not None
                 or params.get("spec")
                 or params.get("info")
                 or params.get("skill")
+                or params.get("session_reset")
             )
         ),
         # `--config init` is the mode that needs an adapter without a profile:
@@ -166,6 +234,7 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 or params.get("spec")
                 or params.get("info")
                 or params.get("skill")
+                or params.get("session_reset")
             )
         ),
         # bare `hsql` renders help, so it names no adapter either
@@ -407,6 +476,44 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         ),
     )
     @click.option(
+        "--serve",
+        metavar="NAME",
+        help=(
+            "Connect, then hold the connection open as the session named NAME "
+            "and answer `--session NAME` invocations from it until stopped. "
+            "Takes connection options only. Not on native Windows."
+        ),
+    )
+    @click.option(
+        "--session",
+        metavar="NAME",
+        help=(
+            "Send this invocation to the running session named NAME, started "
+            "with --serve. HSQL_SESSION=NAME does the same for every "
+            "invocation, and runs without the session, with a warning, when "
+            "none is up."
+        ),
+    )
+    @click.option(
+        "--session-reset",
+        is_flag=True,
+        help=(
+            "Ask the session to close its connection and open a fresh one, "
+            "and exit without running SQL. Temp tables, settings and an open "
+            "transaction are gone. Needs --session."
+        ),
+    )
+    @click.option(
+        "--queue-timeout",
+        metavar="SECONDS",
+        type=click.FloatRange(min=0, min_open=True),
+        help=(
+            "With --serve: a request waits at most SECONDS for the one before "
+            "it, then exits 4 without reaching the database. [default: no "
+            "limit]"
+        ),
+    )
+    @click.option(
         "--limit",
         default=DEFAULT_LIMIT,
         show_default=True,
@@ -459,6 +566,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         catalog: bool,
         catalog_search: str | None,
         path: str | None,
+        serve: str | None,
+        session: str | None,
+        session_reset: bool,
         **kwargs: Any,
     ) -> None:
         """Execute SQL and exit.
@@ -481,6 +591,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             for k in kwargs
             if ctx.get_parameter_source(k) != click.core.ParameterSource.DEFAULT
         }
+        # the partition refusals reach past `kwargs`, because the mode flags and
+        # the two role flags are named parameters of this callback rather than
+        # keys of it -- so a `--catalog` or a `--serve` the caller typed would
+        # otherwise be invisible to a check that only reads what the merge sees
+        typed_options = {
+            name
+            for name in ctx.params
+            if ctx.get_parameter_source(name) != click.core.ParameterSource.DEFAULT
+        }
         values: dict[str, Any] = dict(
             merge_profile_with_cli(
                 profile=profile_config,
@@ -490,6 +609,42 @@ def build_cli(argv: Sequence[str]) -> click.Command:
         )
         for key in TUI_ONLY_KEYS:
             values.pop(key, None)
+
+        # the session this invocation is answered by, when a server built
+        # this command to answer it
+        served: Served | None = ctx.obj
+        _refuse_session_keys_from_a_profile(ctx, values)
+        # a mode that reads no database is not the session's business: it
+        # runs where the caller is, with the options the caller typed
+        connects = not (skill or info or spec or config_mode is not None)
+        if serve is not None and (session is not None or served is not None):
+            diagnostics.error(
+                "--serve starts a session and --session sends to one; pass one of them."
+            )
+            ctx.exit(ExitCode.USAGE)
+        if session is not None:
+            # `main()` reads this flag before it parses anything, so it only
+            # arrives here when something else built the command
+            diagnostics.error(
+                f"--session {session} is read before hsql parses anything else, "
+                f"so it cannot be answered from here; run '{PROGRAM} --session "
+                f"{session} ...' from a shell."
+            )
+            ctx.exit(ExitCode.USAGE)
+        if serve is not None:
+            _refuse_per_request_options(ctx, name=serve, typed=typed_options)
+            _refuse_unservable_name(ctx, serve)
+        elif served is not None:
+            _refuse_the_sessions_options(
+                ctx, served, typed=typed_options, connects=connects
+            )
+        elif "queue_timeout" in explicitly_set:
+            diagnostics.error(
+                "--queue-timeout is a --serve option: it bounds how long a "
+                "request waits for the one before it."
+            )
+            ctx.exit(ExitCode.USAGE)
+        raw_queue_timeout = values.pop("queue_timeout", None)
 
         # redact secrets in config values and CLI args
         hide_secrets_in(
@@ -510,13 +665,27 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.exit(ExitCode.USAGE)
         on_error: OnError = "continue" if raw_on_error == "continue" else "stop"
         read_only: bool = bool(values.pop("read_only", False))
-        try:
-            # off the config either way: what is left of it is the adapter's
-            ssh_config = take_ssh_keys(values, typed=explicitly_set)
-        except HarlequinConfigError as e:
-            diagnostics.report_error(e)
-            ctx.exit(ExitCode.USAGE)
+        ssh_config: dict[str, Any] = {}
+        if served is not None and connects:
+            # the session connected when it started, through whatever tunnel
+            # it has, as whichever adapter it was given: a profile discovered
+            # where the caller is does not change any of that
+            for key in SSH_KEYS:
+                values.pop(key, None)
+            adapter = served.adapter
+            read_only = False
+        else:
+            try:
+                # off the config either way: what is left of it is the adapter's
+                ssh_config = take_ssh_keys(values, typed=explicitly_set)
+            except HarlequinConfigError as e:
+                diagnostics.report_error(e)
+                ctx.exit(ExitCode.USAGE)
+        # a server runs no SQL of its own, so a --timeout a profile set for the
+        # requests is not one the server counts down
         raw_timeout = values.pop("timeout", None)
+        if serve is not None:
+            raw_timeout = None
         stats: bool = bool(values.pop("stats", False))
         tuples_only: bool = bool(values.pop("tuples_only", False))
         no_align: bool = bool(values.pop("no_align", False))
@@ -541,6 +710,8 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             spec=spec,
             info=info,
             skill=skill,
+            serve=serve,
+            session_reset=session_reset,
         )
         if path is not None and not catalog and catalog_search is None:
             diagnostics.error("--path must be used with --catalog or --catalog-search.")
@@ -654,6 +825,15 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             )
 
         # every mode below this connects to the database
+        if session_reset:
+            if served is None:
+                diagnostics.error(
+                    "--session-reset asks a running session, and this invocation "
+                    "names none. Pass --session NAME, or set HSQL_SESSION."
+                )
+                ctx.exit(ExitCode.USAGE)
+            ctx.exit(_reset_session(ctx, served))
+
         _refuse_undeclared_read_only(
             ctx,
             adapter=adapter,
@@ -667,7 +847,10 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             seconds=timeout_seconds,
             typed="timeout" in explicitly_set,
         )
-        deadline = _deadline(timeout_seconds)
+        deadline = _deadline(
+            timeout_seconds, abandon=None if served is None else served.abandon
+        )
+        queue_timeout = _timeout_seconds(ctx, raw_queue_timeout, key="--queue-timeout")
 
         if ssh_config.get("ssh_host"):
             # entered before the child exists: `start()` blocks for the whole
@@ -683,14 +866,28 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             ctx.call_on_close(tunnel.stop)
             diagnostics.report_tunnel(tunnel.notice(), tunnel.warnings())
 
+        if serve is not None:
+            ctx.exit(
+                _serve(
+                    ctx,
+                    serve,
+                    adapter=adapter,
+                    conn_str=conn_str,
+                    read_only=read_only,
+                    values=values,
+                    queue_timeout=queue_timeout,
+                )
+            )
+
         if catalog:
             catalog_path = _catalog_path(ctx, path)
             if "limit" in explicitly_set:
                 # ahead of the connection, so it is said whether or not the
                 # database answers
                 diagnostics.report_limit_ignored("--catalog")
-            connection = _connect(
+            connection = _connection_for(
                 ctx,
+                served,
                 adapter=adapter,
                 conn_str=conn_str,
                 read_only=read_only,
@@ -731,8 +928,9 @@ def build_cli(argv: Sequence[str]) -> click.Command:
                 # ahead of the connection, so it is said whether or not the
                 # database answers
                 diagnostics.report_limit_ignored("--catalog-search")
-            connection = _connect(
+            connection = _connection_for(
                 ctx,
+                served,
                 adapter=adapter,
                 conn_str=conn_str,
                 read_only=read_only,
@@ -768,6 +966,18 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             )
             ctx.exit(ExitCode.USAGE)
 
+        if served is not None and served.stdin is None and _names_stdin(sources):
+            # the client's argv scan is a scan, not a parse, and a boolean
+            # short option an adapter declares is not in it: `-zf -` for such
+            # a `-z` reaches here with no stdin, and must not run an empty
+            # script as if that were what was piped
+            diagnostics.error(
+                "-f - reads standard input, and the request the session received "
+                "carried none. Spell it --file -, which the session's client "
+                "always reads."
+            )
+            ctx.exit(ExitCode.USAGE)
+
         try:
             statements = _read_statements(sources)
         except OSError as e:
@@ -796,8 +1006,13 @@ def build_cli(argv: Sequence[str]) -> click.Command:
             detect_overflow=limit is not None,
         )
 
-        connection = _connect(
-            ctx, adapter=adapter, conn_str=conn_str, read_only=read_only, values=values
+        connection = _connection_for(
+            ctx,
+            served,
+            adapter=adapter,
+            conn_str=conn_str,
+            read_only=read_only,
+            values=values,
         )
 
         run = _Run(deadline=deadline)
@@ -933,6 +1148,8 @@ def _one_mode(
     spec: bool,
     info: bool,
     skill: bool,
+    serve: str | None = None,
+    session_reset: bool = False,
 ) -> str | None:
     """The one mode this invocation chose, or exit having named the two it did.
 
@@ -947,6 +1164,8 @@ def _one_mode(
         ("--spec", spec),
         ("--info", info),
         ("--skill", skill),
+        (f"--serve {serve}", serve is not None),
+        ("--session-reset", session_reset),
     )
     chosen = [name for name, was_asked in asked if was_asked]
     if len(chosen) > 1:
@@ -990,19 +1209,220 @@ def _connect(
     values: Mapping[str, Any],
 ) -> "HarlequinConnection":
     """The connection this invocation runs on, or exit having said why not."""
+    return _connected(
+        ctx,
+        _adapter_instance(
+            ctx, adapter=adapter, conn_str=conn_str, read_only=read_only, values=values
+        ),
+    )
+
+
+def _adapter_instance(
+    ctx: click.Context,
+    *,
+    adapter: str,
+    conn_str: Sequence[str],
+    read_only: bool,
+    values: Mapping[str, Any],
+) -> "HarlequinAdapter":
+    """The adapter this invocation connects with, or exit having said why not."""
     try:
-        adapter_instance = load_adapter(adapter)(
-            conn_str=conn_str, read_only=read_only, **values
-        )
+        return load_adapter(adapter)(conn_str=conn_str, read_only=read_only, **values)
     except HarlequinConfigError as e:
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
 
+
+def _connected(
+    ctx: click.Context, adapter_instance: "HarlequinAdapter"
+) -> "HarlequinConnection":
     try:
         return adapter_instance.connect()
     except HarlequinConnectionError as e:
         diagnostics.report_error(e)
         ctx.exit(ExitCode.CONNECTION)
+
+
+def _connection_for(
+    ctx: click.Context,
+    served: "Served | None",
+    *,
+    adapter: str,
+    conn_str: Sequence[str],
+    read_only: bool,
+    values: Mapping[str, Any],
+) -> "HarlequinConnection":
+    """The session's connection when there is a session, and a new one otherwise."""
+    if served is None:
+        return _connect(
+            ctx, adapter=adapter, conn_str=conn_str, read_only=read_only, values=values
+        )
+    try:
+        return served.connection()
+    except HarlequinConnectionError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.CONNECTION)
+
+
+def _serve(
+    ctx: click.Context,
+    name: str,
+    *,
+    adapter: str,
+    conn_str: Sequence[str],
+    read_only: bool,
+    values: Mapping[str, Any],
+    queue_timeout: float | None,
+) -> ExitCode:
+    """Connect, and answer for the session called `name` until stopped.
+
+    The server is what `--session-reset` reconnects through, so it is handed
+    the adapter and not just the connection.
+    """
+    # here rather than at module scope: sockets and threads are the one
+    # invocation in many that serves, and every other one would pay for them
+    from harlequin.hsql.server import Server
+
+    adapter_instance = _adapter_instance(
+        ctx, adapter=adapter, conn_str=conn_str, read_only=read_only, values=values
+    )
+    connection = _connected(ctx, adapter_instance)
+    return Server(
+        name,
+        adapter=adapter,
+        connection=connection,
+        reconnect=adapter_instance.connect,
+        queue_timeout=queue_timeout,
+    ).serve()
+
+
+def _reset_session(ctx: click.Context, served: "Served") -> ExitCode:
+    """Answer `--session-reset` and return its code, or exit having said why not.
+
+    Exit 3 for a reconnect that failed, since that is what the session now
+    is: one with no connection, which the next request is told about too.
+    """
+    try:
+        served.reset()
+    except HarlequinConnectionError as e:
+        diagnostics.report_error(e)
+        ctx.exit(ExitCode.CONNECTION)
+    diagnostics.note(f"session {served.name!r} reconnected.")
+    return ExitCode.OK
+
+
+def _is_connection_option(name: str) -> bool:
+    """Whether an option is answered when a connection is opened.
+
+    Every option is in exactly one group, and the command declares no
+    adapter's options itself, so one it does not know is an adapter's -- and
+    an adapter's options are all connection-time.
+    """
+    return name in CONNECTION_OPTIONS or name not in (
+        PER_REQUEST_OPTIONS | SERVER_OPTIONS | ROLE_OPTIONS
+    )
+
+
+def _spelling(ctx: click.Context, name: str) -> str:
+    """How the command line spells a parameter, for an error that names it."""
+    for param in ctx.command.params:
+        if param.name == name:
+            if isinstance(param, click.Argument):
+                return param.human_readable_name
+            return max(param.opts, key=len)
+    return name
+
+
+def _refuse_per_request_options(
+    ctx: click.Context, *, name: str, typed: set[str]
+) -> None:
+    """Exit with an error if `--serve` was given an option a request answers.
+
+    Every flag a server would need for a query is one it cannot answer once
+    for every invocation to come, so the refusal names the invocation the
+    option belongs on rather than only the one it does not.
+    """
+    for key in sorted(typed):
+        if key in PER_REQUEST_OPTIONS:
+            spelling = _spelling(ctx, key)
+            diagnostics.error(
+                f"{spelling} is a per-request option, and --serve takes none. "
+                f"Start the session, then send it the request: "
+                f"'{PROGRAM} --serve {name} ...', then "
+                f"'{PROGRAM} --session {name} {spelling} ...'."
+            )
+            ctx.exit(ExitCode.USAGE)
+
+
+def _refuse_unservable_name(ctx: click.Context, name: str) -> None:
+    """Exit with an error if no client could ever reach a session so named.
+
+    Asked of the name before a connection is paid for, and asked with the
+    client's own check, so the two halves cannot disagree about a name.
+    """
+    from harlequin.hsql.client import cannot_be_served
+    from harlequin.hsql.session import Session
+
+    refusal = cannot_be_served(Session(name, explicit=True), os.environ)
+    if refusal is not None:
+        reason, remedy, code = refusal
+        diagnostics.error(f"{reason}.{remedy}")
+        ctx.exit(code)
+
+
+def _refuse_the_sessions_options(
+    ctx: click.Context, served: "Served", *, typed: set[str], connects: bool
+) -> None:
+    """Exit with an error if a served request typed an option the session owns.
+
+    A connection option describes a connection the session already opened,
+    so a request that typed one either agrees with it, and asked for nothing,
+    or differs, and asked for a different session. A server-lifetime option
+    describes the server, which is up.
+    """
+    for key in sorted(typed):
+        spelling = _spelling(ctx, key)
+        if key in SERVER_OPTIONS:
+            diagnostics.error(
+                f"{spelling} is a --serve option, and the session named "
+                f"{served.name!r} already has one."
+            )
+            ctx.exit(ExitCode.USAGE)
+        if connects and _is_connection_option(key):
+            diagnostics.error(
+                f"{spelling} is a connection option, and the session named "
+                f"{served.name!r} connected when it started. Drop it, or start "
+                f"a session with it: '{PROGRAM} --serve NAME {spelling} ...'."
+            )
+            ctx.exit(ExitCode.USAGE)
+
+
+def _refuse_session_keys_from_a_profile(
+    ctx: click.Context, values: Mapping[str, Any]
+) -> None:
+    """Exit with an error if a config file said which process runs this.
+
+    Only a profile can have put one of these in the merged values: the two
+    flags are named parameters of the callback, so a typed one never reaches
+    the merge.
+    """
+    for key in CLI_ONLY_SESSION_KEYS:
+        if key in values:
+            remedy = (
+                f"Pass --{key}, or set HSQL_SESSION"
+                if key == "session"
+                else f"Pass --{key}"
+            )
+            diagnostics.error(
+                f"{key} says which process runs an invocation, so it is read "
+                f"from the command line and not from a config file. {remedy}."
+            )
+            ctx.exit(ExitCode.USAGE)
+
+
+def _names_stdin(sources: Sequence[tuple[str, tuple[str, ...]]]) -> bool:
+    """Whether any `-f` in the invocation reads standard input."""
+    return any(kind == "file" and "-" in values for kind, values in sources)
 
 
 def _catalog_path(ctx: click.Context, raw: str | None) -> "CatalogPath":
@@ -1103,31 +1523,36 @@ def _refuse_undeclared_timeout(
         ctx.exit(ExitCode.USAGE)
 
 
-def _timeout_seconds(ctx: click.Context, raw: Any) -> float | None:
+def _timeout_seconds(
+    ctx: click.Context, raw: Any, *, key: str = "--timeout"
+) -> float | None:
     """How long this invocation has, or exit having said why that is not a time.
 
     click has already vetted a `--timeout` typed on the command line; a profile
     can say anything.
     """
     try:
-        return parse_seconds(raw, key="--timeout")
+        return parse_seconds(raw, key=key)
     except HarlequinConfigError as e:
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
 
 
-def _deadline(seconds: float | None) -> "Deadline | None":
+def _deadline(
+    seconds: float | None, *, abandon: Callable[[], None] | None = None
+) -> "Deadline | None":
     """The clock this invocation runs under, or None for as long as it takes.
 
     Deferred, and None where nothing asked: a run with no deadline starts no
     worker thread, and the two phases stay on the thread they have always been
-    on.
+    on. `abandon` is a session's answer to a cancel that did not land, in
+    place of ending the process.
     """
     if seconds is None:
         return None
     from harlequin.hsql.timeout import Deadline
 
-    return Deadline(seconds)
+    return Deadline(seconds, abandon=abandon)
 
 
 def _under_deadline(
@@ -1486,6 +1911,30 @@ def _write_config(
         diagnostics.report_error(e)
         ctx.exit(ExitCode.USAGE)
     return ExitCode.OK
+
+
+def run(argv: Sequence[str], *, served: "Served | None" = None) -> int:
+    """Parse and run one invocation, and return the code it exits with.
+
+    The whole of the cold path, and the whole of one request on a session's
+    server -- which is the point: a served invocation is this function with
+    `served` set, and nothing else. What the callback needs to know about the
+    session travels as `ctx.obj`.
+    """
+    try:
+        # the same arguments to both: which adapter's options the command
+        # carries is decided from them, and then click parses them.
+        code = build_cli(argv).main(
+            args=list(argv), prog_name=PROGRAM, standalone_mode=False, obj=served
+        )
+    except click.ClickException as e:
+        # parse-level failures -- an unknown option, a bad choice. click already
+        # exits 2 for those, which is the code hsql documents for usage errors.
+        e.show()
+        return e.exit_code
+    except (click.Abort, KeyboardInterrupt):
+        return ExitCode.INTERRUPT
+    return code if isinstance(code, int) else ExitCode.OK
 
 
 def bare_command() -> click.Command:
@@ -2038,6 +2487,13 @@ def _epilog(installed: Sequence[str], adapter: str | None) -> str:
             f"  {PROGRAM} --catalog --path db.schema    one level below that\n"
             f"  {PROGRAM} --catalog --path db.sch.tbl   a relation's columns\n"
             f"  {PROGRAM} --catalog-search orders       anything in it named that"
+        ),
+        (
+            "Sessions (not on native Windows):\n"
+            f"  {PROGRAM} --serve NAME [CONN_STR]      hold a connection open\n"
+            f"  {PROGRAM} --session NAME -c ...        send it a query; or "
+            "HSQL_SESSION=NAME\n"
+            f"  {PROGRAM} --session NAME --session-reset   reconnect it"
         ),
         (
             "Exit codes:\n"

--- a/src/harlequin/hsql/client.py
+++ b/src/harlequin/hsql/client.py
@@ -82,7 +82,7 @@ def run(
     and my temp tables vanished" must not be something a caller has to guess
     at.
     """
-    refusal = _cannot_be_served(session, environ)
+    refusal = cannot_be_served(session, environ)
     if refusal is not None:
         return _no_session(session, refusal[0], remedy=refusal[1], code=refusal[2])
 
@@ -115,14 +115,16 @@ def run(
         connection.close()
 
 
-def _cannot_be_served(
+def cannot_be_served(
     session: "Session", environ: "Mapping[str, str]"
 ) -> "tuple[str, str, int] | None":
     """Why this invocation can never reach a session, before one is looked for.
 
     A reason, a remedy and an exit code -- all `USAGE`, because none of them is
     a server that happens to be down, and a caller who answered an exit 3 by
-    starting one would answer it forever.
+    starting one would answer it forever. The server asks the same question of
+    the name it was given, so that a name no client could reach is refused
+    before a connection is paid for.
 
     Ordered most specific first. A flag with no value is the caller's typo on
     every platform, so it is named before the platform is: telling someone on

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -179,7 +179,7 @@ def report_queue_timeout(seconds: float, *, stream: TextIO) -> None:
     )
 
 
-def report_crash(report_path: Path | None) -> None:
+def report_crash(report_path: Path | None, *, stream: TextIO | None = None) -> None:
     """Say that this was a bug in hsql, and where the report is.
 
     Plain text, no panel: hsql writes no box drawing, and this leaves through
@@ -187,10 +187,16 @@ def report_crash(report_path: Path | None) -> None:
     """
     from harlequin.crash import ISSUE_URL
 
-    error("hsql hit a bug in itself and could not finish the run.")
-    note(f"please report this crash to help improve Harlequin: {ISSUE_URL}")
+    error("hsql hit a bug in itself and could not finish the run.", stream=stream)
+    note(
+        f"please report this crash to help improve Harlequin: {ISSUE_URL}",
+        stream=stream,
+    )
     if report_path is not None:
-        note(f"the file you will need for the crash report is at {report_path}")
+        note(
+            f"the file you will need for the crash report is at {report_path}",
+            stream=stream,
+        )
 
 
 def report_theme_confusion(conn_str: Sequence[str]) -> None:

--- a/src/harlequin/hsql/diagnostics.py
+++ b/src/harlequin/hsql/diagnostics.py
@@ -23,7 +23,7 @@ import os
 import sys
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, TextIO
 
 from harlequin.exception import (
     HarlequinCatalogPathError,
@@ -106,13 +106,13 @@ def exit_code_for(error: BaseException) -> ExitCode:
     return ExitCode.QUERY
 
 
-def error(message: str) -> None:
+def error(message: str, *, stream: TextIO | None = None) -> None:
     """One plain line, prefixed with the program name.
 
     No panel, no ANSI, no box drawing: those are affordances of a full-screen
     app, and here they would be something a caller has to parse around.
     """
-    _write(f"{PROGRAM}: error: {message}")
+    _write(f"{PROGRAM}: error: {message}", stream=stream)
 
 
 def report_error(exception: BaseException) -> None:
@@ -122,8 +122,61 @@ def report_error(exception: BaseException) -> None:
     error(message)
 
 
-def note(message: str) -> None:
-    _write(f"note: {message}")
+def note(message: str, *, stream: TextIO | None = None) -> None:
+    _write(f"note: {message}", stream=stream)
+
+
+def report_session_ready(name: str, adapter: str, *, stream: TextIO) -> None:
+    """Say that a session is up, and how to reach it.
+
+    On the server's own stderr, which is the operator's stream: every other
+    line a request produces goes to the client that sent it.
+    """
+    note(
+        f"session {name!r} is ready ({adapter}). Send it queries with "
+        f"`{PROGRAM} --session {name} -c ...`, or set HSQL_SESSION={name}. "
+        "Ctrl-C stops it.",
+        stream=stream,
+    )
+
+
+def report_session_stopped(name: str, requests: int, *, stream: TextIO) -> None:
+    note(
+        f"session {name!r} stopped after {requests} "
+        f"{'request' if requests == 1 else 'requests'}.",
+        stream=stream,
+    )
+
+
+def report_request(number: int, code: int, elapsed_ms: int, *, stream: TextIO) -> None:
+    """One line per request answered, so a foreground server shows its work."""
+    note(f"request {number}: exit {code} in {elapsed_ms}ms", stream=stream)
+
+
+def report_peer_refused(uid: int, *, stream: TextIO) -> None:
+    note(f"refused a connection from uid {uid}, which is not yours.", stream=stream)
+
+
+def report_bad_request(reason: str, *, stream: TextIO) -> None:
+    note(f"dropped a connection that sent no request: {reason}", stream=stream)
+
+
+def report_client_gone(*, stream: TextIO) -> None:
+    note("a client went away before its answer reached it.", stream=stream)
+
+
+def report_queue_timeout(seconds: float, *, stream: TextIO) -> None:
+    """Say that a request waited its whole `--queue-timeout` for the one ahead.
+
+    Distinct from `report_timeout()` on purpose: this request never reached
+    the database, and a caller retrying a query that ran too long is doing
+    the wrong thing about one that never ran.
+    """
+    error(
+        f"waited {seconds:g}s for the session's previous request and never "
+        "reached the database (--queue-timeout).",
+        stream=stream,
+    )
 
 
 def report_crash(report_path: Path | None) -> None:
@@ -313,7 +366,7 @@ def report_stats(
     _write(json.dumps(payload, separators=(",", ":")))
 
 
-def _write(line: str) -> None:
+def _write(line: str, *, stream: TextIO | None = None) -> None:
     # stdout first, always. It is block-buffered when it is a pipe, and stderr
     # is not, so a diagnostic written now would otherwise overtake the result
     # set it describes -- and the two streams would interleave differently on a
@@ -321,9 +374,13 @@ def _write(line: str) -> None:
     # that true for errors and --stats as well as for notes.
     sys.stdout.flush()
     # sys.stderr is resolved on each call, not bound at import: a test harness
-    # that swaps the stream out has to be able to see what was written.
+    # that swaps the stream out has to be able to see what was written. A
+    # session's server names a stream instead, because while it answers a
+    # request the process's stderr is that request's.
     #
     # Redacting here rather than at each call site is what makes this a
     # promise: an error raised by a driver, a note, a `--stats` payload with a
     # message in it, and whatever is added next all leave through this line.
-    print(redact_text(line), file=sys.stderr)
+    print(redact_text(line), file=sys.stderr if stream is None else stream)
+    if stream is not None:
+        stream.flush()

--- a/src/harlequin/hsql/server.py
+++ b/src/harlequin/hsql/server.py
@@ -1,0 +1,623 @@
+"""The half of a warm session that holds the connection: `hsql --serve NAME`.
+
+A foreground process that connects once and then answers invocations sent to
+it over a unix socket, so that a caller pays neither the imports nor the
+connection again. What it runs is the same command the cold path builds --
+`harlequin.hsql.cli.run()`, with the request's argv -- into a recorder that
+stands in for the process's streams, and what it sends back is the bytes that
+recorder holds and the code the command exited with. The server formats
+nothing and parses nothing of its own, which is what keeps a served invocation
+byte-for-byte a cold one.
+
+A session is one connection, so requests run **one at a time**: the adapter
+contract says nothing about thread-safety, and the IDE has never needed it. A
+second client waits its turn, bounded by `--queue-timeout`, and is told it
+never reached the database if that runs out -- a different fact from a query
+that ran too long.
+
+A running server is a live, authenticated connection that anything able to
+write its socket can use, so the socket is the credential: `AF_UNIX` only, in
+a directory only this user can reach, and every peer's uid is checked on
+accept. Native Windows has no `AF_UNIX`, so this is POSIX only; WSL2 is Linux
+and gets it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import signal
+import socket
+import struct
+import sys
+import threading
+import time
+import traceback
+from collections import deque
+from itertools import count
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Mapping, Sequence
+
+from harlequin.exception import HarlequinConnectionError
+from harlequin.hsql import diagnostics, protocol
+from harlequin.hsql.diagnostics import ExitCode
+from harlequin.hsql.session import (
+    UnsafeRuntimeDir,
+    check_runtime_dir,
+    socket_path,
+)
+
+if TYPE_CHECKING:
+    from harlequin.adapter import HarlequinConnection
+
+ACCEPT_POLL_SECONDS = 0.5
+"""How often the accept loop looks up from the socket to see if it was stopped."""
+
+REQUEST_TIMEOUT_SECONDS = 30.0
+"""How long a connected client has to send its request before it is dropped,
+so that a client that connects and stalls cannot hold a thread forever."""
+
+REPEATED_SIGNAL_SECONDS = 1.0
+"""A second stop signal this long after the first is an operator who wants
+out now, rather than the same Ctrl-C arriving twice."""
+
+BACKLOG = 16
+"""Connections the kernel queues before the accept loop gets to them."""
+
+LOCK_SUFFIX = ".lock"
+"""Beside the socket, and held for the server's lifetime: the one thing that
+tells a live session from a stale socket file without racing another server
+starting under the same name."""
+
+
+class SessionRunning(Exception):
+    """A server is already up under this name."""
+
+
+class Turnstile:
+    """One request at a time, in the order they arrived.
+
+    A lock would serve requests in whatever order the interpreter woke the
+    waiters; this hands out tickets so that the client that has waited longest
+    goes next, and so that a waiter can give up on a deadline of its own.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._waiting: deque[int] = deque()
+        self._tickets = count()
+        self._busy = False
+
+    @property
+    def queued(self) -> int:
+        """How many requests are waiting their turn."""
+        with self._condition:
+            return len(self._waiting)
+
+    def enter(self, timeout: float | None) -> bool:
+        """Wait for a turn, and return whether one came before `timeout`."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._condition:
+            ticket = next(self._tickets)
+            self._waiting.append(ticket)
+            while self._busy or self._waiting[0] != ticket:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    self._waiting.remove(ticket)
+                    self._condition.notify_all()
+                    return False
+                self._condition.wait(remaining)
+            self._waiting.popleft()
+            self._busy = True
+            return True
+
+    def leave(self) -> None:
+        with self._condition:
+            self._busy = False
+            self._condition.notify_all()
+
+
+class Recorder:
+    """A request's two streams, in the order the command wrote to them.
+
+    One list rather than two buffers, so that a note written between two
+    result sets reaches the caller's terminal between them, as it does cold.
+    """
+
+    def __init__(self, *, stdout_isatty: bool = False, stderr_isatty: bool = False):
+        self.segments: list[tuple[int, bytearray]] = []
+        self._stdout_isatty = stdout_isatty
+        self._stderr_isatty = stderr_isatty
+
+    def write(self, kind: int, data: bytes) -> None:
+        if self.segments and self.segments[-1][0] == kind:
+            self.segments[-1][1].extend(data)
+        elif data:
+            self.segments.append((kind, bytearray(data)))
+
+    def stdout(self) -> io.TextIOWrapper:
+        """A stand-in for `sys.stdout`, whose `.buffer` is what `-o -` writes."""
+        return io.TextIOWrapper(
+            _Stream(self, protocol.STDOUT, isatty=self._stdout_isatty),
+            encoding="utf-8",
+            write_through=True,
+        )
+
+    def stderr(self) -> io.TextIOWrapper:
+        return io.TextIOWrapper(
+            _Stream(self, protocol.STDERR, isatty=self._stderr_isatty),
+            encoding="utf-8",
+            errors="backslashreplace",
+            write_through=True,
+        )
+
+
+class _Stream(io.RawIOBase):
+    """One of a recorder's streams, as a raw binary stream."""
+
+    def __init__(self, recorder: Recorder, kind: int, *, isatty: bool) -> None:
+        super().__init__()
+        self._recorder = recorder
+        self._kind = kind
+        self._isatty = isatty
+
+    @property
+    def name(self) -> str:
+        return "<session>"
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, data: Any) -> int:
+        view = memoryview(data)
+        self._recorder.write(self._kind, view.tobytes())
+        return view.nbytes
+
+    def isatty(self) -> bool:
+        return self._isatty
+
+
+class Served:
+    """What the command is told about the session answering it."""
+
+    def __init__(self, server: Server, request: protocol.Request) -> None:
+        self._server = server
+        self.name = server.name
+        self.adapter = server.adapter
+        self.stdin = request.stdin
+
+    def connection(self) -> HarlequinConnection:
+        """The session's connection.
+
+        Raises: HarlequinConnectionError if the session has none to offer.
+        """
+        return self._server.connection()
+
+    def reset(self) -> None:
+        """Close the session's connection and open a fresh one.
+
+        Raises: HarlequinConnectionError if the new one could not be opened.
+        """
+        self._server.reset()
+
+    def abandon(self) -> None:
+        """Note that a cancelled run outlasted its grace period.
+
+        The cold path ends the process here, because a thread still inside a
+        driver aborts an interpreter that exits around it. A server ends the
+        request instead, and offers no connection until it is reset: the next
+        request would otherwise run on a connection another thread still has.
+        """
+        self._server.abandon()
+
+
+class Server:
+    """One session: a name, a connection, and the socket that reaches it."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        adapter: str,
+        connection: HarlequinConnection,
+        reconnect: Callable[[], HarlequinConnection],
+        queue_timeout: float | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
+        self.name = name
+        self.adapter = adapter
+        self._connection: HarlequinConnection | None = connection
+        self._connection_error: str | None = None
+        self._reconnect = reconnect
+        self._abandoned = False
+        self._queue_timeout = queue_timeout
+        self._environ = dict(os.environ if environ is None else environ)
+        self._cwd = os.getcwd()
+        self._turnstile = Turnstile()
+        self._stopping = threading.Event()
+        self._stop_asked_at: float | None = None
+        self._requests = 0
+        self._stderr = sys.stderr
+        self._lock: io.TextIOWrapper | None = None
+
+    @property
+    def requests(self) -> int:
+        """How many requests this session has answered."""
+        return self._requests
+
+    def stop(self) -> None:
+        """Ask the accept loop to finish, from any thread."""
+        self._stopping.set()
+
+    def serve(self) -> ExitCode:
+        """Listen until stopped, and return the code the process exits with.
+
+        Stopping is a signal, or `stop()`: the socket comes down first so a
+        new client is told nothing is listening, requests already accepted
+        are answered, and then the connection is closed.
+        """
+        path = os.path.abspath(socket_path(self.name, self._environ))
+        # the handler is installed before the socket is listening, or a stop
+        # signal in the window between `listen()` and the handler would kill a
+        # process a client can already reach
+        with self._stopping_on_signal():
+            try:
+                listener = self._listen(path)
+            except SessionRunning:
+                diagnostics.error(
+                    f"a session named {self.name!r} is already running.",
+                    stream=self._stderr,
+                )
+                return ExitCode.USAGE
+            except (UnsafeRuntimeDir, OSError) as e:
+                diagnostics.error(
+                    f"a session named {self.name!r} cannot listen: {e}",
+                    stream=self._stderr,
+                )
+                return ExitCode.USAGE
+
+            _warm_imports()
+            diagnostics.report_session_ready(
+                self.name, self.adapter, stream=self._stderr
+            )
+            try:
+                self._accept(listener)
+            finally:
+                listener.close()
+                with contextlib.suppress(OSError):
+                    os.unlink(path)
+                # every request already accepted is answered before the
+                # connection goes away under it
+                self._turnstile.enter(None)
+                self._close_connection()
+                self._unlock()
+        diagnostics.report_session_stopped(
+            self.name, self._requests, stream=self._stderr
+        )
+        if self._abandoned:
+            # a thread still inside the driver aborts an interpreter that
+            # exits around it
+            from harlequin.hsql.timeout import halt
+
+            halt(ExitCode.OK)
+        return ExitCode.OK
+
+    # --- the session's connection ---------------------------------------------
+
+    def connection(self) -> HarlequinConnection:
+        reset = f"run `hsql --session {self.name} --session-reset` to reconnect"
+        if self._abandoned:
+            raise HarlequinConnectionError(
+                f"the session named {self.name!r} cancelled a query that did not "
+                f"stop, so its connection cannot be used; {reset}.",
+                title="hsql session unavailable",
+            )
+        if self._connection is None:
+            raise HarlequinConnectionError(
+                f"the session named {self.name!r} has no connection: "
+                f"{self._connection_error}; {reset}.",
+                title="hsql session unavailable",
+            )
+        return self._connection
+
+    def reset(self) -> None:
+        self._close_connection()
+        self._abandoned = False
+        self._connection_error = None
+        # where the server started, not where the client is: a relative path
+        # in the adapter's options resolves the way it did the first time
+        with _in_directory(self._cwd):
+            try:
+                self._connection = self._reconnect()
+            except HarlequinConnectionError as e:
+                self._connection_error = e.msg
+                raise
+
+    def abandon(self) -> None:
+        self._abandoned = True
+
+    def _close_connection(self) -> None:
+        connection, self._connection = self._connection, None
+        if connection is None or self._abandoned:
+            # an abandoned connection belongs to the thread still inside it
+            return
+        with contextlib.suppress(Exception):  # adapters are third-party code
+            connection.close()
+
+    # --- the socket ------------------------------------------------------------
+
+    def _listen(self, path: str) -> socket.socket:
+        """Claim the name and bind its socket.
+
+        Raises: SessionRunning if another server holds the name,
+        UnsafeRuntimeDir if the directory is not this user's alone, and
+        OSError for anything the filesystem or the kernel refused.
+        """
+        directory = os.path.dirname(path)
+        with contextlib.suppress(FileExistsError):
+            os.mkdir(directory, 0o700)
+        check_runtime_dir(directory)
+        self._lock_name(path[: -len(".sock")] + LOCK_SUFFIX)
+        # stale, since the lock is ours: whatever server left it is gone
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(path)
+            # honored on Linux and macOS, though the directory's mode is the
+            # control every kernel enforces
+            os.chmod(path, 0o600)
+            listener.listen(BACKLOG)
+        except BaseException:
+            listener.close()
+            raise
+        return listener
+
+    def _lock_name(self, lock_path: str) -> None:
+        import fcntl
+
+        lock = open(lock_path, "w")  # noqa: SIM115 -- held for the server's lifetime
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            lock.close()
+            raise SessionRunning(lock_path) from None
+        self._lock = lock
+
+    def _unlock(self) -> None:
+        if self._lock is not None:
+            self._lock.close()
+            self._lock = None
+
+    def _accept(self, listener: socket.socket) -> None:
+        listener.settimeout(ACCEPT_POLL_SECONDS)
+        while not self._stopping.is_set():
+            try:
+                connection, _ = listener.accept()
+            except TimeoutError:
+                continue
+            uid = peer_uid(connection)
+            if uid is not None and uid != os.getuid():
+                # only reachable through a directory that is not this user's
+                # alone, which both halves refuse to use; belt and braces
+                diagnostics.report_peer_refused(uid, stream=self._stderr)
+                connection.close()
+                continue
+            threading.Thread(
+                target=self._attend,
+                args=(connection,),
+                name="hsql-request",
+                daemon=True,
+            ).start()
+
+    @contextlib.contextmanager
+    def _stopping_on_signal(self) -> Iterator[None]:
+        """Stop on `SIGINT` or `SIGTERM`, and exit at once on a repeated one.
+
+        Repeated after a moment, that is: a terminal's Ctrl-C reaches every
+        process in the foreground group, and a wrapper that then signals its
+        child delivers two within milliseconds, which is one operator asking
+        once. Only the main thread can install a handler; anywhere else,
+        `stop()` is the way to stop.
+        """
+        from harlequin.hsql.timeout import halt
+
+        def handle(number: int, frame: Any) -> None:
+            now = time.monotonic()
+            if (
+                self._stop_asked_at is not None
+                and now - self._stop_asked_at > REPEATED_SIGNAL_SECONDS
+            ):
+                halt(ExitCode.INTERRUPT)
+            if self._stop_asked_at is None:
+                self._stop_asked_at = now
+            self._stopping.set()
+
+        replaced: list[tuple[signal.Signals, Any]] = []
+        for number in (signal.SIGINT, signal.SIGTERM):
+            with contextlib.suppress(ValueError, OSError):
+                replaced.append((number, signal.signal(number, handle)))
+        try:
+            yield
+        finally:
+            for number, previous in replaced:
+                if previous is None:
+                    continue
+                with contextlib.suppress(ValueError, OSError, TypeError):
+                    signal.signal(number, previous)
+
+    # --- one request -----------------------------------------------------------
+
+    def _attend(self, connection: socket.socket) -> None:
+        """Answer one client, on its own thread, in its turn."""
+        with connection:
+            try:
+                protocol.send_frame(
+                    connection, protocol.HELLO, protocol.VERSION.encode("utf-8")
+                )
+                connection.settimeout(REQUEST_TIMEOUT_SECONDS)
+                frame = protocol.recv_frame(connection)
+                connection.settimeout(None)
+                if frame is None:
+                    # a client that refused to be served by this version
+                    return
+                if frame[0] != protocol.REQUEST:
+                    raise protocol.ProtocolError(f"expected a request, got {frame[0]}")
+                request = protocol.unpack_request(frame[1])
+            except (protocol.ProtocolError, OSError) as e:
+                diagnostics.report_bad_request(str(e), stream=self._stderr)
+                return
+
+            if not self._turnstile.enter(self._queue_timeout):
+                recorder = Recorder()
+                diagnostics.report_queue_timeout(
+                    self._queue_timeout or 0, stream=recorder.stderr()
+                )
+                self._answer(connection, recorder.segments, ExitCode.TIMEOUT)
+                return
+            started = time.monotonic()
+            try:
+                segments, code = self._run(request)
+            finally:
+                self._turnstile.leave()
+            self._requests += 1
+            elapsed_ms = round((time.monotonic() - started) * 1000)
+            self._answer(connection, segments, code)
+            diagnostics.report_request(
+                self._requests, code, elapsed_ms, stream=self._stderr
+            )
+
+    def _run(
+        self, request: protocol.Request
+    ) -> tuple[list[tuple[int, bytearray]], int]:
+        """Run one invocation as the cold path would, into a recorder."""
+        from harlequin.hsql import cli
+
+        recorder = Recorder(
+            stdout_isatty=request.stdout_isatty, stderr_isatty=request.stderr_isatty
+        )
+        try:
+            with self._as(request, recorder):
+                code = cli.run(request.argv, served=Served(self, request))
+        except NotADirectoryError as e:
+            diagnostics.error(str(e), stream=recorder.stderr())
+            return recorder.segments, ExitCode.USAGE
+        except Exception as e:  # noqa: BLE001 -- the server outlives a request
+            traceback.print_exc(file=self._stderr)
+            diagnostics.error(
+                f"the session named {self.name!r} could not run this request: "
+                f"{e or type(e).__name__}",
+                stream=recorder.stderr(),
+            )
+            return recorder.segments, ExitCode.QUERY
+        return recorder.segments, code
+
+    @contextlib.contextmanager
+    def _as(self, request: protocol.Request, recorder: Recorder) -> Iterator[None]:
+        """Make this process look like the client's, for one request.
+
+        Its working directory, so a relative `-o`, `-f` or `--config-path`
+        and the config files hsql discovers resolve where the caller is; the
+        environment it forwards; and its streams, so `--color auto` reads the
+        caller's terminal and `-f -` reads what it piped. All of it is
+        process-wide, which is safe because requests run one at a time and
+        nothing else here touches any of it.
+
+        Raises: NotADirectoryError if the client's directory cannot be entered.
+        """
+        try:
+            os.chdir(request.cwd)
+        except OSError as e:
+            raise NotADirectoryError(
+                f"the working directory {request.cwd} cannot be entered: {e.strerror}"
+            ) from e
+        saved_environ = {
+            key: os.environ.get(key) for key in protocol.FORWARDED_ENV_VARS
+        }
+        saved_streams = (sys.stdin, sys.stdout, sys.stderr)
+        try:
+            for key in protocol.FORWARDED_ENV_VARS:
+                if key in request.environ:
+                    os.environ[key] = request.environ[key]
+                else:
+                    os.environ.pop(key, None)
+            sys.stdin = io.TextIOWrapper(
+                io.BytesIO(request.stdin or b""), encoding="utf-8"
+            )
+            sys.stdout = recorder.stdout()
+            sys.stderr = recorder.stderr()
+            yield
+        finally:
+            with contextlib.suppress(Exception):
+                sys.stdout.flush()
+                sys.stderr.flush()
+            sys.stdin, sys.stdout, sys.stderr = saved_streams
+            for key, value in saved_environ.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            os.chdir(self._cwd)
+
+    def _answer(
+        self,
+        connection: socket.socket,
+        segments: Sequence[tuple[int, bytearray]],
+        code: int,
+    ) -> None:
+        """Send the recorded streams, chunked, and then the exit code."""
+        try:
+            for kind, data in segments:
+                for start in range(0, len(data), protocol.CHUNK_SIZE):
+                    protocol.send_frame(
+                        connection,
+                        kind,
+                        bytes(data[start : start + protocol.CHUNK_SIZE]),
+                    )
+            protocol.send_frame(connection, protocol.EXIT, bytes([code & 0xFF]))
+        except OSError:
+            # the client went away; the request ran, and there is nobody to
+            # tell about it
+            diagnostics.report_client_gone(stream=self._stderr)
+
+
+def _warm_imports() -> None:
+    """Pay for the execution core before the first request, not during it.
+
+    The cold path defers these so that an invocation that never runs SQL never
+    loads them; a server exists to run SQL, and the seconds they cost belong
+    to its start-up rather than to whichever caller happens to be first.
+    """
+    import harlequin.export  # noqa: F401
+    import harlequin.hsql.output  # noqa: F401
+    import harlequin.layout  # noqa: F401
+    import harlequin.query  # noqa: F401
+    import harlequin.statements  # noqa: F401
+
+
+def peer_uid(connection: socket.socket) -> int | None:
+    """The uid of the process at the other end, or None where the kernel cannot say."""
+    try:
+        if hasattr(socket, "SO_PEERCRED"):
+            # struct ucred: pid, uid, gid
+            credentials = connection.getsockopt(
+                socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
+            )
+            return int(struct.unpack("3i", credentials)[1])
+        if hasattr(socket, "LOCAL_PEERCRED"):
+            # struct xucred: version, uid, then the groups. SOL_LOCAL is 0.
+            credentials = connection.getsockopt(0, socket.LOCAL_PEERCRED, 76)
+            return int(struct.unpack_from("II", credentials)[1])
+    except (OSError, struct.error):
+        return None
+    return None
+
+
+@contextlib.contextmanager
+def _in_directory(path: str) -> Iterator[None]:
+    previous = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)

--- a/src/harlequin/hsql/server.py
+++ b/src/harlequin/hsql/server.py
@@ -46,16 +46,13 @@ from harlequin.hsql.session import (
     check_runtime_dir,
     socket_path,
 )
+from harlequin.redact import redact_text
 
 if TYPE_CHECKING:
     from harlequin.adapter import HarlequinConnection
 
 ACCEPT_POLL_SECONDS = 0.5
 """How often the accept loop looks up from the socket to see if it was stopped."""
-
-REQUEST_TIMEOUT_SECONDS = 30.0
-"""How long a connected client has to send its request before it is dropped,
-so that a client that connects and stalls cannot hold a thread forever."""
 
 REPEATED_SIGNAL_SECONDS = 1.0
 """A second stop signal this long after the first is an operator who wants
@@ -77,9 +74,8 @@ class SessionRunning(Exception):
 class Turnstile:
     """One request at a time, in the order they arrived.
 
-    A lock would serve requests in whatever order the interpreter woke the
-    waiters; this hands out tickets so that the client that has waited longest
-    goes next, and so that a waiter can give up on a deadline of its own.
+    Hands out tickets, so the client that has waited longest goes next and a
+    waiter can give up on a deadline of its own.
     """
 
     def __init__(self) -> None:
@@ -136,10 +132,16 @@ class Recorder:
             self.segments.append((kind, bytearray(data)))
 
     def stdout(self) -> io.TextIOWrapper:
-        """A stand-in for `sys.stdout`, whose `.buffer` is what `-o -` writes."""
+        """A stand-in for `sys.stdout`, whose `.buffer` is what `-o -` writes.
+
+        `newline="\n"` is what CPython builds `sys.stdout` with on POSIX, and
+        the bytes are hsql's contract: the default would translate every `\n`
+        this writes to `os.linesep`.
+        """
         return io.TextIOWrapper(
             _Stream(self, protocol.STDOUT, isatty=self._stdout_isatty),
             encoding="utf-8",
+            newline="\n",
             write_through=True,
         )
 
@@ -148,6 +150,7 @@ class Recorder:
             _Stream(self, protocol.STDERR, isatty=self._stderr_isatty),
             encoding="utf-8",
             errors="backslashreplace",
+            newline="\n",
             write_through=True,
         )
 
@@ -203,10 +206,8 @@ class Served:
     def abandon(self) -> None:
         """Note that a cancelled run outlasted its grace period.
 
-        The cold path ends the process here, because a thread still inside a
-        driver aborts an interpreter that exits around it. A server ends the
-        request instead, and offers no connection until it is reset: the next
-        request would otherwise run on a connection another thread still has.
+        The session then offers no connection until it is reset: the next
+        request would otherwise run on one another thread still holds.
         """
         self._server.abandon()
 
@@ -295,8 +296,6 @@ class Server:
             self.name, self._requests, stream=self._stderr
         )
         if self._abandoned:
-            # a thread still inside the driver aborts an interpreter that
-            # exits around it
             from harlequin.hsql.timeout import halt
 
             halt(ExitCode.OK)
@@ -455,9 +454,10 @@ class Server:
                 protocol.send_frame(
                     connection, protocol.HELLO, protocol.VERSION.encode("utf-8")
                 )
-                connection.settimeout(REQUEST_TIMEOUT_SECONDS)
+                # no clock on this read: a `-f -` sends the bytes a human is
+                # still typing, and a client that stalls holds a daemon thread
+                # rather than a turn at the connection
                 frame = protocol.recv_frame(connection)
-                connection.settimeout(None)
                 if frame is None:
                     # a client that refused to be served by this version
                     return
@@ -503,7 +503,10 @@ class Server:
             diagnostics.error(str(e), stream=recorder.stderr())
             return recorder.segments, ExitCode.USAGE
         except Exception as e:  # noqa: BLE001 -- the server outlives a request
-            traceback.print_exc(file=self._stderr)
+            diagnostics.note(
+                f"request failed: {redact_text(traceback.format_exc())}",
+                stream=self._stderr,
+            )
             diagnostics.error(
                 f"the session named {self.name!r} could not run this request: "
                 f"{e or type(e).__name__}",

--- a/src/harlequin/hsql/server.py
+++ b/src/harlequin/hsql/server.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Mapping, Sequence
 
 from harlequin.exception import HarlequinConnectionError
 from harlequin.hsql import diagnostics, protocol
-from harlequin.hsql.diagnostics import ExitCode
+from harlequin.hsql.diagnostics import PROGRAM, ExitCode
 from harlequin.hsql.session import (
     UnsafeRuntimeDir,
     check_runtime_dir,
@@ -49,6 +49,8 @@ from harlequin.hsql.session import (
 from harlequin.redact import redact_text
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from harlequin.adapter import HarlequinConnection
 
 ACCEPT_POLL_SECONDS = 0.5
@@ -503,16 +505,17 @@ class Server:
             diagnostics.error(str(e), stream=recorder.stderr())
             return recorder.segments, ExitCode.USAGE
         except Exception as e:  # noqa: BLE001 -- the server outlives a request
+            # a bug in hsql, which a cold run answers with a crash report and
+            # exit 70 -- so a served one does too, rather than with the code
+            # for SQL the database rejected
             diagnostics.note(
                 f"request failed: {redact_text(traceback.format_exc())}",
                 stream=self._stderr,
             )
-            diagnostics.error(
-                f"the session named {self.name!r} could not run this request: "
-                f"{e or type(e).__name__}",
-                stream=recorder.stderr(),
+            diagnostics.report_crash(
+                _crash_report(e, request), stream=recorder.stderr()
             )
-            return recorder.segments, ExitCode.QUERY
+            return recorder.segments, ExitCode.CRASH
         return recorder.segments, code
 
     @contextlib.contextmanager
@@ -582,6 +585,25 @@ class Server:
             # the client went away; the request ran, and there is nobody to
             # tell about it
             diagnostics.report_client_gone(stream=self._stderr)
+
+
+def _crash_report(error: BaseException, request: protocol.Request) -> "Path | None":
+    """Write a crash report for a bug hit while serving, or None if it could not.
+
+    The same report a cold run writes, so a caller who hit the bug through a
+    session has the same file to attach.
+    """
+    from harlequin.crash import build_crash_report, write_crash_report
+    from harlequin.redact import redact_conn_str
+
+    try:
+        context = {
+            "argv": " ".join(redact_conn_str(list(request.argv))),
+            "session": True,
+        }
+        return write_crash_report(build_crash_report(error, context, program=PROGRAM))
+    except BaseException:
+        return None
 
 
 def _warm_imports() -> None:

--- a/src/harlequin/hsql/session.py
+++ b/src/harlequin/hsql/session.py
@@ -27,6 +27,12 @@ SESSION_ENV_VAR = "HSQL_SESSION"
 SESSION_OPTION = "--session"
 """The typed spelling: an assertion, so an invocation fails without one."""
 
+SERVE_OPTION = "--serve"
+"""The other role. An invocation that starts a session is never sent to one,
+whatever `HSQL_SESSION` says -- or a shell with it set could never start a
+second session -- and a `--session` typed beside it is left for the command
+to refuse, since the client has no parser to refuse it with."""
+
 MAX_NAME_LENGTH = 64
 
 MAX_SOCKET_PATH = 104
@@ -90,6 +96,8 @@ def requested_session(
         if argument == "--":
             # everything after it is an argument, not an option
             break
+        if argument == SERVE_OPTION or argument.startswith(SERVE_OPTION + "="):
+            return None
         if argument.startswith(SESSION_OPTION + "="):
             named = Session(argument.split("=", 1)[1], explicit=True)
         elif argument == SESSION_OPTION:

--- a/src/harlequin/hsql/timeout.py
+++ b/src/harlequin/hsql/timeout.py
@@ -52,9 +52,22 @@ class TimedOut(Exception):
 class Deadline:
     """How long a run may take, and whether its time is up."""
 
-    def __init__(self, seconds: float, *, grace: float | None = None) -> None:
+    def __init__(
+        self,
+        seconds: float,
+        *,
+        grace: float | None = None,
+        abandon: Callable[[], None] | None = None,
+    ) -> None:
         self.seconds = seconds
         self.grace = GRACE_SECONDS if grace is None else grace
+        self.abandon = abandon
+        """What to do when cancelled work outlasts the grace period.
+
+        By default the process ends, with the timeout reported, because a
+        thread still inside a driver aborts an interpreter that exits around
+        it. A session's server ends the request instead and keeps running.
+        """
         self._expired = threading.Event()
 
     @property
@@ -90,13 +103,15 @@ class Deadline:
             # the caller stopped, not one that ran too long
             self._cancel(connection)
             if not finished.wait(self.grace):
-                _halt(ExitCode.INTERRUPT)
+                halt(ExitCode.INTERRUPT)
             raise
         if not in_time:
             self._cancel(connection)
             if not finished.wait(self.grace):
-                diagnostics.report_timeout(self.seconds)
-                _halt(ExitCode.TIMEOUT)
+                if self.abandon is None:
+                    diagnostics.report_timeout(self.seconds)
+                    halt(ExitCode.TIMEOUT)
+                self.abandon()
             raise TimedOut()
         if failure:
             raise failure[0]
@@ -116,7 +131,7 @@ class Deadline:
             connection.cancel()
 
 
-def _halt(code: ExitCode) -> NoReturn:
+def halt(code: ExitCode) -> NoReturn:
     """End the process now, around a worker thread that would abort it."""
     for stream in (sys.stdout, sys.stderr):
         with contextlib.suppress(Exception):

--- a/src/harlequin/schemas/config-v1.json
+++ b/src/harlequin/schemas/config-v1.json
@@ -254,6 +254,15 @@
           "description": "Write the Agent Skill for driving hsql, as markdown. -o installs it: 'hsql --skill -o ~/.claude/skills/hsql/'.",
           "default": false
         },
+        "session_reset": {
+          "type": "boolean",
+          "description": "Ask the session to close its connection and open a fresh one, and exit without running SQL. Temp tables, settings and an open transaction are gone. Needs --session.",
+          "default": false
+        },
+        "queue_timeout": {
+          "type": "number",
+          "description": "With --serve: a request waits at most SECONDS for the one before it, then exits 4 without reaching the database. [default: no limit]"
+        },
         "limit": {
           "type": "integer",
           "description": "Maximum rows fetched per result set. -1 for no limit.",

--- a/tests/hsql_sessions.py
+++ b/tests/hsql_sessions.py
@@ -36,6 +36,7 @@ class WarmSession:
         self.runtime_dir = runtime_dir
         self.env = {"XDG_RUNTIME_DIR": str(runtime_dir)}
         self.stderr_path = runtime_dir / f"{name}.stderr"
+        self._stderr_file = self.stderr_path.open("wb")
         self.process = subprocess.Popen(
             [
                 sys.executable,
@@ -46,7 +47,7 @@ class WarmSession:
                 "main()\n",
             ],
             stdout=subprocess.PIPE,
-            stderr=self.stderr_path.open("wb"),
+            stderr=self._stderr_file,
             cwd=home,
             env={
                 **{
@@ -99,6 +100,7 @@ class WarmSession:
         finally:
             if self.process.stdout is not None:
                 self.process.stdout.close()
+            self._stderr_file.close()
 
 
 ServeSession = Callable[..., WarmSession]

--- a/tests/hsql_sessions.py
+++ b/tests/hsql_sessions.py
@@ -1,0 +1,105 @@
+"""A `hsql --serve` process for tests to talk to, in a fresh interpreter.
+
+Not in-process: a server swaps the process's streams, environment and working
+directory for the length of every request, and pytest owns all three.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Sequence
+
+from harlequin.hsql.session import socket_path
+
+HsqlSubprocess = Callable[..., "subprocess.CompletedProcess[bytes]"]
+"""One invocation of the console script, in a fresh interpreter, as bytes."""
+
+
+class WarmSession:
+    """One session, and the environment a client reaches it through."""
+
+    def __init__(
+        self,
+        name: str,
+        serve_argv: Sequence[str],
+        *,
+        runtime_dir: Path,
+        home: Path,
+    ) -> None:
+        self.name = name
+        self.runtime_dir = runtime_dir
+        self.env = {"XDG_RUNTIME_DIR": str(runtime_dir)}
+        self.stderr_path = runtime_dir / f"{name}.stderr"
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys\n"
+                f"sys.argv = ['hsql', '--serve', {name!r}, *{list(serve_argv)!r}]\n"
+                "from harlequin.hsql import main\n"
+                "main()\n",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=self.stderr_path.open("wb"),
+            cwd=home,
+            env={
+                **{
+                    key: value
+                    for key, value in os.environ.items()
+                    if key not in ("HSQL_SESSION", "NO_COLOR")
+                },
+                "HOME": str(home),
+                "USERPROFILE": str(home),
+                "XDG_CONFIG_HOME": str(home / "xdg"),
+                **self.env,
+            },
+        )
+
+    @property
+    def socket_path(self) -> Path:
+        return Path(socket_path(self.name, self.env))
+
+    def wait_until_ready(self, timeout: float = 30.0) -> None:
+        """Block until the server answers a connection, or it exited."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError(
+                    f"the server exited {self.process.returncode}: {self.stderr()}"
+                )
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                probe.connect(str(self.socket_path))
+            except OSError:
+                time.sleep(0.05)
+                continue
+            finally:
+                probe.close()
+            return
+        raise RuntimeError(f"the server never listened: {self.stderr()}")
+
+    def stderr(self) -> str:
+        return self.stderr_path.read_text(encoding="utf-8", errors="replace")
+
+    def stop(self, timeout: float = 30.0) -> int:
+        """Stop it the way an operator does, and return its exit code."""
+        if self.process.poll() is None:
+            self.process.send_signal(signal.SIGINT)
+        try:
+            return self.process.wait(timeout)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            return self.process.wait(5)
+        finally:
+            if self.process.stdout is not None:
+                self.process.stdout.close()
+
+
+ServeSession = Callable[..., WarmSession]
+"""Start a session under a name, and stop it when the test is done."""

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterator, Mapping, Sequence
 
 import pytest
 
 from harlequin.adapter import HarlequinAdapter
 from harlequin.query import ResultSet, RowLimit, execute, fetch
 from harlequin.statements import split
+from tests.hsql_sessions import HsqlSubprocess, ServeSession, WarmSession
 
 
 @pytest.fixture
@@ -68,3 +71,89 @@ def run_python(tmp_path: Path) -> Callable[[str], subprocess.CompletedProcess[st
         )
 
     return _run
+
+
+@pytest.fixture
+def hsql_subprocess(tmp_path: Path) -> HsqlSubprocess:
+    """Run `main()` the way the console script does, in a fresh interpreter.
+
+    Bytes rather than text, because the bytes are what hsql promises. A clean
+    machine, as `run_python` gives: the child's cwd, home and config dir are
+    empty directories unless a test names a cwd, and no `HSQL_SESSION` of
+    whoever runs the tests reaches it -- a test that wants a session names
+    one in `env`.
+    """
+
+    def _run(
+        argv: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        stdin: bytes | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys\n"
+                f"sys.argv = ['hsql', *{list(argv)!r}]\n"
+                "from harlequin.hsql import main\n"
+                "main()\n",
+            ],
+            capture_output=True,
+            input=stdin,
+            cwd=tmp_path if cwd is None else cwd,
+            env={
+                **{
+                    key: value
+                    for key, value in os.environ.items()
+                    if key not in ("HSQL_SESSION", "NO_COLOR")
+                },
+                "HOME": str(tmp_path),
+                "USERPROFILE": str(tmp_path),
+                "XDG_CONFIG_HOME": str(tmp_path / "xdg"),
+                "APPDATA": str(tmp_path / "appdata"),
+                "LOCALAPPDATA": str(tmp_path / "localappdata"),
+                **(env or {}),
+            },
+        )
+
+    return _run
+
+
+@pytest.fixture
+def short_runtime_dir() -> Iterator[Path]:
+    """A runtime directory a socket path still fits under.
+
+    `sun_path` holds 104 bytes on macOS and pytest's `tmp_path` is longer than
+    that there before a socket name is added.
+    """
+    base = tempfile.mkdtemp(prefix="hsql-", dir="/tmp")
+    yield Path(base)
+    shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.fixture
+def serve_session(short_runtime_dir: Path, tmp_path: Path) -> Iterator[ServeSession]:
+    """Start sessions, and stop every one of them when the test is done."""
+    started: list[WarmSession] = []
+
+    def _serve(
+        name: str = "test",
+        *serve_argv: str,
+        wait: bool = True,
+    ) -> WarmSession:
+        session = WarmSession(
+            name,
+            serve_argv or ("-a", "duckdb", "--no-init", ":memory:"),
+            runtime_dir=short_runtime_dir,
+            home=tmp_path,
+        )
+        started.append(session)
+        if wait:
+            session.wait_until_ready()
+        return session
+
+    yield _serve
+    for session in started:
+        session.stop()

--- a/tests/unit_tests/test_hsql_equivalence.py
+++ b/tests/unit_tests/test_hsql_equivalence.py
@@ -1,0 +1,245 @@
+"""One invocation produces the same bytes cold and warm.
+
+The risk a session carries is not that it fails but that it drifts: that in
+some corner -- a NULL, a `-t` footer, an error's exit code, a truncation notice
+-- the served path and the cold path produce different bytes, and a caller who
+set `HSQL_SESSION` months ago gets an answer the docs do not describe.
+
+The claim is about one invocation, from a fresh session. Given the same
+starting state, an invocation writes the same stdout, the same stderr and exits
+the same whether it ran cold or warm; nothing is claimed about what the *next*
+invocation sees, which is the feature (`@pytest.mark.session_divergent` is
+where those live). So every case here runs twice, both through the real
+console script, and the session is reset between cases.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+from pathlib import Path
+from typing import Iterator, Sequence
+
+import pytest
+
+from harlequin.hsql.diagnostics import ExitCode
+from tests.hsql_sessions import HsqlSubprocess, ServeSession, WarmSession
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"), reason="hsql sessions are POSIX-only"
+)
+
+COLD = ["-a", "duckdb", "--no-init", ":memory:"]
+"""What the session connects with, so a cold run connects the same way."""
+
+TEN_ROWS = (
+    "with recursive t(n) as ("
+    "select 1 union all select n + 1 from t where n < 10"
+    ") select n from t"
+)
+
+ELAPSED = re.compile(rb'"elapsed_ms":\d+')
+"""The one field of `--stats` that two runs of anything never agree on."""
+
+# Cases that connect and run SQL (or error at/after the connect step): cold
+# carries the connection, warm carries the session, and the per-request args
+# are the same. This is the drift surface the design cares about -- a NULL, a
+# footer, a truncation notice, an error's exit code.
+CONNECTING: dict[str, list[str]] = {
+    "select": ["-c", "select 1 as a, 'two' as b, null as c"],
+    "tuples-only": ["-tAc", "select 42"],
+    "psql-algebra": ["--no-header", "--no-footer", "-c", "select 1 as a"],
+    "null-string": ["--null-string", "∅", "-c", "select null as a"],
+    "csv": ["--csv", "-c", "select 1 as a, null as b"],
+    "csv-null": ["--csv", "--null-string", "NULL", "-c", "select null as a"],
+    "json": ["--json", "-c", "select 1 as a, 'x' as b"],
+    "jsonl": ["--jsonl", "-c", "select 1 as a; select 2 as a"],
+    "markdown": ["--markdown", "-c", "select 1 as a"],
+    "vertical": ["-x", "-c", "select 1 as a, 2 as b"],
+    "none": ["--format", "none", "-c", "select 1"],
+    "unicode": ["-c", "select '中文' as a, 'ab' as b"],
+    "types": [
+        "-c",
+        "select 12345.6789::decimal(18, 4) as d, date '2024-03-01' as day, "
+        "[1, 2] as items, {'a': 1} as record, '\\x00\\xFF'::blob as payload",
+    ],
+    "truncated": ["--limit", "3", "-c", TEN_ROWS],
+    "row-cap": ["--display-rows", "2", "-tc", TEN_ROWS],
+    "row-cap-ignored": ["--csv", "--display-rows", "2", "-c", TEN_ROWS],
+    "two-results": ["-c", "select 1 as a", "-c", "select 2 as b"],
+    "result-last": ["--result", "last", "-c", "select 1 as a; select 2 as b"],
+    "result-index": ["--result", "2", "-c", "select 1 as a; select 2 as b"],
+    "result-out-of-range": ["--result", "9", "-c", "select 1"],
+    "one-csv-two-results": ["--csv", "-c", "select 1; select 2"],
+    "on-error-stop": ["-c", "select * from nowhere; select 1 as after"],
+    "on-error-continue": [
+        "--on-error",
+        "continue",
+        "-c",
+        "select * from nowhere; select 1 as after",
+    ],
+    "query-error": ["-c", "select from"],
+    "empty-result": ["--csv", "-c", "select 1 as a where false"],
+    "stats": ["--stats", "--limit", "3", "-c", TEN_ROWS],
+    "stats-error": ["--stats", "-c", "select * from nowhere"],
+    "color-always": ["--color", "always", "-c", "select 1 as a"],
+    "color-never": ["--color", "never", "-c", "select 1 as a"],
+    "two-formats": ["--csv", "--json", "-c", "select 1"],
+    "path-without-catalog": ["--path", "x", "-c", "select 1"],
+    "catalog": ["--catalog"],
+    "catalog-path": ["--catalog", "--path", "memory.main"],
+    "catalog-search": ["--catalog-search", "zzz"],
+    "catalog-limit-ignored": ["--catalog", "--limit", "5"],
+    "file": ["-tAf", "q.sql"],
+    "file-missing": ["-f", "missing.sql"],
+    "stdin": ["--csv", "-f", "-"],
+    "output-file": ["--csv", "-o", "out.csv", "-c", "select 1 as a"],
+    "output-dir": ["--csv", "-o", "results/", "-c", "select 1 as a; select 2 as b"],
+    "output-parquet": [
+        "--format",
+        "parquet",
+        "-o",
+        "out.parquet",
+        "-c",
+        "select 1 as a",
+    ],
+}
+
+# Cases that never reach the connection: the modes, and the usage errors caught
+# before connecting. The session runs them through the same command the cold
+# path builds, so cold and warm run the identical argv -- warm just names the
+# session -- and the equivalence is that the session did nothing to the bytes.
+LOCAL: dict[str, list[str]] = {
+    "bare": [],
+    "bad-flag": ["--nope"],
+    "two-modes": ["--catalog", "--spec"],
+    "help": ["--help"],
+    "version": ["--version"],
+    "spec": ["--spec", "-a", "duckdb"],
+    "info": ["--info", "-a", "duckdb"],
+    "config-show": ["--config", "show"],
+    "config-list-profiles": ["--config", "list-profiles"],
+    "skill": ["--skill"],
+}
+
+STDIN = b"select 'piped' as a"
+
+
+@pytest.fixture(scope="module")
+def session(serve_session_module: ServeSession) -> WarmSession:
+    return serve_session_module("eq")
+
+
+@pytest.fixture(scope="module")
+def serve_session_module(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[ServeSession]:
+    """One server per module per xdist worker -- and, below, a fresh session
+    per case, which is what makes a shared server safe."""
+    import shutil
+    import tempfile
+
+    runtime_dir = Path(tempfile.mkdtemp(prefix="hsql-", dir="/tmp"))
+    home = tmp_path_factory.mktemp("session-home")
+    started: list[WarmSession] = []
+
+    def _serve(name: str) -> WarmSession:
+        started.append(WarmSession(name, COLD, runtime_dir=runtime_dir, home=home))
+        started[-1].wait_until_ready()
+        return started[-1]
+
+    yield _serve
+    for session in started:
+        session.stop()
+    shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def fresh(session: WarmSession, hsql_subprocess: HsqlSubprocess) -> WarmSession:
+    """Equivalence holds from a fresh session, so every case gets one."""
+    proc = hsql_subprocess(
+        ["--session", session.name, "--session-reset"], env=session.env
+    )
+    assert proc.returncode == ExitCode.OK, proc.stderr
+    return session
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """What the cases that read or write files find where they run."""
+    (tmp_path / "q.sql").write_text("select 'from a file' as a")
+    return tmp_path
+
+
+def _normalize(stream: bytes) -> bytes:
+    return ELAPSED.sub(b'"elapsed_ms":N', stream)
+
+
+def _both(
+    hsql_subprocess: HsqlSubprocess,
+    workspace: Path,
+    fresh: WarmSession,
+    cold_argv: Sequence[str],
+    warm_argv: Sequence[str],
+    *,
+    stdin: bytes | None,
+) -> None:
+    cold_dir, warm_dir = workspace / "cold", workspace / "warm"
+    for directory in (cold_dir, warm_dir):
+        directory.mkdir()
+        (directory / "q.sql").write_bytes((workspace / "q.sql").read_bytes())
+
+    cold = hsql_subprocess(cold_argv, cwd=cold_dir, stdin=stdin)
+    warm = hsql_subprocess(
+        ["--session", fresh.name, *warm_argv], cwd=warm_dir, stdin=stdin, env=fresh.env
+    )
+
+    assert warm.returncode == cold.returncode
+    assert warm.stdout == cold.stdout
+    assert _normalize(warm.stderr) == _normalize(cold.stderr)
+    cold_files = {
+        p.relative_to(cold_dir): p.read_bytes()
+        for p in cold_dir.rglob("*")
+        if p.is_file()
+    }
+    warm_files = {
+        p.relative_to(warm_dir): p.read_bytes()
+        for p in warm_dir.rglob("*")
+        if p.is_file()
+    }
+    assert warm_files == cold_files
+
+
+@pytest.mark.parametrize("argv", list(CONNECTING.values()), ids=list(CONNECTING))
+def test_a_query_is_the_same_bytes_cold_and_warm(
+    argv: Sequence[str],
+    fresh: WarmSession,
+    hsql_subprocess: HsqlSubprocess,
+    workspace: Path,
+) -> None:
+    """Cold connects for itself; warm runs on the session's connection. Same
+    starting state, same bytes."""
+    stdin = STDIN if "-" in argv else None
+    _both(hsql_subprocess, workspace, fresh, [*COLD, *argv], argv, stdin=stdin)
+
+
+@pytest.mark.parametrize("argv", list(LOCAL.values()), ids=list(LOCAL))
+def test_a_mode_is_the_same_bytes_cold_and_warm(
+    argv: Sequence[str],
+    fresh: WarmSession,
+    hsql_subprocess: HsqlSubprocess,
+    workspace: Path,
+) -> None:
+    """A mode reads no database, so the session runs the identical argv the
+    cold path would, and must not touch the bytes on the way."""
+    _both(hsql_subprocess, workspace, fresh, argv, argv, stdin=None)
+
+
+def test_the_cases_cover_every_exit_code_but_the_signals(
+    fresh: WarmSession, hsql_subprocess: HsqlSubprocess, workspace: Path
+) -> None:
+    """A drift in an exit code is the one a script notices last."""
+    codes = set()
+    for argv in (CONNECTING["select"], CONNECTING["query-error"], LOCAL["bad-flag"]):
+        codes.add(hsql_subprocess([*COLD, *argv], cwd=workspace).returncode)
+    assert codes == {ExitCode.OK, ExitCode.QUERY, ExitCode.USAGE}

--- a/tests/unit_tests/test_hsql_equivalence.py
+++ b/tests/unit_tests/test_hsql_equivalence.py
@@ -41,10 +41,9 @@ TEN_ROWS = (
 ELAPSED = re.compile(rb'"elapsed_ms":\d+')
 """The one field of `--stats` that two runs of anything never agree on."""
 
-# Cases that connect and run SQL (or error at/after the connect step): cold
-# carries the connection, warm carries the session, and the per-request args
-# are the same. This is the drift surface the design cares about -- a NULL, a
-# footer, a truncation notice, an error's exit code.
+# Cases that connect and run SQL, or error at the connect step: cold carries
+# the connection, warm carries the session, and the per-request args are the
+# same on both sides.
 CONNECTING: dict[str, list[str]] = {
     "select": ["-c", "select 1 as a, 'two' as b, null as c"],
     "tuples-only": ["-tAc", "select 42"],

--- a/tests/unit_tests/test_hsql_serve.py
+++ b/tests/unit_tests/test_hsql_serve.py
@@ -439,6 +439,28 @@ def test_a_deadline_a_server_gave_an_abandon_hook_ends_the_run_not_the_process()
     never.set()
 
 
+def test_a_bug_in_hsql_is_exit_70_through_a_session_too(
+    in_process_server: Server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crash is the one failure a session could answer differently from a
+    cold run: 70 says a bug in hsql and 1 says the database rejected the SQL,
+    which is the confusion `CRASH` exists to remove. The client gets the same
+    diagnostic either way, and the session goes on serving."""
+
+    def boom(*args: Any, **kwargs: Any) -> int:
+        raise RuntimeError("simulated bug")
+
+    monkeypatch.setattr("harlequin.hsql.cli.run", boom)
+    request = protocol.Request(
+        argv=["-c", "select 1"], cwd=os.getcwd(), environ={}, stdin=None
+    )
+    segments, code = in_process_server._run(request)
+    assert code == ExitCode.CRASH
+    stderr = b"".join(bytes(d) for kind, d in segments if kind == protocol.STDERR)
+    assert b"hsql hit a bug in itself" in stderr
+    assert not any(kind == protocol.STDOUT for kind, _ in segments)
+
+
 def test_an_abandoned_connection_is_offered_to_nobody_until_a_reset() -> None:
     """A cancel that outlasts its grace leaves the connection to the thread
     still inside it, so `abandon()` marks the session unusable until a reset,

--- a/tests/unit_tests/test_hsql_serve.py
+++ b/tests/unit_tests/test_hsql_serve.py
@@ -28,6 +28,7 @@ from click.testing import CliRunner, Result
 from harlequin.exception import HarlequinConnectionError
 from harlequin.hsql import protocol, server
 from harlequin.hsql.cli import (
+    CONFIG_OPTIONS,
     CONNECTION_OPTIONS,
     PER_REQUEST_OPTIONS,
     ROLE_OPTIONS,
@@ -91,7 +92,13 @@ def test_every_option_is_in_exactly_one_group() -> None:
     group and a served request refuses the server's, so an option in neither
     or in both would be one nobody refuses -- or one both do."""
     declared = {param.name for param in bare_command().params if param.name}
-    groups = [CONNECTION_OPTIONS, PER_REQUEST_OPTIONS, SERVER_OPTIONS, ROLE_OPTIONS]
+    groups = [
+        CONNECTION_OPTIONS,
+        CONFIG_OPTIONS,
+        PER_REQUEST_OPTIONS,
+        SERVER_OPTIONS,
+        ROLE_OPTIONS,
+    ]
     assert declared == set().union(*groups)
     for first in groups:
         for second in groups:
@@ -149,10 +156,13 @@ def test_serve_does_not_reset(hsql: Hsql) -> None:
 @pytest.mark.parametrize(
     "name,reason",
     [
+        # a flag with no value is the caller's typo on every platform, so it is
+        # answered before the platform is; the rest reach the name check only
+        # where a session could have run
         ("", "needs a name"),
-        ("bad name", "is not a session name"),
-        ("../etc", "is not a session name"),
-        ("x" * 65, "is not a session name"),
+        pytest.param("bad name", "is not a session name", marks=needs_unix_sockets),
+        pytest.param("../etc", "is not a session name", marks=needs_unix_sockets),
+        pytest.param("x" * 65, "is not a session name", marks=needs_unix_sockets),
     ],
 )
 def test_serve_refuses_a_name_no_client_could_reach(
@@ -242,19 +252,60 @@ def test_a_served_request_may_not_type_a_connection_option(
 ) -> None:
     """The session connected when it started, so its connection is fixed: a
     request that typed a connection option would otherwise run on the session's
-    connection while believing it had changed it. (Comparing the value against
-    the session's, so an identical one is served, is PR 3's refinement.)
-
-    -P and --config-path are connection options too, but they fail earlier, in
-    the first pass that reads them -- also an exit 2, and also before any query
-    runs on the wrong connection.
-    """
+    connection while believing it had changed it."""
     res = hsql(*args, "-c", "select 1", obj=served_by(in_process_server))
     assert res.exit_code == ExitCode.USAGE
     assert res.stdout == ""
     assert "is a connection option, and the session named 'inproc' connected" in (
         res.stderr
     )
+
+
+def test_a_served_request_takes_a_profile_of_per_request_options(
+    hsql: Hsql, in_process_server: Server, tmp_path: Path
+) -> None:
+    """A profile names where options come from rather than being one, so what
+    it holds decides: nothing here says which database, so it applies -- the
+    same way a `default_profile` discovered in the caller's directory does."""
+    path = tmp_path / "hsql.toml"
+    path.write_text('[profiles.csv-out]\nformat = "csv"\nlimit = 5\n')
+    res = hsql(
+        "--config-path",
+        path,
+        "-P",
+        "csv-out",
+        "-c",
+        "select 1 as a",
+        obj=served_by(in_process_server),
+    )
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "a\n1\n"
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("adapter", '"sqlite"'), ("read_only", "true"), ("conn_str", '["other.db"]')],
+)
+def test_a_served_request_refuses_a_profile_that_names_a_connection(
+    hsql: Hsql, in_process_server: Server, tmp_path: Path, key: str, value: str
+) -> None:
+    """A typed profile that answers what the session answered at start-up is
+    refused under the key that answers it, rather than as a flag."""
+    path = tmp_path / "hsql.toml"
+    path.write_text(f"[profiles.prod]\n{key} = {value}\n")
+    res = hsql(
+        "--config-path",
+        path,
+        "-P",
+        "prod",
+        "-c",
+        "select 1",
+        obj=served_by(in_process_server),
+    )
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert f"the profile 'prod' sets {key}" in res.stderr
+    assert "--serve NAME -P prod" in res.stderr
 
 
 def test_a_served_request_may_not_type_a_server_option(
@@ -375,10 +426,9 @@ class _FakeConnection:
 def test_a_deadline_a_server_gave_an_abandon_hook_ends_the_run_not_the_process() -> (
     None
 ):
-    """The cold path ends the process when cancelled work outlasts the grace,
-    because a thread inside a driver aborts an interpreter exiting around it.
-    A server has to keep running, so its deadline calls an abandon hook instead
-    of halting, and raises TimedOut for the request to attribute."""
+    """Where the cold path halts the process, a deadline given an abandon hook
+    calls it and raises TimedOut for the request to attribute, so the server
+    lives on."""
     abandoned: list[bool] = []
     never = threading.Event()
     connection: Any = _FakeConnection("held")
@@ -421,26 +471,35 @@ def test_the_turnstile_serves_in_arrival_order() -> None:
     turnstile = server.Turnstile()
     order: list[int] = []
     assert turnstile.enter(None)
-    ready = threading.Barrier(3)
 
     def wait_turn(number: int) -> None:
-        ready.wait()
-        # a moment apart, so that the tickets are handed out in this order
-        time.sleep(0.05 * number)
         turnstile.enter(None)
         order.append(number)
         turnstile.leave()
 
-    threads = [threading.Thread(target=wait_turn, args=(n,)) for n in (1, 2)]
-    for thread in threads:
+    threads = []
+    for number in (1, 2):
+        thread = threading.Thread(target=wait_turn, args=(number,))
         thread.start()
-    ready.wait()
-    time.sleep(0.3)
-    assert turnstile.queued == 2
+        threads.append(thread)
+        # each ticket is taken before the next thread starts, so the arrival
+        # order is this loop's rather than the scheduler's
+        _until(lambda waiting=number: turnstile.queued == waiting)  # type: ignore[misc]
+
     turnstile.leave()
     for thread in threads:
         thread.join(5)
     assert order == [1, 2]
+
+
+def _until(condition: Callable[[], bool], timeout: float = 10.0) -> None:
+    """Block until `condition` holds, so a test orders threads by observation."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        time.sleep(0.005)
+    raise AssertionError("the condition never held")
 
 
 def test_the_turnstile_gives_up_on_a_deadline() -> None:
@@ -771,6 +830,22 @@ def test_a_client_that_dies_mid_query_does_not_take_the_session_down(
 
 
 @needs_unix_sockets
+def test_a_timeout_stops_the_request_and_leaves_the_session_up(
+    send: HsqlSubprocess,
+) -> None:
+    """The whole chain a served `--timeout` crosses: the deadline cancels, the
+    request attributes it and exits 4, and the session is usable straight
+    after -- DuckDB's cancel lands inside the grace period, so the connection
+    is never abandoned. (The grace running out is `Deadline`'s own test: no
+    adapter that cancels can reach it.)"""
+    proc = send(["--timeout", "0.1", "-c", "select count(*) from range(2000000000)"])
+    assert proc.returncode == ExitCode.TIMEOUT
+    assert proc.stdout == b""
+    assert b"timed out after 0.1s" in proc.stderr
+    assert send(["-tAc", "select 'still up'"]).stdout == b"still up\n"
+
+
+@needs_unix_sockets
 def test_a_queue_timeout_is_not_a_query_timeout(
     serve_session: ServeSession,
     hsql_subprocess: HsqlSubprocess,
@@ -898,6 +973,7 @@ def test_color_auto_reads_the_callers_terminal(warm: WarmSession) -> None:
     assert b"\x1b[" not in b"".join(data for _, data in honored)
 
 
+@needs_unix_sockets
 def test_the_peer_uid_is_ours_on_a_socketpair() -> None:
     left, right = socket.socketpair(socket.AF_UNIX)
     with left, right:

--- a/tests/unit_tests/test_hsql_serve.py
+++ b/tests/unit_tests/test_hsql_serve.py
@@ -1,0 +1,905 @@
+"""The half of a warm session that holds the connection: `hsql --serve`.
+
+What is asserted here is the server's half of the contract: which options each
+role takes, that requests run one at a time on one connection, that the
+session's state is what `--session-reset` clears, and the ways a session comes
+down. Byte-equivalence with the cold path is `test_hsql_equivalence.py`'s.
+
+Servers run in a fresh interpreter, because a server swaps the process's
+streams, environment and working directory for every request; the command's
+own refusals run in process, through the same `Served` the server hands it.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator, Sequence
+
+import click
+import pytest
+from click.testing import CliRunner, Result
+
+from harlequin.exception import HarlequinConnectionError
+from harlequin.hsql import protocol, server
+from harlequin.hsql.cli import (
+    CONNECTION_OPTIONS,
+    PER_REQUEST_OPTIONS,
+    ROLE_OPTIONS,
+    SERVER_OPTIONS,
+    bare_command,
+    build_cli,
+)
+from harlequin.hsql.diagnostics import ExitCode
+from harlequin.hsql.server import Served, Server
+from harlequin.hsql.timeout import Deadline, TimedOut
+from tests.hsql_sessions import HsqlSubprocess, ServeSession, WarmSession
+
+needs_unix_sockets = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"), reason="hsql sessions are POSIX-only"
+)
+
+Hsql = Callable[..., Result]
+
+
+@pytest.fixture
+def hsql(no_discovered_config: None) -> Hsql:
+    """Invoke hsql in process, cold, or served when `obj` names a session."""
+    runner = CliRunner()
+
+    def _run(*args: str, **kwargs: Any) -> Result:
+        argv = [str(arg) for arg in args]
+        return runner.invoke(build_cli(argv), argv, catch_exceptions=False, **kwargs)
+
+    return _run
+
+
+@pytest.fixture
+def duck() -> list[str]:
+    return ["-a", "duckdb", "--no-init", ":memory:"]
+
+
+@pytest.fixture
+def in_process_server(duckdb_adapter: Any) -> Server:
+    """A session with a real DuckDB connection, and no socket."""
+    adapter = duckdb_adapter([":memory:"], no_init=True)
+    return Server(
+        "inproc",
+        adapter="duckdb",
+        connection=adapter.connect(),
+        reconnect=adapter.connect,
+    )
+
+
+def served_by(server: Server, *, stdin: bytes | None = None) -> Served:
+    return Served(
+        server,
+        protocol.Request(argv=[], cwd=os.getcwd(), environ={}, stdin=stdin),
+    )
+
+
+# --- the partition -----------------------------------------------------------
+
+
+def test_every_option_is_in_exactly_one_group() -> None:
+    """The rule that defines the two roles: `--serve` refuses the per-request
+    group and a served request refuses the server's, so an option in neither
+    or in both would be one nobody refuses -- or one both do."""
+    declared = {param.name for param in bare_command().params if param.name}
+    groups = [CONNECTION_OPTIONS, PER_REQUEST_OPTIONS, SERVER_OPTIONS, ROLE_OPTIONS]
+    assert declared == set().union(*groups)
+    for first in groups:
+        for second in groups:
+            if first is not second:
+                assert not first & second
+
+
+def test_an_adapters_options_are_connection_options(hsql: Hsql) -> None:
+    """The command declares none of them, so they are the group by default."""
+    res = hsql("--serve", "prod", "-a", "duckdb", "--no-init", "--csv")
+    assert res.exit_code == ExitCode.USAGE
+    # `--csv` is refused, and `--no-init` was not -- it came first on the line
+    assert "--csv is a per-request option" in res.stderr
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["-c", "select 1"],
+        ["-f", "script.sql"],
+        ["--format", "csv"],
+        ["--limit", "10"],
+        ["--timeout", "5"],
+        ["--catalog"],
+        ["--info"],
+        ["-o", "out.csv"],
+        ["--stats"],
+    ],
+)
+def test_serve_refuses_per_request_options(hsql: Hsql, args: list[str]) -> None:
+    """The feature's most likely first mistake, so the message names the right
+    invocation rather than only the wrong one."""
+    res = hsql("--serve", "prod", *args)
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "is a per-request option, and --serve takes none" in res.stderr
+    assert "hsql --serve prod" in res.stderr
+    assert "hsql --session prod" in res.stderr
+
+
+def test_serve_and_session_are_two_roles(hsql: Hsql) -> None:
+    res = hsql("--serve", "a", "--session", "b")
+    assert res.exit_code == ExitCode.USAGE
+    assert "--serve starts a session and --session sends to one" in res.stderr
+
+
+def test_serve_does_not_reset(hsql: Hsql) -> None:
+    """--session-reset is a client operation -- it asks a running session --
+    so on --serve it is refused as the per-request option it is."""
+    res = hsql("--serve", "a", "--session-reset")
+    assert res.exit_code == ExitCode.USAGE
+    assert "is a per-request option, and --serve takes none" in res.stderr
+
+
+@pytest.mark.parametrize(
+    "name,reason",
+    [
+        ("", "needs a name"),
+        ("bad name", "is not a session name"),
+        ("../etc", "is not a session name"),
+        ("x" * 65, "is not a session name"),
+    ],
+)
+def test_serve_refuses_a_name_no_client_could_reach(
+    hsql: Hsql, name: str, reason: str
+) -> None:
+    """Asked with the client's own check, and before a connection is paid for."""
+    res = hsql("--serve", name, "-a", "duckdb", ":memory:")
+    assert res.exit_code == ExitCode.USAGE
+    assert reason in res.stderr
+
+
+def test_queue_timeout_belongs_to_serve(hsql: Hsql, duck: list[str]) -> None:
+    res = hsql(*duck, "--queue-timeout", "2", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert "--queue-timeout is a --serve option" in res.stderr
+
+
+def test_session_reset_needs_a_session(hsql: Hsql) -> None:
+    """It reconnects a running session, so with none named there is nothing to
+    do -- and it attaches no adapter options, so it takes no connection args."""
+    res = hsql("--session-reset")
+    assert res.exit_code == ExitCode.USAGE
+    assert "names none" in res.stderr
+    assert "HSQL_SESSION" in res.stderr
+
+
+def test_a_session_flag_that_reached_the_parser_is_refused(
+    hsql: Hsql, duck: list[str]
+) -> None:
+    """`main()` reads it before it parses anything, so only a caller that built
+    the command some other way can put it here."""
+    res = hsql(*duck, "--session", "prod", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert "--session prod is read before hsql parses anything else" in res.stderr
+
+
+@pytest.mark.parametrize("key", ["session", "serve"])
+def test_a_profile_may_not_say_which_process_runs_an_invocation(
+    hsql: Hsql, tmp_path: Path, key: str
+) -> None:
+    """The `CLI_ONLY_SSH_KEYS`-shaped refusal: `session` is decided before any
+    config file is read, and a profile that served would turn a query into a
+    daemon."""
+    path = tmp_path / "hsql.toml"
+    path.write_text(f'[profiles.prod]\nadapter = "duckdb"\n{key} = "prod"\n')
+    res = hsql("--config-path", path, "-P", "prod", "-c", "select 1")
+    assert res.exit_code == ExitCode.USAGE
+    assert f"{key} says which process runs an invocation" in res.stderr
+    assert f"--{key}" in res.stderr
+
+
+def test_a_profiles_session_key_is_not_in_the_schema() -> None:
+    from harlequin.config_schema import build_schema
+
+    profile = build_schema(bare_command().params, adapters=None)["$defs"]["profile"][
+        "properties"
+    ]
+    assert "session" not in profile
+    assert "serve" not in profile
+    # while the keys a profile may set are
+    assert "queue_timeout" in profile
+
+
+def test_session_is_a_profile_key_the_ide_leaves_alone() -> None:
+    """One profile serves both commands, and the IDE reads hsql's keys off the
+    command rather than a copy, so the new ones are there without a change."""
+    from harlequin.cli import hsql_profile_keys
+
+    assert {"session", "serve", "session_reset", "queue_timeout"} <= hsql_profile_keys()
+
+
+# --- a served request, in process --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["-a", "sqlite"],
+        ["--read-only"],
+        ["--ssh-host", "bastion"],
+        ["--no-init"],
+        ["other.db"],
+    ],
+)
+def test_a_served_request_may_not_type_a_connection_option(
+    hsql: Hsql, in_process_server: Server, args: list[str]
+) -> None:
+    """The session connected when it started, so its connection is fixed: a
+    request that typed a connection option would otherwise run on the session's
+    connection while believing it had changed it. (Comparing the value against
+    the session's, so an identical one is served, is PR 3's refinement.)
+
+    -P and --config-path are connection options too, but they fail earlier, in
+    the first pass that reads them -- also an exit 2, and also before any query
+    runs on the wrong connection.
+    """
+    res = hsql(*args, "-c", "select 1", obj=served_by(in_process_server))
+    assert res.exit_code == ExitCode.USAGE
+    assert res.stdout == ""
+    assert "is a connection option, and the session named 'inproc' connected" in (
+        res.stderr
+    )
+
+
+def test_a_served_request_may_not_type_a_server_option(
+    hsql: Hsql, in_process_server: Server
+) -> None:
+    res = hsql(
+        "--queue-timeout", "3", "-c", "select 1", obj=served_by(in_process_server)
+    )
+    assert res.exit_code == ExitCode.USAGE
+    assert "--queue-timeout is a --serve option, and the session named 'inproc'" in (
+        res.stderr
+    )
+
+
+def test_a_served_request_may_not_serve(hsql: Hsql, in_process_server: Server) -> None:
+    res = hsql("--serve", "other", obj=served_by(in_process_server))
+    assert res.exit_code == ExitCode.USAGE
+    assert "pass one of them" in res.stderr
+
+
+def test_a_mode_that_reads_no_database_is_not_the_sessions_business(
+    hsql: Hsql, in_process_server: Server
+) -> None:
+    """`--info -a sqlite` narrows a document; it does not ask to reconnect."""
+    res = hsql("--info", "-a", "sqlite", obj=served_by(in_process_server))
+    assert res.exit_code == ExitCode.OK
+    assert '"sqlite"' in res.stdout
+
+
+def test_a_served_request_runs_on_the_sessions_connection(
+    hsql: Hsql, in_process_server: Server
+) -> None:
+    served = served_by(in_process_server)
+    assert hsql("-c", "create temp table t as select 1 as v", obj=served).exit_code == 0
+    res = hsql("-tAc", "select v from t", obj=served)
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "1\n"
+
+
+def test_a_dash_f_dash_with_no_stdin_is_refused(
+    hsql: Hsql, in_process_server: Server
+) -> None:
+    """The client's argv scan misses a `-f` behind a boolean short an adapter
+    declares, and an empty script run as if it were what was piped is the
+    silent failure this turns into an exit 2."""
+    res = hsql("-f", "-", obj=served_by(in_process_server, stdin=None))
+    assert res.exit_code == ExitCode.USAGE
+    assert "carried none" in res.stderr
+    assert "--file -" in res.stderr
+
+
+def test_a_dash_f_dash_with_stdin_is_allowed(
+    hsql: Hsql, in_process_server: Server
+) -> None:
+    """The guard refuses only a `-f -` whose request carried no stdin; with one
+    it reads the caller's SQL. (The bytes come through the server's own stdin
+    stand-in end to end; here the CliRunner supplies them.)"""
+    served = served_by(in_process_server, stdin=b"select 5 as five")
+    res = hsql("-tAf", "-", obj=served, input="select 5 as five")
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == "5\n"
+
+
+def test_session_reset_reconnects(hsql: Hsql, in_process_server: Server) -> None:
+    served = served_by(in_process_server)
+    hsql("-c", "create temp table t as select 1 as v", obj=served)
+    res = hsql("--session-reset", obj=served)
+    assert res.exit_code == ExitCode.OK
+    assert res.stdout == ""
+    assert "reconnected" in res.stderr
+    assert hsql("-c", "select v from t", obj=served).exit_code == ExitCode.QUERY
+
+
+def test_a_reset_that_cannot_reconnect_leaves_the_session_without_a_connection(
+    hsql: Hsql, duckdb_adapter: Any
+) -> None:
+    """Exit 3 for the reset, and exit 3 for every request after it until a
+    reset succeeds: a session with no connection says so rather than pretending."""
+    adapter = duckdb_adapter([":memory:"], no_init=True)
+    attempts: list[int] = []
+
+    def reconnect() -> Any:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise HarlequinConnectionError("the warehouse is down")
+        return adapter.connect()
+
+    session = Server(
+        "flaky", adapter="duckdb", connection=adapter.connect(), reconnect=reconnect
+    )
+    served = served_by(session)
+    res = hsql("--session-reset", obj=served)
+    assert res.exit_code == ExitCode.CONNECTION
+    assert "the warehouse is down" in res.stderr
+    res = hsql("-c", "select 1", obj=served)
+    assert res.exit_code == ExitCode.CONNECTION
+    assert "has no connection" in res.stderr
+    assert "--session-reset" in res.stderr
+    assert hsql("--session-reset", obj=served).exit_code == ExitCode.OK
+    assert hsql("-c", "select 1", obj=served).exit_code == ExitCode.OK
+
+
+# --- a cancel that does not land ---------------------------------------------
+
+
+class _FakeConnection:
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.closed = False
+
+    def cancel(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_a_deadline_a_server_gave_an_abandon_hook_ends_the_run_not_the_process() -> (
+    None
+):
+    """The cold path ends the process when cancelled work outlasts the grace,
+    because a thread inside a driver aborts an interpreter exiting around it.
+    A server has to keep running, so its deadline calls an abandon hook instead
+    of halting, and raises TimedOut for the request to attribute."""
+    abandoned: list[bool] = []
+    never = threading.Event()
+    connection: Any = _FakeConnection("held")
+    deadline = Deadline(0.01, grace=0.01, abandon=lambda: abandoned.append(True))
+    with pytest.raises(TimedOut):
+        deadline.run(lambda: never.wait(30), connection=connection)
+    assert abandoned == [True]
+    never.set()
+
+
+def test_an_abandoned_connection_is_offered_to_nobody_until_a_reset() -> None:
+    """A cancel that outlasts its grace leaves the connection to the thread
+    still inside it, so `abandon()` marks the session unusable until a reset,
+    rather than handing the next request a connection another thread holds."""
+    opened: list[Any] = [_FakeConnection("first")]
+
+    def reconnect() -> Any:
+        opened.append(_FakeConnection(f"reconnect-{len(opened)}"))
+        return opened[-1]
+
+    session = Server(
+        "stuck", adapter="duckdb", connection=opened[0], reconnect=reconnect
+    )
+    assert session.connection() is opened[0]
+    session.abandon()
+    with pytest.raises(HarlequinConnectionError) as raised:
+        session.connection()
+    assert "cancelled a query that did not stop" in raised.value.msg
+    assert "--session-reset" in raised.value.msg
+    # the abandoned connection is left to its thread, not closed under it
+    assert not opened[0].closed  # type: ignore[attr-defined]
+    session.reset()
+    assert session.connection() is opened[-1]
+
+
+# --- the turnstile ---------------------------------------------------------------
+
+
+def test_the_turnstile_serves_in_arrival_order() -> None:
+    turnstile = server.Turnstile()
+    order: list[int] = []
+    assert turnstile.enter(None)
+    ready = threading.Barrier(3)
+
+    def wait_turn(number: int) -> None:
+        ready.wait()
+        # a moment apart, so that the tickets are handed out in this order
+        time.sleep(0.05 * number)
+        turnstile.enter(None)
+        order.append(number)
+        turnstile.leave()
+
+    threads = [threading.Thread(target=wait_turn, args=(n,)) for n in (1, 2)]
+    for thread in threads:
+        thread.start()
+    ready.wait()
+    time.sleep(0.3)
+    assert turnstile.queued == 2
+    turnstile.leave()
+    for thread in threads:
+        thread.join(5)
+    assert order == [1, 2]
+
+
+def test_the_turnstile_gives_up_on_a_deadline() -> None:
+    turnstile = server.Turnstile()
+    assert turnstile.enter(None)
+    started = time.monotonic()
+    assert not turnstile.enter(0.05)
+    assert time.monotonic() - started < 2
+    assert turnstile.queued == 0
+    turnstile.leave()
+    assert turnstile.enter(0.05)
+
+
+# --- the recorder -------------------------------------------------------------------
+
+
+def test_the_recorder_keeps_the_order_the_streams_were_written_in() -> None:
+    """A note between two result sets reaches the terminal between them."""
+    recorder = server.Recorder(stdout_isatty=True)
+    out, err = recorder.stdout(), recorder.stderr()
+    out.write("one\n")
+    out.buffer.write(b"two\n")
+    err.write("note\n")
+    out.write("three\n")
+    assert [(kind, bytes(data)) for kind, data in recorder.segments] == [
+        (protocol.STDOUT, b"one\ntwo\n"),
+        (protocol.STDERR, b"note\n"),
+        (protocol.STDOUT, b"three\n"),
+    ]
+    assert out.isatty() and not err.isatty()
+
+
+def test_click_writes_binary_output_to_the_recorder() -> None:
+    """`-o -` is `click.open_file("-", "wb")`, which has to find the buffer."""
+    recorder = server.Recorder()
+    stream = recorder.stdout()
+    saved = sys.stdout
+    sys.stdout = stream
+    try:
+        click.open_file("-", mode="wb").write(b"bytes\n")
+        click.echo("text")
+    finally:
+        sys.stdout = saved
+    assert bytes(recorder.segments[0][1]) == b"bytes\ntext\n"
+
+
+# --- a real server, in a fresh interpreter -------------------------------------
+
+
+@pytest.fixture
+def warm(serve_session: ServeSession) -> WarmSession:
+    return serve_session("warm")
+
+
+@pytest.fixture
+def send(hsql_subprocess: HsqlSubprocess, warm: WarmSession) -> HsqlSubprocess:
+    """One invocation, sent to the session by the real console script."""
+
+    def _send(argv: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        return hsql_subprocess(["--session", warm.name, *argv], env=warm.env, **kwargs)
+
+    return _send
+
+
+@needs_unix_sockets
+def test_a_session_answers(send: HsqlSubprocess, warm: WarmSession) -> None:
+    proc = send(["-c", "select 1 as a"])
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b" a\n---\n 1\n(1 row)\n"
+    assert proc.stderr == b""
+
+
+@needs_unix_sockets
+@pytest.mark.session_divergent
+def test_a_temp_table_survives_between_invocations(
+    send: HsqlSubprocess, hsql_subprocess: HsqlSubprocess
+) -> None:
+    """The single most useful thing about the feature, and the one nobody reads
+    the docs to discover. Cold, the second invocation has no such table."""
+    assert (
+        send(
+            ["--format", "none", "-c", "create temp table t as select 7 as v"]
+        ).returncode
+        == 0
+    )
+    warm_result = send(["-tAc", "select v from t"])
+    assert warm_result.returncode == ExitCode.OK
+    assert warm_result.stdout == b"7\n"
+    cold = ["-a", "duckdb", "--no-init", ":memory:"]
+    assert (
+        hsql_subprocess(
+            [*cold, "-c", "create temp table t as select 7 as v"]
+        ).returncode
+        == 0
+    )
+    cold_result = hsql_subprocess([*cold, "-tAc", "select v from t"])
+    assert cold_result.returncode == ExitCode.QUERY
+    assert b"does not exist" in cold_result.stderr
+
+
+@needs_unix_sockets
+@pytest.mark.session_divergent
+def test_a_setting_survives_between_invocations(send: HsqlSubprocess) -> None:
+    assert send(["--format", "none", "-c", "set TimeZone='Asia/Tokyo'"]).returncode == 0
+    proc = send(["-tAc", "select current_setting('TimeZone')"])
+    assert proc.stdout == b"Asia/Tokyo\n"
+
+
+@needs_unix_sockets
+@pytest.mark.session_divergent
+def test_a_reset_clears_the_sessions_state(send: HsqlSubprocess) -> None:
+    send(["--format", "none", "-c", "create temp table t as select 7 as v"])
+    proc = send(["--session-reset"])
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b""
+    assert b"reconnected" in proc.stderr
+    assert send(["-c", "select v from t"]).returncode == ExitCode.QUERY
+
+
+@needs_unix_sockets
+def test_a_relative_output_path_is_the_clients(
+    send: HsqlSubprocess, tmp_path: Path
+) -> None:
+    """The server writes `-o`, resolved where the caller is, not where it is."""
+    client_dir = tmp_path / "client"
+    client_dir.mkdir()
+    proc = send(["--csv", "-o", "out.csv", "-c", "select 1 as a"], cwd=client_dir)
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b""
+    assert (client_dir / "out.csv").read_bytes() == b"a\n1\n"
+
+
+@needs_unix_sockets
+def test_a_relative_script_path_is_the_clients(
+    send: HsqlSubprocess, tmp_path: Path
+) -> None:
+    client_dir = tmp_path / "client"
+    client_dir.mkdir()
+    (client_dir / "q.sql").write_text("select 'from a file' as a")
+    proc = send(["-tAf", "q.sql"], cwd=client_dir)
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b"from a file\n"
+
+
+@needs_unix_sockets
+def test_a_config_file_where_the_client_is_applies_its_per_request_keys(
+    send: HsqlSubprocess, tmp_path: Path
+) -> None:
+    """Config discovery is cwd-dependent, and the cwd is the client's."""
+    client_dir = tmp_path / "project"
+    client_dir.mkdir()
+    (client_dir / ".harlequin.toml").write_text(
+        'default_profile = "here"\n[profiles.here]\nformat = "csv"\n'
+    )
+    proc = send(["-c", "select 1 as a"], cwd=client_dir)
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b"a\n1\n"
+
+
+@needs_unix_sockets
+def test_piped_sql_reaches_the_session(send: HsqlSubprocess) -> None:
+    proc = send(["-f", "-", "--csv"], stdin=b"select 3 as three")
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b"three\n3\n"
+
+
+@needs_unix_sockets
+def test_the_servers_own_streams_carry_only_its_log(
+    warm: WarmSession, send: HsqlSubprocess
+) -> None:
+    """Result sets go to the client that asked; the operator sees a line per request."""
+    send(["-c", "select 'to the client' as a"])
+    send(["-c", "select * from nowhere"])
+    assert warm.stop() == ExitCode.OK
+    log = warm.stderr()
+    assert "to the client" not in log
+    assert "session 'warm' is ready (duckdb)" in log
+    assert "request 1: exit 0" in log
+    assert "request 2: exit 1" in log
+    assert "session 'warm' stopped after 2 requests" in log
+    assert warm.process.stdout is not None
+
+
+@needs_unix_sockets
+def test_a_stopped_session_takes_its_socket_with_it(warm: WarmSession) -> None:
+    assert warm.socket_path.exists()
+    assert warm.stop() == ExitCode.OK
+    assert not warm.socket_path.exists()
+
+
+@needs_unix_sockets
+def test_a_second_server_under_the_same_name_is_refused(
+    warm: WarmSession, serve_session: ServeSession
+) -> None:
+    second = serve_session("warm", wait=False)
+    assert second.process.wait(30) == ExitCode.USAGE
+    assert "already running" in second.stderr()
+    # and the first is untouched: its socket is still the one that answers
+    assert warm.socket_path.exists()
+
+
+@needs_unix_sockets
+def test_a_stale_socket_is_replaced(
+    short_runtime_dir: Path, serve_session: ServeSession
+) -> None:
+    """A server that died leaves its file; the next one under that name is
+    what unlinks it, since a client never does."""
+    from harlequin.hsql.session import socket_path
+
+    (short_runtime_dir / "hsql").mkdir(mode=0o700)
+    stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    stale.bind(socket_path("warm", {"XDG_RUNTIME_DIR": str(short_runtime_dir)}))
+    stale.close()
+    session = serve_session("warm")
+    assert session.socket_path.exists()
+    assert session.stop() == ExitCode.OK
+
+
+@needs_unix_sockets
+def test_a_runtime_dir_someone_else_can_reach_is_refused(
+    short_runtime_dir: Path, serve_session: ServeSession
+) -> None:
+    shared = short_runtime_dir / "hsql"
+    shared.mkdir()
+    os.chmod(shared, 0o777)
+    session = serve_session("warm", wait=False)
+    assert session.process.wait(30) == ExitCode.USAGE
+    assert "cannot listen" in session.stderr()
+
+
+@needs_unix_sockets
+def test_serve_on_a_connection_that_fails_exits_3(serve_session: ServeSession) -> None:
+    session = serve_session(
+        "warm", "-a", "duckdb", "--no-init", "/nonexistent/dir/x.db", wait=False
+    )
+    assert session.process.wait(30) == ExitCode.CONNECTION
+
+
+class Blocked:
+    """A request the test holds open: the server is reading a FIFO for its SQL.
+
+    Deterministic where a slow query is not: opening the FIFO for writing
+    blocks until the server has opened it to read, which is after the request
+    took its turn, so everything sent after that is queued behind it.
+    """
+
+    def __init__(self, fifo: Path, warm: WarmSession, tmp_path: Path) -> None:
+        self.fifo = fifo
+        os.mkfifo(fifo)
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys\n"
+                f"sys.argv = ['hsql', '--session', {warm.name!r}, "
+                f"'--format', 'none', '-f', {str(fifo)!r}]\n"
+                "from harlequin.hsql import main\n"
+                "main()\n",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp_path,
+            env={**os.environ, **warm.env, "HOME": str(tmp_path)},
+        )
+        self.writer = open(fifo, "w")
+
+    def release(self, sql: str = "select 1") -> None:
+        self.writer.write(sql)
+        self.writer.close()
+
+
+@pytest.fixture
+def blocked(
+    warm: WarmSession, short_runtime_dir: Path, tmp_path: Path
+) -> Iterator[Blocked]:
+    held = Blocked(short_runtime_dir / "script.fifo", warm, tmp_path)
+    yield held
+    if held.process.poll() is None:
+        held.process.kill()
+    held.process.wait(5)
+    if held.process.stdout is not None:
+        held.process.stdout.close()
+    if held.process.stderr is not None:
+        held.process.stderr.close()
+
+
+@needs_unix_sockets
+@pytest.mark.session_divergent
+def test_a_second_client_waits_its_turn(blocked: Blocked, send: HsqlSubprocess) -> None:
+    """One connection, one request at a time: the second client's query sees
+    what the first one, still running when it was sent, went on to create."""
+    second = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "sys.argv = ['hsql', '--session', 'warm', '-tAc', 'select v from q']\n"
+            "from harlequin.hsql import main\n"
+            "main()\n",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, **blocked_env(blocked)},
+    )
+    blocked.release("create temp table q as select 42 as v")
+    out, err = second.communicate(timeout=30)
+    assert second.returncode == ExitCode.OK, err
+    assert out == b"42\n"
+    assert blocked.process.wait(30) == ExitCode.OK
+
+
+def blocked_env(blocked: Blocked) -> dict[str, str]:
+    return {"XDG_RUNTIME_DIR": str(blocked.fifo.parent)}
+
+
+@needs_unix_sockets
+def test_a_client_that_dies_mid_query_does_not_take_the_session_down(
+    blocked: Blocked, send: HsqlSubprocess, warm: WarmSession
+) -> None:
+    blocked.process.kill()
+    blocked.process.wait(5)
+    blocked.release("select 1")
+    proc = send(["-tAc", "select 'still up'"])
+    assert proc.returncode == ExitCode.OK
+    assert proc.stdout == b"still up\n"
+    assert warm.stop() == ExitCode.OK
+    assert "a client went away" in warm.stderr()
+
+
+@needs_unix_sockets
+def test_a_queue_timeout_is_not_a_query_timeout(
+    serve_session: ServeSession,
+    hsql_subprocess: HsqlSubprocess,
+    short_runtime_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """A client that never reached the database exits 4 saying so -- a
+    different fact from a query that ran too long, and one the caller acts on
+    differently."""
+    session = serve_session(
+        "queued", "--queue-timeout", "0.2", "-a", "duckdb", "--no-init", ":memory:"
+    )
+    held = Blocked(short_runtime_dir / "q.fifo", session, tmp_path)
+    try:
+        proc = hsql_subprocess(
+            ["--session", "queued", "-c", "select 1"], env=session.env
+        )
+        assert proc.returncode == ExitCode.TIMEOUT
+        assert proc.stdout == b""
+        assert b"never reached the database" in proc.stderr
+        assert b"--queue-timeout" in proc.stderr
+    finally:
+        held.release()
+        held.process.wait(30)
+    assert (
+        hsql_subprocess(
+            ["--session", "queued", "-tAc", "select 2"], env=session.env
+        ).stdout
+        == b"2\n"
+    )
+
+
+# --- the wire, from a client that is not ours -------------------------------------
+
+
+def raw_request(
+    warm: WarmSession, **fields: Any
+) -> tuple[list[tuple[int, bytes]], int]:
+    """Send one request over the protocol by hand, and return what came back."""
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    with connection:
+        connection.connect(str(warm.socket_path))
+        hello = protocol.recv_frame(connection)
+        assert hello == (protocol.HELLO, protocol.VERSION.encode())
+        request = {
+            "argv": [],
+            "cwd": os.getcwd(),
+            "environ": {},
+            "stdin": None,
+            **fields,
+        }
+        protocol.send_frame(
+            connection, protocol.REQUEST, protocol.pack_request(**request)
+        )
+        frames: list[tuple[int, bytes]] = []
+        while True:
+            frame = protocol.recv_frame(connection)
+            assert frame is not None
+            if frame[0] == protocol.EXIT:
+                return frames, int.from_bytes(frame[1], "big")
+            frames.append(frame)
+
+
+@needs_unix_sockets
+def test_the_server_refuses_a_dash_f_dash_that_carried_no_stdin(
+    warm: WarmSession,
+) -> None:
+    """The check that turns every miss of the client's argv scan into an exit 2."""
+    frames, code = raw_request(warm, argv=["-f", "-"], stdin=None)
+    assert code == ExitCode.USAGE
+    assert b"carried none" in b"".join(
+        data for kind, data in frames if kind == protocol.STDERR
+    )
+
+
+@needs_unix_sockets
+def test_the_server_refuses_a_working_directory_it_cannot_enter(
+    warm: WarmSession,
+) -> None:
+    frames, code = raw_request(
+        warm, argv=["-c", "select 1"], cwd="/nonexistent/anywhere"
+    )
+    assert code == ExitCode.USAGE
+    assert b"cannot be entered" in b"".join(
+        data for kind, data in frames if kind == protocol.STDERR
+    )
+
+
+@needs_unix_sockets
+def test_the_servers_stdout_is_chunked(warm: WarmSession) -> None:
+    """Many `STDOUT` frames then one `EXIT`, so that streaming has somewhere to land."""
+    wide = "select repeat('x', 1000) as a from range(200)"
+    frames, code = raw_request(warm, argv=["-tA", "--display-rows", "-1", "-c", wide])
+    assert code == ExitCode.OK
+    stdout = [data for kind, data in frames if kind == protocol.STDOUT]
+    assert len(stdout) > 1
+    assert all(len(chunk) <= protocol.CHUNK_SIZE for chunk in stdout)
+    assert b"".join(stdout) == (b"x" * 1000 + b"\n") * 200
+
+
+@needs_unix_sockets
+def test_a_client_that_sends_no_request_is_dropped(
+    warm: WarmSession, send: HsqlSubprocess
+) -> None:
+    """A version it refused to be served by, or one that died: the server
+    reads the hello, hears nothing back, and goes on serving."""
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    with connection:
+        connection.connect(str(warm.socket_path))
+        assert protocol.recv_frame(connection) is not None
+    assert send(["-tAc", "select 1"]).stdout == b"1\n"
+
+
+@needs_unix_sockets
+def test_color_auto_reads_the_callers_terminal(warm: WarmSession) -> None:
+    """On the server every stream is a buffer, so the request has to say."""
+    argv = ["--color", "auto", "-c", "select 1 as a"]
+    plain, _ = raw_request(warm, argv=argv, stdout_isatty=False)
+    styled, _ = raw_request(warm, argv=argv, stdout_isatty=True)
+    assert b"\x1b[" not in b"".join(data for _, data in plain)
+    assert b"\x1b[" in b"".join(data for _, data in styled)
+    honored, _ = raw_request(
+        warm, argv=argv, stdout_isatty=True, environ={"NO_COLOR": "1"}
+    )
+    assert b"\x1b[" not in b"".join(data for _, data in honored)
+
+
+def test_the_peer_uid_is_ours_on_a_socketpair() -> None:
+    left, right = socket.socketpair(socket.AF_UNIX)
+    with left, right:
+        uid = server.peer_uid(right)
+    assert uid is None or uid == os.getuid()

--- a/tests/unit_tests/test_hsql_session.py
+++ b/tests/unit_tests/test_hsql_session.py
@@ -57,6 +57,12 @@ needs_unix_sockets = pytest.mark.skipif(
         (["--session"], {}, ("", True)),
         # after `--` everything is an argument, so this is a connection string
         (["--", "--session", "prod"], {}, None),
+        # the other role: a server is never a client, whatever the shell says
+        (["--serve", "prod"], {"HSQL_SESSION": "prod"}, None),
+        (["--serve=prod", "-a", "sqlite"], {"HSQL_SESSION": "other"}, None),
+        # and a typed `--session` beside it is left for the command to refuse
+        (["--session", "a", "--serve", "b"], {}, None),
+        (["--", "--serve", "prod"], {"HSQL_SESSION": "prod"}, ("prod", False)),
     ],
 )
 def test_the_session_an_invocation_names(

--- a/tests/unit_tests/test_import_hygiene.py
+++ b/tests/unit_tests/test_import_hygiene.py
@@ -30,6 +30,7 @@ HEADLESS_IMPORTS = [
     "import harlequin.hsql",
     "import harlequin.hsql.cli",
     "import harlequin.hsql.client",
+    "import harlequin.hsql.server",
     "import harlequin.keymap",
     "import harlequin.layout",
     "import harlequin.navigate",


### PR DESCRIPTION
No issue; this is PR 2 of the six in [`docs/plans/hsql-warm-sessions-design.md`](https://github.com/tconbeer/harlequin/blob/main/docs/plans/hsql-warm-sessions-design.md) §9, on top of #1132.

**What** are the key elements of this solution?

`hsql --serve NAME [CONN_STR]` runs in the foreground, connects once, and answers `hsql --session NAME ...` invocations sent to it over an `AF_UNIX` socket — so a caller pays neither the imports nor the connection again. `select 1` against a warm DuckDB session answers in ~25ms against ~350ms cold, and against a server-backed adapter the whole of `connect()` is what stops being paid per invocation.

- **`harlequin/hsql/server.py`** — the accept loop, one worker at a time, the socket lifecycle, the uid check. A request is run by `cli.run(argv, served=...)`, the same command the cold path builds, writing into a recorder that stands in for the process's streams; what goes back is those bytes and the exit code. The server formats nothing and parses nothing of its own.
- **`--session`, `--session-reset` and `--queue-timeout`** become click options beside `--serve`. `--session-reset` closes the connection and opens a fresh one without restarting the process — the escape hatch for a session left in a strange state, and what gives each equivalence test a fresh one.
- **The §4.1 flag partition, on both sides.** Every option is in exactly one of four groups (connection-time, per-request, server-lifetime, role), pinned by a test that checks the four partition the command's own parameters. `--serve` refuses per-request options; a served request refuses `--queue-timeout`. Each refusal names the invocation the option belongs on:
  ```
  hsql: error: --command is a per-request option, and --serve takes none. Start the
  session, then send it the request: 'hsql --serve prod ...', then 'hsql --session
  prod --command ...'.
  ```
- **`session` and `serve` join `CLI_ONLY_SESSION_KEYS`**, refused from a config file the way `ssh_allow_reuse` is, and dropped from the generated schema. `session` is read before any config file is, so a profile setting it would name a session the invocation was never sent to; a profile answering `serve` would turn a query into a daemon.
- **Cancellation that doesn't land.** The cold path ends the process when cancelled work outlasts its grace period, because a thread still inside a driver aborts an interpreter exiting around it. A server can't do that, so `Deadline` takes an `abandon` hook: the request exits 4, and the session refuses to hand its connection to anyone until a reset.

POSIX only — native Windows has no `AF_UNIX`, which the client from #1132 already handles. WSL2 is Linux and gets it.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The design doc argues the whole shape (§3 rejects more import optimization, a batch mode, MCP-instead, and a connection pool); what this PR decided on top of it:

- **The server runs `cli.run()` rather than its own path.** A second execution path would be a second product, and §8 names that as the risk this feature carries. The mitigation is structural: the server has no formatting and no flag handling, so it *can't* drift. Byte-equivalence is the test that fails if it ever does.
- **One request at a time, via a turnstile rather than a lock.** Two threads on one DuckDB connection fail outright, and the adapter contract promises nothing about thread-safety — the IDE has always run exclusive workers. A lock would wake waiters in whatever order the interpreter chose; a turnstile hands out tickets so the client that waited longest goes next, and so a waiter can give up on `--queue-timeout` and be told it *never reached the database* — a different fact from a query that ran too long, and one a caller retries differently.
- **A `flock` beside the socket.** Distinguishing a live session from a stale socket file by connecting races another server starting under the same name. The lock makes "am I the session called `prod`" atomic, and the second server is refused rather than quietly stealing the name.
- **A served request refuses connection options outright, rather than comparing them.** §4.4's differing-options rejection needs the recorded connection identity, which is PR 3. Until then the choice is between ignoring them — which §4.4 rejects, because a client that typed `-a postgres` and got DuckDB has been lied to — and refusing all of them. Refusing is the conservative half and is forward-compatible: PR 3 relaxes it to "refuse only if it differs," so an identical `-a duckdb` starts being served.
- **The signal handler is installed before the socket listens.** Found by a test: `listen()` makes the socket connectable, so a stop signal arriving before the handler was installed killed a process a client could already reach, exiting 130 on what should be a clean stop.
- **Two equivalence parametrizations, not one.** The claim is "given the same starting state, one invocation produces the same bytes cold or warm" — but a *cold* invocation carries the connection on its command line and a warm one does not, and appending `--no-init :memory:` to `hsql --spec` changes what that invocation means. So invocations that connect compare `hsql CONN ARGS` against `hsql --session NAME ARGS`, and the modes that read no database compare identical argv both ways. Splitting them is what keeps the assertion honest rather than exempting the cases that wouldn't pass.

Tradeoffs worth naming: the server swaps the process's cwd, forwarded environment and streams for the length of each request, which is only safe *because* requests are serialized — that invariant is load-bearing beyond concurrency. And a session is stateful in ways a cold invocation is not (§5), which is a feature and a sharp edge; the `session_divergent` marker below is the enumerated version of it.

Does this PR require a change to Harlequin's docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [x] Yes; I haven't opened a PR, but the gist of the change is: the "Headless & Agents" topic needs a session section — written per §5.1 as *"a database session you can send commands to,"* not *"hsql, but faster,"* since a reader holding the first model predicts the temp-table behavior correctly and a reader holding the second files a bug — plus a `SessionStart`-hook example and the note that `--idle-timeout 0` is the answer to "my session died between calls." That is PR 6 of the plan, which is docs-only and deliberately not last in spirit.

Did you add or update tests for this change?
- [x] Yes.

Three kinds, per §6:

1. **`tests/unit_tests/test_hsql_equivalence.py`** — every single invocation run twice, cold and warm, asserting identical stdout bytes, identical stderr, identical exit code, and identical files for the `-o` cases. 51 cases covering the formats, NULLs, truncation, the row cap, multi-result selection, `--on-error`, `--stats`, color, the catalog modes, and the usage errors. Each gets a fresh session via `--session-reset`, so the suite is the primary consumer of the escape hatch §5 proposes for humans.
2. **`@pytest.mark.session_divergent`** — registered beside `online` and `py12`. A marked test must assert what the warm behavior *is*, not merely that it differs: a temp table is `does not exist` cold and a result set warm, and both are in the assertions.
3. **`tests/unit_tests/test_hsql_serve.py`** — the partition (including the test that the four groups partition the command's parameters), the turnstile's ordering and its deadline, the recorder's stream interleaving, the socket lifecycle (stale socket, a second server, an unsafe runtime dir, clean shutdown), and the wire from a client that is not ours (chunked stdout, the `-f -`-with-no-stdin refusal, a cwd that can't be entered, `--color auto` reading the caller's terminal).

Full suite: 1542 unit passed, 139 functional passed. mypy clean over 142 files, all five import-linter contracts kept, ruff clean. The client's cold-start budget is unchanged at 58 modules — the client never imports the server. `docs/generated/hsql-reference.md` and `src/harlequin/schemas/config-v1.json` regenerated.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR. *(No issue exists for warm sessions, so the entry carries no link.)*
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCbCzJWyU8yqSiUeDTxvzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCbCzJWyU8yqSiUeDTxvzb)_