### PR TITLE
fix: don't break the JSON export on a single quote in the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - `harlequin` now exits non-zero when it fails: 1 after a crash, and 2 for a config or connection error it used to report as success ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - Harlequin now refreshes the Data Catalog when an SSH tunnel reconnects, so expanding a node no longer raises a Catalog Error ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
+- Exporting to JSON no longer fails with a Parser Error when the path holds a single quote (a `Bob's exports` folder, say), or when the Date Format or Timestamp Format option does.
 
 ## [2.13.0] - 2026-09-02
 

--- a/src/harlequin/export.py
+++ b/src/harlequin/export.py
@@ -186,28 +186,26 @@ def _export_json(
 ) -> None:
     import duckdb
 
-    array = ", ARRAY TRUE" if kwargs.get("array") else ""
-    compression = (
-        f", COMPRESSION {kwargs.get('compression')}"
-        if kwargs.get("compression")
-        else ""
-    )
-    date_format = (
-        f", DATEFORMAT '{kwargs.get('''date_format''')}'"
-        if kwargs.get("date_format")
-        else ""
-    )
-    ts_format = (
-        f", TIMESTAMPFORMAT '{kwargs.get('''timestamp_format''')}'"
-        if kwargs.get("timestamp_format")
-        else ""
-    )
+    # the one writer reached as SQL text, so every value in the statement is
+    # bound: a path or a format string holding a single quote would end the
+    # literal it sits in, and duckdb would refuse to parse the rest.
+    array_clause = ", ARRAY TRUE" if kwargs.get("array") else ""
+    option_clauses = ""
+    bound_values: list[str] = [dest_path]
+    for keyword, option_name in (
+        ("COMPRESSION", "compression"),
+        ("DATEFORMAT", "date_format"),
+        ("TIMESTAMPFORMAT", "timestamp_format"),
+    ):
+        value = kwargs.get(option_name)
+        if value:
+            option_clauses += f", {keyword} ?"
+            bound_values.append(str(value))
     try:
         duckdb.execute(
-            f"copy (select * from data) to '{dest_path}' "
-            "(FORMAT JSON"
-            f"{array}{compression}{date_format}{ts_format}"
-            ")"
+            "copy (select * from data) to ? "
+            f"(FORMAT JSON{array_clause}{option_clauses})",
+            bound_values,
         )
     except (duckdb.Error, OSError) as e:
         raise HarlequinCopyError(

--- a/tests/unit_tests/test_export.py
+++ b/tests/unit_tests/test_export.py
@@ -179,6 +179,21 @@ class TestJsonOptions:
             data, "json"
         )
 
