### PR TITLE
fix: derive binding priority per key so alt+<letter> can be bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - `harlequin` now exits non-zero when it fails: 1 after a crash, and 2 for a config or connection error it used to report as success ([#687](https://github.com/tconbeer/harlequin/issues/687)).
 - Harlequin now refreshes the Data Catalog when an SSH tunnel reconnects, so expanding a node no longer raises a Catalog Error ([#1127](https://github.com/tconbeer/harlequin/issues/1127)).
 - Exporting to JSON no longer fails with a Parser Error when the path holds a single quote (a `Bob's exports` folder, say), or when the Date Format or Timestamp Format option does.
+- A keymap can now bind `alt+<letter>` to a Query Editor action; the letter used to be typed into the buffer instead of running the action ([#1131](https://github.com/tconbeer/harlequin/issues/1131)).
 
 ## [2.13.0] - 2026-09-02
 

--- a/src/harlequin/actions.py
+++ b/src/harlequin/actions.py
@@ -107,13 +107,10 @@ HARLEQUIN_ACTIONS = {
     "code_editor.load_buffer": Action(
         target=CodeEditor, action="load", description="Open Query", show=True
     ),
-    # priority: a focused TextArea inserts any key that carries a printable
-    # character, and a terminal's alt+e carries an "e".
     "code_editor.launch_external_editor": Action(
         target=CodeEditor,
         action="launch_external_editor",
         description="Launch External Editor",
-        priority=True,
     ),
     "code_editor.find": Action(
         target=CodeEditor, action="find", description="Find", show=True

--- a/src/harlequin/bindings.py
+++ b/src/harlequin/bindings.py
@@ -9,6 +9,27 @@ if TYPE_CHECKING:
     from textual.widget import Widget
 
 
+def key_needs_priority(key: str) -> bool:
+    """Must a binding on this key be checked before the focused widget sees it?
+
+    A terminal sends alt+e as ESC e, which Textual parses into the key `alt+e`
+    carrying the character "e", so a focused Input or TextArea inserts the
+    letter and a non-priority binding on the key never fires. Only a
+    single-character key takes the `alt+` prefix, and ctrl replaces the
+    character with a control code, so alt+<character> and alt+shift+<character>
+    are the modified spellings that arrive as text. An unmodified printable key
+    arrives as text too, but it is indistinguishable from typing, so it keeps
+    Textual's behavior.
+    """
+    modifiers, separator, unmodified_key = key.rpartition("+")
+    if not separator or len(unmodified_key) != 1:
+        return False
+    modifier_names = set(modifiers.split("+"))
+    return (
+        modifier_names in ({"alt"}, {"alt", "shift"}) and unmodified_key.isprintable()
+    )
+
+
 def bind(
     target: Widget | App,
     keys: str,
@@ -18,19 +39,34 @@ def bind(
     key_display: str | None = None,
     priority: bool = False,
 ) -> None:
+    priority_keys: list[str] = []
+    bubbling_keys: list[str] = []
+    for key in keys.split(","):
+        key = key.strip()
+        if priority or key_needs_priority(key):
+            priority_keys.append(key)
+        else:
+            bubbling_keys.append(key)
+
     try:
-        target._bindings.bind(
-            keys=keys,
-            action=action,
-            description=(
-                description
-                if description
-                else " ".join([w.capitalize() for w in action.split("_")])
-            ),
-            show=show or bool(key_display),
-            key_display=key_display,
-            priority=priority,
-        )
+        for grouped_keys, keys_are_priority in (
+            (priority_keys, True),
+            (bubbling_keys, False),
+        ):
+            if not grouped_keys:
+                continue
+            target._bindings.bind(
+                keys=",".join(grouped_keys),
+                action=action,
+                description=(
+                    description
+                    if description
+                    else " ".join([w.capitalize() for w in action.split("_")])
+                ),
+                show=show or bool(key_display),
+                key_display=key_display,
+                priority=keys_are_priority,
+            )
     except Exception as e:
         raise HarlequinBindingError(
             title="Error configuring key bindings",

--- a/tests/data/functional_tests/test_keymap_from_config/config.toml
+++ b/tests/data/functional_tests/test_keymap_from_config/config.toml
@@ -20,5 +20,12 @@ keys="d"
 action="results_viewer.cursor_right"
 key_display="➡"
 
+[[keymaps.alt_keys]]
+keys="alt+n"
+action="code_editor.new_buffer"
+
 [profiles.more_keys]
 keymap_name=["vscode", "more_arrows"]
+
+[profiles.alt_keys]
+keymap_name=["vscode", "alt_keys"]

--- a/tests/functional_tests/test_keymap_from_config.py
+++ b/tests/functional_tests/test_keymap_from_config.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from typing import Awaitable, Callable
 
 import pytest
+from textual import events
 
 from harlequin import Harlequin, HarlequinAdapter
 from harlequin.config import load_profile_and_keymaps
@@ -76,3 +77,58 @@ async def test_results_viewer_bindings(
         await pilot.press("w")
         assert table.cursor_coordinate == (0, 1)
         assert table.selection_anchor_coordinate is None
+
+
+def press_alt(app: Harlequin, character: str) -> None:
+    """Sends alt+<character> the way a terminal does.
+
+    ESC + n parses to the key `alt+n` carrying the character "n", which
+    `pilot.press()` does not send and a focused TextArea would insert.
+    """
+    key_event = events.Key(f"alt+{character}", character)
+    key_event.set_sender(app)
+    assert app._driver is not None
+    app._driver.send_message(key_event)
+
+
+@pytest.mark.asyncio
+async def test_alt_letter_binding_beats_the_focused_editor(
+    duckdb_adapter: type[HarlequinAdapter],
+    data_dir: Path,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """alt+n opens a buffer instead of typing an "n" into the focused one."""
+    config_path = (
+        data_dir / "functional_tests" / "test_keymap_from_config" / "config.toml"
+    )
+    profile, my_keymaps = load_profile_and_keymaps(
+        config_path=config_path, profile_name="alt_keys"
+    )
+    app = Harlequin(
+        duckdb_adapter([":memory:"], no_init=True),
+        keymap_names=profile["keymap_name"],
+        user_defined_keymaps=my_keymaps,
+    )
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        app.editor.text = "select 1"
+        app.editor.focus()
+        await pilot.press("ctrl+end")
+        assert app.editor_collection.tab_count == 1
+
+        press_alt(app, "n")
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+
+        assert app.editor_collection.tab_count == 2
+        assert app.editor.text == ""
+
+        # the buffer the editor was on did not get an "n" typed into it
+        await pilot.press("ctrl+k")
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        assert app.editor_collection.active == "tab-1"
+        assert app.editor.text == "select 1"

--- a/tests/functional_tests/test_keymap_vscode.py
+++ b/tests/functional_tests/test_keymap_vscode.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from textual.css.query import NoMatches
+from textual.widgets import Input
 
 from harlequin import Harlequin
 
@@ -254,3 +255,38 @@ async def test_results_viewer_bindings(
         await pilot.press("ctrl+c")
         assert app.editor.text_input is not None
         assert app.editor.text_input.clipboard.startswith("1\t2\t3")
+
+
+@pytest.mark.asyncio
+async def test_editor_bindings_do_not_beat_the_find_input(
+    app: Harlequin,
+    wait_for_workers: Callable[[Harlequin], Awaitable[None]],
+) -> None:
+    """ctrl+w and ctrl+k edit the find input, rather than closing or switching a buffer.
+
+    Both are bound to a `code_editor.*` action on `EditorCollection`, an ancestor
+    of the find input, and the input's own editing keys have to win.
+    """
+    async with app.run_test() as pilot:
+        await wait_for_workers(app)
+        while app.editor is None:
+            await pilot.pause()
+
+        await pilot.press("ctrl+n")
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        assert app.editor_collection.tab_count == 2
+        assert app.editor_collection.active == "tab-2"
+
+        await pilot.press("ctrl+f")
+        find_input = app.query_one("#textarea__find_input", Input)
+        await pilot.press("f", "o", "o", "space", "b", "a", "r")
+        assert find_input.value == "foo bar"
+
+        await pilot.press("ctrl+w")
+        assert find_input.value == "foo "
+        assert app.editor_collection.tab_count == 2
+
+        await pilot.press("ctrl+k")
+        assert find_input.value == "foo "
+        assert app.editor_collection.active == "tab-2"

--- a/tests/unit_tests/test_bindings.py
+++ b/tests/unit_tests/test_bindings.py
@@ -1,1 +1,94 @@
-# TODO!
+"""Which keys a binding has to claim ahead of the focused widget.
+
+A key that reaches Harlequin carrying a printable character is inserted by a
+focused Input or TextArea before any binding on it fires, so `bind()` derives
+priority from the key. What is asserted here is the split: alt+<character> is
+claimed, and neither an unmodified key nor a ctrl+ key is.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widget import Widget
+
+from harlequin.bindings import bind, key_needs_priority
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "alt+e",
+        "alt+1",
+        "alt+shift+e",
+    ],
+)
+def test_keys_that_arrive_as_text(key: str) -> None:
+    assert key_needs_priority(key) is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        # typing looks exactly like this, so these keep Textual's behavior
+        "e",
+        "space",
+        "full_stop",
+        # ctrl replaces the character with a control code
+        "ctrl+e",
+        "ctrl+alt+e",
+        # a terminal never prefixes a named key with alt+
+        "alt+left",
+        "alt+enter",
+        # no character at all
+        "f4",
+        "shift+tab",
+        # degenerate spellings must not raise
+        "",
+        "+",
+    ],
+)
+def test_keys_that_do_not_arrive_as_text(key: str) -> None:
+    assert key_needs_priority(key) is False
+
+
+def test_priority_is_derived_per_key() -> None:
+    """One binding over two keys splits, so ctrl+e keeps bubbling."""
+    widget = Widget()
+    bind(widget, "alt+e,ctrl+e", "launch_external_editor")
+
+    (alt_binding,) = widget._bindings.key_to_bindings["alt+e"]
+    (ctrl_binding,) = widget._bindings.key_to_bindings["ctrl+e"]
+
+    assert alt_binding.priority is True
+    assert ctrl_binding.priority is False
+    assert alt_binding.action == ctrl_binding.action == "launch_external_editor"
+    assert (
+        alt_binding.description == ctrl_binding.description == "Launch External Editor"
+    )
+
+
+def test_explicit_priority_applies_to_every_key() -> None:
+    widget = Widget()
+    bind(widget, "ctrl+q,f10", "quit", priority=True)
+
+    assert all(
+        binding.priority is True
+        for key in ("ctrl+q", "f10")
+        for binding in widget._bindings.key_to_bindings[key]
+    )
+
+
+def test_key_display_and_show_survive_the_split() -> None:
+    widget = Widget()
+    bind(
+        widget,
+        "alt+e,ctrl+e",
+        "launch_external_editor",
+        description="Launch External Editor",
+        key_display="⌥e or ^e",
+    )
+
+    for key in ("alt+e", "ctrl+e"):
+        (binding,) = widget._bindings.key_to_bindings[key]
+        assert binding.key_display == "⌥e or ^e"
+        assert binding.show is True


### PR DESCRIPTION
What are the key elements of this solution?

bindings.bind() now decides priority per key of passing one flag through for the whole comma-separated list. A new key_needs_priority() marks the two spellings that get delivered to a widget as text. Alt+<character> and alt+shift+<character>. As priority bindings and leaves everything else bubbling. Because BindingsMap.bind() gives every key in a call the priority the keys get partitioned and its called once per group.

That replaces the per-action priority=True on code_editor.launch_external_editor added in #1130. The fix now applies to any action a user binds to an alt key rather than to alt+e on one action.

The root cause: a terminal sends alt+e as ESC e and Textuals parser turns that into a key named alt+e that still carries the character "e" (_xterm_parser._sequence_to_key_events: if len(name) == 1 and alt: name = f"alt+{name}"). Key.is_printable only looks at character. A focused TextArea or Input handles the event as text and inserts the letter. And a bubbling binding on the key never runs.

Why did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

The issue suggests handling this in bind() and that's where it belongs: the thing that makes the key unreachable is a property of the key, not of the action or of the widget that happens to be focused. Deriving it in bind() means a keymap author binding alt+j to something gets working behavior without anyone touching HARLEQUIN_ACTIONS.

The issue also asks what else carries a character. Going through Textual 8.2.8 the full set of keys delivered with a printable character is:

1. Bare printable keys. E, space, full_stop and the punctuation names

2. Alt+<printable>

3. Alt+shift+<letter> (uppercase arrives as alt+shift+ plus the lowercase letter)

Only (2) and (3) are treated as priority. Ctrl+<letter> isn't affected. It arrives as a control code, which's n't printable. And named keys like alt+left never take the alt+ prefix at all since the parser only adds it when the key name is a single character. Under Kittys protocol these keys arrive with no character so the priority flag is a no-op there.


Does this PR require a change to Harlequins docs?

- [x] No.

- [ ] Yes. I have opened a PR at [tconbeer/harlequin-web](https://github.com/tconbeer/harlequin-web).

- [ ] Yes; I haven't opened a PR but the gist of the change is:...

I checked src/docs/keymaps/config.md, src/docs/bindings.md and src/docs/troubleshooting/key-bindings.md in harlequin-web. None of them document a limitation on keys so there's nothing that needs correcting. Happy to add a note if you'd like the key rules written down somewhere.

Did you. Update tests for this change?

- [x] Yes.

- [ ] No I believe tests aren't necessary.

- [ ] No I need help with testing this change.

- tests/unit_tests/test_bindings.py was a # TODO! placeholder so it now covers which keys need priority the per-key partitioning (binding "alt+e,ctrl+e" in one call gives one priority binding and one bubbling one) and that show/key_display survive the split.

- test_keymap_from_config.py::test_alt_letter_binding_beats_the_focused_editor binds alt+n to code_editor.new_buffer from a config keymap and checks a buffer opens of an "n" being typed. It constructs the event directly because pilot.press() doesn't send a character alongside an alt key and so can't reproduce the bug. This also covers the ancestor-target case that the existing alt+e coverage doesn't. New_buffer lives on EditorCollection, not CodeEditor.

- test_keymap_vscode.py::test_editor_bindings_do_not_beat_the_find_input is the guard for the alternative above.

Full suite green locally on 3.10: 1853 passed 5 skipped 148 snapshots passed, with ruff and mypy clean. The one test I skipped is test_load_extension. The committed hello0.dylib fixture is x86_64. I'm on an arm64 Mac. It fails the way on a clean checkout of main so its unrelated to this change.

Please complete the following checklist:

- [x] I have added an entry, to CHANGELOG.md under the [Unreleased] section heading. That entry references the issue closed by this PR.

- [x ] I acknowledge Harlequins MIT license. I do not own my contribution.