### PR TITLE
fix: preserve bracketed text in error panels (#1137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- Error panels no longer drop bracketed identifiers (like `[amount]`) from database error messages ([#1137](https://github.com/tconbeer/harlequin/issues/1137)).
 - `harlequin` now exits non-zero when it fails: 1 after a crash, and 2 for a config or connection error it used to report as success ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - Harlequin now refreshes the Data Catalog when an SSH tunnel reconnects, so expanding a node no longer raises a Catalog Error ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
 

--- a/src/harlequin/exception.py
+++ b/src/harlequin/exception.py
@@ -15,10 +15,16 @@ class HarlequinExit(Exception):
 
 
 class HarlequinError(Exception):
-    def __init__(self, msg: str, title: str = "") -> None:
+    markup: bool = False  # pretty_error_message interprets Rich markup only when True
+
+    def __init__(
+        self, msg: str, title: str = "", *, markup: bool | None = None
+    ) -> None:
         super().__init__(msg)
         self.msg = msg
         self.title = title
+        if markup is not None:
+            self.markup = markup
 
 
 class HarlequinBindingError(HarlequinError):
@@ -38,7 +44,7 @@ class HarlequinConnectionError(HarlequinError):
 class HarlequinCrashError(HarlequinError):
     """A bug in Harlequin itself, as the panel that replaces the traceback."""
 
-    pass
+    markup = True
 
 
 class HarlequinCopyError(HarlequinError):
@@ -90,11 +96,19 @@ def pretty_print_error(error: HarlequinError) -> None:
 
 
 def pretty_error_message(error: HarlequinError) -> "Panel":
+    from rich.markup import escape
     from rich.panel import Panel
 
+    # Driver text is the common case, and rich treats a string as markup, so
+    # `[amount]` would vanish. Authored markup opts in via `error.markup`.
+    body = str(error)
+    title = error.title if error.title else "Harlequin encountered an error."
+    if not getattr(error, "markup", False):
+        body = escape(body)
+        title = escape(title)
     return Panel.fit(
-        str(error),
-        title=error.title if error.title else ("Harlequin encountered an error."),
+        body,
+        title=title,
         title_align="left",
         border_style="red",
     )

--- a/src/harlequin/windows_timezone.py
+++ b/src/harlequin/windows_timezone.py
@@ -56,6 +56,8 @@ def check_and_install_tzdata() -> None:
                     f.write(zone_response.read())
                 pa.set_timezone_db_path(str(HARLEQUIN_TZ_DATA_PATH))
             except Exception as e:
+                from rich.markup import escape
+
                 err_msg = (
                     "Harlequin was not able to download a timezone database. Without "
                     "a timezone database, Harlequin may crash if you attempt to load "
@@ -63,8 +65,8 @@ def check_and_install_tzdata() -> None:
                     "anyway, set the --no-download-tzdata option.\n"
                     "For more info, see "
                     "[link]https://harlequin.sh/docs/troubleshooting/timezone-windows[/]"
-                    f"\nDownload failed with the following exception:\n{e}"
+                    f"\nDownload failed with the following exception:\n{escape(str(e))}"
                 )
                 raise HarlequinTzDataError(
-                    msg=err_msg, title="Harlequin Timezone Error"
+                    msg=err_msg, title="Harlequin Timezone Error", markup=True
                 ) from e

--- a/tests/unit_tests/test_exception.py
+++ b/tests/unit_tests/test_exception.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 import subprocess
 from typing import Callable
 
+import pytest
+from rich.console import Console
+
+from harlequin.exception import (
+    HarlequinError,
+    HarlequinQueryError,
+    pretty_error_message,
+)
+
 
 def test_pretty_print_warning_goes_to_stderr(
     run_python: Callable[[str], subprocess.CompletedProcess[str]],
@@ -19,3 +28,53 @@ def test_pretty_print_warning_goes_to_stderr(
     )
     assert proc.stdout == ""
     assert "A message." in proc.stderr
+
+
+def render_error(error: HarlequinError) -> str:
+    """The panel as a terminal receives it, escape sequences and all."""
+    console = Console(
+        width=100,
+        force_terminal=True,
+        legacy_windows=False,
+        no_color=False,
+        _environ={"TERM": "xterm-256color"},
+    )
+    with console.capture() as capture:
+        console.print(pretty_error_message(error))
+    return capture.get()
+
+
+@pytest.mark.parametrize(
+    ("msg", "must_contain"),
+    [
+        ("no column [amount] in table [orders]", ("[amount]", "[orders]")),
+        ("syntax error near [dbo].[users]", ("[dbo]", "[users]")),
+        ("column [red]count[/red] is ambiguous", ("[red]count[/red]",)),
+        (
+            "[Microsoft][ODBC Driver 17]Login failed.",
+            ("[Microsoft]", "[ODBC Driver 17]"),
+        ),
+    ],
+)
+def test_pretty_error_message_prints_bracketed_text(
+    msg: str, must_contain: tuple[str, ...]
+) -> None:
+    """A driver quotes identifiers in brackets; those are text, not markup."""
+    rendered = render_error(HarlequinQueryError(msg=msg, title="Query Error"))
+    for fragment in must_contain:
+        assert fragment in rendered
+
+
+def test_pretty_error_message_prints_bracketed_title() -> None:
+    rendered = render_error(HarlequinQueryError(msg="ok", title="Error in [orders]"))
+    assert "[orders]" in rendered
+
+
+def test_pretty_error_message_markup_opt_in_keeps_links_clickable() -> None:
+    """Authored markup still renders: a `[link]` becomes an OSC-8 hyperlink."""
+    url = "https://harlequin.sh/docs"
+    rendered = render_error(
+        HarlequinError(f"see [link={url}]{url}[/link]", title="Info", markup=True)
+    )
+    assert "\x1b]8;" in rendered
+    assert url in rendered


### PR DESCRIPTION
Closes #1137

**What** are the key elements of this solution?

`pretty_error_message()` now `escape()`s the panel body and title unless the error opts in. `HarlequinError.markup` defaults to `False`; `HarlequinCrashError` is `True` so the crash panel's `[link]` markup (and OSC-8) still works. The Windows tzdata error is the other opt-in: it keeps its docs link and `escape()`s the interpolated download exception so a driver message cannot drop brackets either.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The silent drop happens in the renderer, so that is where it has to stop. Most panel text is someone else's (a driver, `str(worker_error)` on a failed connect), so the default is safe.

Two other shapes:

1. Escape only at call sites that wrap foreign text. Faithful, but every future `HarlequinConnectionError(msg=str(e))` has to remember, and forgetting is this same bug.
2. Escape always and turn the authored `[link]` messages into bare URLs. That would strip the crash panel's clickable links from #1136.

Tradeoff: an adapter that put Rich tags in a query or connection error will lose that styling until it passes `markup=True`. Nothing in this repo does that. `getattr(error, "markup", False)` keeps a subclass that copied `__init__` working.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.