+    @pytest.mark.parametrize(
+        ("option_name", "value", "expected"),
+        [
+            ("date_format", "'%Y'", b'"d":"\'2024\'"'),
+            ("timestamp_format", "'%H:%M'", b'"ts":"\'12:30\'"'),
+        ],
+        ids=["date_format", "timestamp_format"],
+    )
+    def test_a_quote_in_a_format_string_is_part_of_the_format(
+        self, dated: pa.Table, option_name: str, value: str, expected: bytes
+    ) -> None:
+        """These two are free text the copy dialog sends verbatim, and this is
+        the writer that reaches duckdb as SQL text."""
+        assert expected in to_bytes(dated, "json", {option_name: value})
+
 
 class TestParquetOptions:
     @pytest.mark.parametrize(
@@ -427,6 +442,19 @@ class TestDestinationPaths:
         path = tmp_path / "exports" / "nested" / "out.csv"
         write_file(data, path, "csv")
         assert path.is_file()
+
+    @pytest.mark.parametrize("format_name", TEXT_FORMATS + BINARY_FORMATS)
+    def test_a_quote_in_the_path_is_part_of_the_name(
+        self, data: pa.Table, tmp_path: Path, format_name: str
+    ) -> None:
+        """`Bob's exports` is a folder, and every writer can write into it.
+
+        Every format is here because the path is a value to all of them: what a
+        file may be called is not something two formats get to disagree about.
+        """
+        path = tmp_path / "Bob's exports" / f"out.{format_name}"
+        write_file(data, path, format_name)
+        assert path.stat().st_size > 0
 
 
 class TestSuffixes:


### PR DESCRIPTION
Supersedes #1142, which is @MaxFreedomPollard's work rebased onto `main` unchanged. The commit keeps their authorship; this PR exists only because the branch lives on their fork and could not be pushed to from here. #1142 closes when this merges.

No existing issue — the bug was found reading `export.py`, so the CHANGELOG entry references none.

**What** are the key elements of this solution?

Exporting a query to JSON failed with a duckdb Parser Error whenever the destination path held a single quote, so a folder called `Bob's exports` could not be exported into. `json`, `jsonl` and `ndjson` were affected; `csv`, `tsv`, `parquet`, `orc` and `feather` write into that same folder fine. The two free-text JSON options had it too: a Date Format of `'%Y'` came back as `Catalog Error: Type with name Y does not exist!`.

`_export_json` is the one writer that reaches duckdb as SQL text rather than through a binding, and it built the whole statement with f-strings: the destination as `to '{dest_path}'`, and the options as `DATEFORMAT '{...}'` and `TIMESTAMPFORMAT '{...}'`. A single quote in any of the three ends the literal it sits in, and the rest of the statement no longer parses.

The statement now binds its values: `copy (select * from data) to ?`, with `COMPRESSION ?`, `DATEFORMAT ?` and `TIMESTAMPFORMAT ?` appended for the options that were set. `ARRAY TRUE` stays inline, since it is a fixed keyword rather than a value.

Two regression tests. `TestDestinationPaths::test_a_quote_in_the_path_is_part_of_the_name` writes into a `Bob's exports` folder for every one of the nine formats, so the assertion is that no writer is special about what a file may be called; on `main` the six non-JSON formats already pass it and `json`, `jsonl` and `ndjson` fail. `TestJsonOptions::test_a_quote_in_a_format_string_is_part_of_the_format` passes `'%Y'` and `'%H:%M'` and reads the quotes back out of the JSON.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

(From the original PR.) Doubling the quotes (`dest_path.replace("'", "''")`) fixes the same three cases, but it puts a hand-rolled SQL escaper in a module where the other four writers hand duckdb and pyarrow their arguments directly. Binding is what those writers effectively do, and it is why csv and parquet never had this.

`COMPRESSION` is bound as well, so no value is pasted into the statement any more; it was checked behavior-neutral first — for each of the four choices the JSON format declares (`auto`, `gzip`, `zstd`, `uncompressed`), writing to `out.json` and to `out.json.gz` gives byte-identical files whether the codec is a bare token or a bound parameter, extension detection under `auto` included.

The `hsql` side is only reachable on a machine whose temp directory holds a quote, since `write_stream()` writes into `tempfile.TemporaryDirectory()` and copies the bytes out. The Data Exporter is where a user picks the path, so that is where this bites.

Does this PR require a change to Harlequin's docs?
- [x] No.
- [ ] Yes, and I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).
- [ ] Yes; I haven't opened a PR, but the gist of the change is: ...

Did you add or update tests for this change?
- [x] Yes.
- [ ] No, I believe tests aren't necessary.
- [ ] No, I need help with testing this change.

Verification of the rebase, on this branch:

- `uv run pytest tests/unit_tests/test_export.py`: 117 passed.
- `uv run pytest -m "not online"`: 1821 passed, 11 failed, 2 errors — every one of those 13 reproduces identically on unmodified `main` in this container (`test_hsql.py`, `test_config_schema.py`, `test_config_wizard.py`, `test_import_hygiene.py`), so none is this change's.
- The single failure on #1142's own CI run, `test_ssh_recovery.py::test_a_refresh_that_reconnects_does_not_ask_for_a_second_one`, is a pre-existing flake: it failed on `main` itself at 58e3e40 (macOS 3.11) with this change nowhere in the tree.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading.
- [x] I acknowledge Harlequin's MIT license. I do not own my contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUP3KxZA5scpUDqZdozAjF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP3KxZA5scpUDqZdozAjF)_